### PR TITLE
feat: Implement reader and writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "maplit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "maplit",
  "proptest",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "ic-types"

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,0 +1,79 @@
+use crate::{Memory, WASM_PAGE_SIZE};
+use std::io;
+
+#[cfg(test)]
+mod tests;
+
+/// A reader to the stable memory.
+///
+/// Keeps an offset and reads off memory consecutively.
+pub struct Reader<'a, M> {
+    /// The offset of the next read.
+    offset: u64,
+
+    /// The stable memory to read data from.
+    memory: &'a M,
+}
+
+#[derive(Debug)]
+pub struct OutOfBounds {
+    pub max_address: u64,
+    pub attempted_read_address: u64,
+}
+
+impl<'a, M: Memory> Reader<'a, M> {
+    /// Creates a new `Reader` which reads from the selected memory starting from the specified offset.
+    pub fn new(memory: &'a M, offset: u64) -> Self {
+        Self { offset, memory }
+    }
+
+    /// Reads data from the memory location specified by an offset.
+    pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, OutOfBounds> {
+        let memory_end_addr = self.memory.size() * WASM_PAGE_SIZE;
+
+        let read_buf = if buf.len() as u64 + self.offset > memory_end_addr {
+            if self.offset < memory_end_addr {
+                // read only until the end of stable memory if an oversized buffer is provided
+                let available_bytes = (memory_end_addr - self.offset) as usize;
+                &mut buf[..available_bytes]
+            } else {
+                return Err(OutOfBounds {
+                    max_address: memory_end_addr,
+                    attempted_read_address: self.offset,
+                });
+            }
+        } else {
+            buf
+        };
+
+        self.memory.read(self.offset, read_buf);
+        self.offset += read_buf.len() as u64;
+        Ok(read_buf.len())
+    }
+}
+
+impl<'a, M: Memory> io::Read for Reader<'a, M> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
+        self.read(buf).or(Ok(0)) // Read defines EOF to be success
+    }
+}
+
+/// A reader to the stable memory which reads bytes a chunk at a time as each chunk is required.
+pub struct BufferedReader<'a, M> {
+    inner: io::BufReader<Reader<'a, M>>,
+}
+
+impl<'a, M: Memory> BufferedReader<'a, M> {
+    /// Creates a new `BufferedReader` which reads from the selected memory
+    pub fn new(buffer_size: usize, reader: Reader<M>) -> BufferedReader<M> {
+        BufferedReader {
+            inner: io::BufReader::with_capacity(buffer_size, reader),
+        }
+    }
+}
+
+impl<'a, M: Memory> io::Read for BufferedReader<'a, M> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}

--- a/src/reader/tests.rs
+++ b/src/reader/tests.rs
@@ -1,0 +1,81 @@
+use crate::reader::{BufferedReader, Reader};
+use crate::{safe_write, Memory, VectorMemory, WASM_PAGE_SIZE};
+use proptest::proptest;
+use std::io::Read;
+
+proptest! {
+    #[test]
+    fn should_read_single_slice(
+        buffer_size in proptest::option::of(0..2 * WASM_PAGE_SIZE as usize),
+        bytes in proptest::collection::vec(0..u8::MAX, WASM_PAGE_SIZE as usize + 1024..2 * WASM_PAGE_SIZE as usize),
+        offset in 0..WASM_PAGE_SIZE,
+        len in 0..1024usize
+    ) {
+        let memory = VectorMemory::default();
+        safe_write(&memory, 0, &bytes).unwrap();
+        let mut reader = build_reader(&memory, buffer_size, offset);
+
+        let mut output = vec![0u8; len];
+        let num_read = reader.read(&mut output).unwrap();
+
+        assert_eq!(num_read, len);
+        assert_eq!(output.as_slice(), &bytes[offset as usize..offset as usize + len]);
+    }
+
+    #[test]
+    fn should_read_multiple_slices(
+        bytes in proptest::collection::vec(0..u8::MAX, WASM_PAGE_SIZE as usize + 4096..2 * WASM_PAGE_SIZE as usize),
+        offset in 0..WASM_PAGE_SIZE,
+        len in 0..512usize,
+        repetitions in 2..8
+    ) {
+        let memory = VectorMemory::default();
+        safe_write(&memory, 0, &bytes).unwrap();
+
+        // use unbuffered reader, because buffered read might return fewer bytes depending on buffer state
+        let mut reader = Reader::new(&memory, offset);
+
+        let mut read_offset = offset;
+        for _ in 0..repetitions {
+            let mut output = vec![0u8; len];
+            let num_read = reader.read(&mut output).unwrap();
+
+            assert_eq!(num_read, len);
+            assert_eq!(output.as_slice(), &bytes[read_offset as usize..read_offset as usize + len]);
+            read_offset += num_read as u64;
+        }
+    }
+
+    #[test]
+    fn should_read_to_end(
+        buffer_size in proptest::option::of(0..2 * WASM_PAGE_SIZE as usize),
+        bytes in proptest::collection::vec(0..u8::MAX, 512..WASM_PAGE_SIZE as usize),
+        offset in 0..512u64,
+    ) {
+        let memory = VectorMemory::default();
+        safe_write(&memory, 0, &bytes).unwrap();
+        let mut reader = build_reader(&memory, buffer_size, offset);
+
+        let mut output = vec![];
+        reader.read_to_end(&mut output).unwrap();
+
+        assert_eq!(output.len(), (WASM_PAGE_SIZE - offset) as usize);
+        // overlapping part with modified bytes
+        assert_eq!(output[..(bytes.len() - offset as usize)], bytes[offset as usize..]);
+        // check rest is all zeroes until end of wasm page
+        assert!(output[(bytes.len() - offset as usize)..].iter().all(|&x| x == 0));
+    }
+}
+
+fn build_reader<'a, M: Memory>(
+    memory: &'a M,
+    buffer_size: Option<usize>,
+    offset: u64,
+) -> Box<dyn Read + 'a> {
+    let reader = Reader::new(memory, offset);
+    if let Some(buffer_size) = buffer_size {
+        Box::new(BufferedReader::new(buffer_size, reader))
+    } else {
+        Box::new(reader)
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,81 @@
+use crate::{safe_write, GrowFailed, Memory};
+use std::io;
+
+#[cfg(test)]
+mod tests;
+
+/// A writer that writes sequentially to memory.
+///
+/// Warning: This will overwrite any existing data in stable memory as it writes, so ensure you set
+/// the `offset` value accordingly if you wish to preserve existing data.
+///
+/// The writer Will attempt to grow the memory as it writes.
+pub struct Writer<'a, M> {
+    /// The offset of the next write.
+    offset: u64,
+
+    /// The stable memory to write data to.
+    memory: &'a mut M,
+}
+
+impl<'a, M: Memory> Writer<'a, M> {
+    /// Creates a new `Writer` which writes to the selected memory starting from the offset.
+    pub fn new(memory: &'a mut M, offset: u64) -> Self {
+        Self { offset, memory }
+    }
+
+    /// Writes a byte slice to the underlying memory directly.
+    ///
+    /// Note: The writer will first attempt to grow the memory enough to write _all_ the data and
+    /// only then start writing. If the memory can not be grown sufficiently, the write is aborted
+    /// without writing any data.
+    pub fn write(&mut self, buf: &[u8]) -> Result<(), GrowFailed> {
+        safe_write(self.memory, self.offset, buf)?;
+        self.offset += buf.len() as u64;
+        Ok(())
+    }
+}
+
+impl<'a, M: Memory> io::Write for Writer<'a, M> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
+        self.write(buf)
+            .map_err(|e| io::Error::new(io::ErrorKind::OutOfMemory, e))?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<(), io::Error> {
+        // Noop.
+        Ok(())
+    }
+}
+
+/// A writer to the stable memory which first writes the bytes to an in memory buffer and flushes
+/// the buffer to stable memory each time it becomes full.
+///
+/// Warning: This will overwrite any existing data in stable memory as it writes, so ensure you set
+/// the `offset` value accordingly if you wish to preserve existing data.
+///
+/// Note: Each call to grow or write to stable memory is a relatively expensive operation, so pick a
+/// buffer size large enough to avoid excessive calls to stable memory.
+pub struct BufferedWriter<'a, M: Memory> {
+    inner: io::BufWriter<Writer<'a, M>>,
+}
+
+impl<'a, M: Memory> BufferedWriter<'a, M> {
+    /// Creates a new `BufferedStableWriter` which writes to the selected memory
+    pub fn new(buffer_size: usize, writer: Writer<M>) -> BufferedWriter<M> {
+        BufferedWriter {
+            inner: io::BufWriter::with_capacity(buffer_size, writer),
+        }
+    }
+}
+
+impl<'a, M: Memory> io::Write for BufferedWriter<'a, M> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}

--- a/src/writer/tests.rs
+++ b/src/writer/tests.rs
@@ -1,0 +1,93 @@
+use crate::writer::{BufferedWriter, Writer};
+use crate::{Memory, RestrictedMemory, VectorMemory, WASM_PAGE_SIZE};
+use proptest::proptest;
+use std::io::Write;
+
+proptest! {
+    #[test]
+    fn should_write_single_slice(
+        buffer_size in proptest::option::of(0..2 * WASM_PAGE_SIZE as usize),
+        bytes in proptest::collection::vec(0..u8::MAX, 0..2 * WASM_PAGE_SIZE as usize),
+        offset in 0..2 * WASM_PAGE_SIZE
+    ) {
+        let mut memory = VectorMemory::default();
+        {
+            let mut writer = build_writer(&mut memory, buffer_size, offset);
+
+            writer.write_all(&bytes).unwrap();
+            writer.flush().unwrap();
+        }
+        let mut buf = vec![0; bytes.len()];
+        memory.read(offset, &mut buf);
+        assert_eq!(bytes, buf);
+    }
+
+    #[test]
+    fn should_write_many_slices(
+        buffer_size in proptest::option::of(0..2 * WASM_PAGE_SIZE as usize),
+        bytes in proptest::collection::vec(0..u8::MAX, 0..2000),
+        repetitions in 1..15usize,
+        offset in 0..2 * WASM_PAGE_SIZE
+    ) {
+        let mut memory = VectorMemory::default();
+        {
+            let mut writer = build_writer(&mut memory, buffer_size, offset);
+            for _ in 0..repetitions {
+                writer.write_all(&bytes).unwrap();
+            }
+            writer.flush().unwrap();
+        }
+
+        let mut read_offset = offset;
+        for _ in 0..repetitions {
+            let mut buf = vec![0; bytes.len()];
+            memory.read(read_offset, &mut buf);
+            assert_eq!(bytes, buf);
+            read_offset += bytes.len() as u64;
+        }
+    }
+
+    #[test]
+    fn should_only_request_min_number_of_pages_required(
+        buffer_size in proptest::option::of(0..2 * WASM_PAGE_SIZE as usize),
+        bytes in proptest::collection::vec(0..u8::MAX, 0..3 * WASM_PAGE_SIZE as usize),
+        offset in 0..2 * WASM_PAGE_SIZE
+    ) {
+        let mut memory = VectorMemory::default();
+        {
+            let mut writer = build_writer(&mut memory, buffer_size, offset);
+            writer.write_all(&bytes).unwrap();
+            writer.flush().unwrap();
+        }
+
+        let capacity_pages = memory.size();
+        let min_pages_required = (offset + bytes.len() as u64 + WASM_PAGE_SIZE - 1) / WASM_PAGE_SIZE;
+
+        assert_eq!(capacity_pages, min_pages_required as u64);
+    }
+
+    #[test]
+    fn should_return_err_on_memory_bounds(
+        buffer_size in proptest::option::of(0..2 * WASM_PAGE_SIZE as usize),
+        offset in 0..2 * WASM_PAGE_SIZE
+    ) {
+        let bytes = vec![0; (2 * WASM_PAGE_SIZE + 1) as usize];
+        let mut memory = RestrictedMemory::new(VectorMemory::default(), 0..2);
+        let mut writer = build_writer(&mut memory, buffer_size, offset);
+        let result = writer.write_all(&bytes);
+        assert!(result.is_err());
+    }
+}
+
+fn build_writer<'a, M: Memory>(
+    memory: &'a mut M,
+    buffer_size: Option<usize>,
+    offset: u64,
+) -> Box<dyn Write + 'a> {
+    let writer = Writer::new(memory, offset);
+    if let Some(buffer_size) = buffer_size {
+        Box::new(BufferedWriter::new(buffer_size, writer))
+    } else {
+        Box::new(writer)
+    }
+}

--- a/src/writer/tests.rs
+++ b/src/writer/tests.rs
@@ -25,7 +25,7 @@ proptest! {
     #[test]
     fn should_write_many_slices(
         buffer_size in proptest::option::of(0..2 * WASM_PAGE_SIZE as usize),
-        bytes in proptest::collection::vec(0..u8::MAX, 0..2000),
+        bytes in proptest::collection::vec(0..u8::MAX, 1..2000),
         repetitions in 1..15usize,
         offset in 0..2 * WASM_PAGE_SIZE
     ) {


### PR DESCRIPTION
This PR adds a reader and a writer implementation (both buffered and unbuffered) to facilitate stable memory interactions that happen sequentially in stable memory. In particular, the reader and writer keep track of the offset and grow stable memory on the fly as required.