### PR TITLE
BREAKING CHANGE: change `Storable` encoding of integers from le to be

### DIFF
--- a/src/storable.rs
+++ b/src/storable.rs
@@ -59,50 +59,50 @@ impl Storable for String {
 
 impl Storable for u128 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Owned(self.to_le_bytes().to_vec())
+        std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
-        Self::from_le_bytes(bytes.try_into().unwrap())
+        Self::from_be_bytes(bytes.try_into().unwrap())
     }
 }
 
 impl Storable for u64 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Owned(self.to_le_bytes().to_vec())
+        std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
-        Self::from_le_bytes(bytes.try_into().unwrap())
+        Self::from_be_bytes(bytes.try_into().unwrap())
     }
 }
 
 impl Storable for u32 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Owned(self.to_le_bytes().to_vec())
+        std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
-        Self::from_le_bytes(bytes.try_into().unwrap())
+        Self::from_be_bytes(bytes.try_into().unwrap())
     }
 }
 
 impl Storable for u16 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Owned(self.to_le_bytes().to_vec())
+        std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
-        Self::from_le_bytes(bytes.try_into().unwrap())
+        Self::from_be_bytes(bytes.try_into().unwrap())
     }
 }
 
 impl Storable for u8 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Owned(self.to_le_bytes().to_vec())
+        std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
-        Self::from_le_bytes(bytes.try_into().unwrap())
+        Self::from_be_bytes(bytes.try_into().unwrap())
     }
 }


### PR DESCRIPTION
Update the way integers are serialized/deserialized to use big-endian bytes rather than little-endian. That way, the byte representations of these numbers are sorted, which is a very desirable property.

I asked all the current users of `stable-structures` and none are using these encodings yet, so this should be a safe breaking change.