### PR TITLE
feat: reading stable structures from a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ version = "0.2.0"
 dependencies = [
  "maplit",
  "proptest",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ repository = "https://github.com/dfinity/stable-structures"
 [dev-dependencies]
 maplit = "1.0.2"
 proptest = "0.9.4"
+tempfile = "3.3.0"

--- a/examples/src/basic_example/src/lib.rs
+++ b/examples/src/basic_example/src/lib.rs
@@ -1,4 +1,4 @@
-use ic_stable_structures::memory_manager::{VirtualMemory, MemoryId, MemoryManager};
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
 use std::cell::RefCell;
 

--- a/examples/src/custom_types_example/src/lib.rs
+++ b/examples/src/custom_types_example/src/lib.rs
@@ -1,5 +1,5 @@
 use candid::{CandidType, Decode, Deserialize, Encode};
-use ic_stable_structures::memory_manager::{VirtualMemory, MemoryId, MemoryManager};
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap, Storable};
 use std::{borrow::Cow, cell::RefCell};
 

--- a/src/file_mem.rs
+++ b/src/file_mem.rs
@@ -1,0 +1,96 @@
+use crate::{Memory, WASM_PAGE_SIZE};
+use std::cell::RefCell;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::rc::Rc;
+
+/// A `Memory` backed by a file.
+#[derive(Clone)]
+pub struct FileMemory(Rc<RefCell<File>>);
+
+impl FileMemory {
+    pub fn new(file: File) -> Self {
+        Self(Rc::new(RefCell::new(file)))
+    }
+}
+
+impl Memory for FileMemory {
+    fn size(&self) -> u64 {
+        let len = self.0.borrow().metadata().unwrap().len();
+        assert_eq!(
+            len % WASM_PAGE_SIZE,
+            0,
+            "File size must correspond to exact page sizes"
+        );
+        len / WASM_PAGE_SIZE
+    }
+
+    fn grow(&self, pages: u64) -> i64 {
+        let previous_size = self.size();
+        self.0
+            .borrow()
+            .set_len((previous_size + pages) * WASM_PAGE_SIZE)
+            .expect("grow must succeed");
+        assert_eq!(self.size(), previous_size + pages);
+        previous_size as i64
+    }
+
+    fn read(&self, offset: u64, dst: &mut [u8]) {
+        self.0
+            .borrow_mut()
+            .seek(SeekFrom::Start(offset))
+            .expect("out of bounds");
+        let bytes_read = self.0.borrow_mut().read(dst).expect("out of bounds");
+        assert_eq!(bytes_read, dst.len(), "out of bounds");
+    }
+
+    fn write(&self, offset: u64, src: &[u8]) {
+        self.0
+            .borrow_mut()
+            .seek(SeekFrom::Start(offset))
+            .expect("out of bounds");
+        let bytes_written = self.0.borrow_mut().write(src).expect("out of bounds");
+        assert_eq!(bytes_written, src.len(), "out of bounds");
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::write;
+    use proptest::prelude::*;
+
+    fn make_vec_memory() -> Rc<RefCell<Vec<u8>>> {
+        Rc::new(RefCell::new(Vec::new()))
+    }
+
+    fn make_file_memory() -> FileMemory {
+        FileMemory::new(tempfile::tempfile().unwrap())
+    }
+
+    #[test]
+    fn write_and_read_random_bytes() {
+        let vec_mem = make_vec_memory();
+        let file_mem = make_file_memory();
+
+        proptest!(|(
+            data in proptest::collection::vec(0..u8::MAX, 0..2*WASM_PAGE_SIZE as usize),
+            offset in 0..10*WASM_PAGE_SIZE
+        )| {
+            // Write a random blob into the memory, growing the memory as it needs to.
+            write(&file_mem, offset, &data);
+
+            // Verify the blob can be read back.
+            let mut bytes = vec![0; data.len()];
+            file_mem.read(offset, &mut bytes);
+            assert_eq!(bytes, data);
+
+            // Do the same write to vec mem and verify both memories are identical.
+            write(&vec_mem, offset, &data);
+            assert_eq!(vec_mem.size(), file_mem.size());
+            let mut buf = vec![0; (file_mem.size() * WASM_PAGE_SIZE) as usize];
+            file_mem.read(0, &mut buf);
+            assert_eq!(buf.as_slice(), vec_mem.borrow().as_slice());
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate core;
 
 pub mod btreemap;
 pub mod cell;
+pub mod file_mem;
 #[cfg(target_arch = "wasm32")]
 mod ic0_memory; // Memory API for canisters.
 pub mod log;
@@ -21,6 +22,7 @@ mod types;
 pub mod vec_mem;
 pub mod writer;
 pub use btreemap::{BTreeMap, BTreeMap as StableBTreeMap};
+pub use file_mem::FileMemory;
 #[cfg(target_arch = "wasm32")]
 pub use ic0_memory::Ic0StableMemory;
 use std::error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,8 @@ impl Display for GrowFailed {
         write!(
             f,
             "Failed to grow memory: current size={}, delta={}",
-            self.current_size, self.delta
+            self.current_size,
+            self.delta
         )
     }
 }


### PR DESCRIPTION
An implementation of `Memory` that is backed up by a file. This is very useful to read stable structures that have been serialized to a file on disk.