### PR TITLE
fix: correctly grow memory on values of size 0

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -165,7 +165,7 @@ impl<T: Storable, M: Memory> Cell<T, M> {
         }
         let size = memory.size();
         let available_space = size * WASM_PAGE_SIZE;
-        if len as u64 > available_space.saturating_sub(HEADER_V1_SIZE) {
+        if len as u64 > available_space.saturating_sub(HEADER_V1_SIZE) || size == 0 {
             let grow_by =
                 (len as u64 + HEADER_V1_SIZE + WASM_PAGE_SIZE - size * WASM_PAGE_SIZE - 1)
                     / WASM_PAGE_SIZE;

--- a/src/cell/tests.rs
+++ b/src/cell/tests.rs
@@ -23,6 +23,13 @@ fn test_cell_init() {
 }
 
 #[test]
+fn test_cell_init_empty() {
+    let mem = VectorMemory::default();
+    let cell = Cell::init(mem, vec![]).unwrap();
+    assert_eq!(Vec::<u8>::new(), *cell.get());
+}
+
+#[test]
 fn test_out_of_space() {
     let mem = RestrictedMemory::new(VectorMemory::default(), 0..1);
     let data = [1u8; 100];


### PR DESCRIPTION
The cell implementation did not correctly grow the memory to store its header when initialized with a default value of size 0.