### PR TITLE
chore: Enhancements to the StableBTreeMap API.

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -886,6 +886,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
+name = "vecs_and_strings"
+version = "0.2.0"
+dependencies = [
+ "candid",
+ "ic-cdk",
+ "ic-cdk-macros",
+ "ic-stable-structures",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "src/basic_example",
+    "src/vecs_and_strings",
     "src/custom_types_example",
 ]

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,8 +12,8 @@ dfx start --background
 dfx deploy
 
 # Insert some data into the basic_example canister.
-dfx canister call basic_example insert '("alice", blob "12341234")'
-dfx canister call basic_example insert '("bob", blob "789789789")'
+dfx canister call basic_example insert '(1:nat, 2:nat)'
+dfx canister call basic_example insert '(3:nat, 4:nat)'
 
 # Upgrade the canister, which clears all the data in the heap.
 dfx deploy --upgrade-unchanged basic_example
@@ -21,10 +21,38 @@ dfx deploy --upgrade-unchanged basic_example
 # Even though the canister has been upgraded and its heap is cleared,
 # querying the canister should still return the data stored prior to
 # the upgrade.
-dfx canister call basic_example get '("alice")'
+dfx canister call basic_example get '(1:nat)'
+> (opt (2 : nat))
+
+dfx canister call basic_example get '(3:nat)'
+> (opt (4 : nat))
+```
+
+## Vecs and Strings Example
+
+This example showcases how to initialize a `StableBTreeMap` that holds strings and vectors.
+
+```bash
+# Start the replica, running in the background
+dfx start --background
+
+# Deploys the examples.
+dfx deploy
+
+# Insert some data.
+dfx canister call vecs_and_strings insert '("alice", blob "12341234")'
+dfx canister call vecs_and_strings insert '("bob", blob "789789789")'
+
+# Upgrade the canister, which clears all the data in the heap.
+dfx deploy --upgrade-unchanged vecs_and_strings
+
+# Even though the canister has been upgraded and its heap is cleared,
+# querying the canister should still return the data stored prior to
+# the upgrade.
+dfx canister call vecs_and_strings get '("alice")'
 > (opt blob "12341234") 
 
-dfx canister call basic_example get '("bob")'
+dfx canister call vecs_and_strings get '("bob")'
 > (opt blob "789789789")
 ```
 

--- a/examples/dfx.json
+++ b/examples/dfx.json
@@ -6,6 +6,11 @@
       "package": "basic_example",
       "type": "rust"
     },
+    "vecs_and_strings": {
+      "candid": "src/vecs_and_strings/candid.did",
+      "package": "vecs_and_strings",
+      "type": "rust"
+    },
     "custom_types_example": {
       "candid": "src/custom_types_example/candid.did",
       "package": "custom_types_example",

--- a/examples/src/basic_example/candid.did
+++ b/examples/src/basic_example/candid.did
@@ -1,4 +1,4 @@
 service : {
-    "get": (text) -> (opt vec nat8) query;
-    "set": (text, vec nat8) -> (opt vec nat8);
+    "get": (nat) -> (opt nat) query;
+    "set": (nat, nat) -> (opt nat);
 }

--- a/examples/src/basic_example/src/lib.rs
+++ b/examples/src/basic_example/src/lib.rs
@@ -1,17 +1,8 @@
-use ic_stable_structures::memory_manager::{VirtualMemory, MemoryId, MemoryManager};
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
 use std::cell::RefCell;
 
 type Memory = VirtualMemory<DefaultMemoryImpl>;
-
-// `StableBTreeMap` requires specifying the maximum size in bytes that keys/values can hold. An
-// entry in the map always takes up the maximum size in memory (i.e. MAX_KEY_SIZE + MAX_VALUE_SIZE),
-// so you shouldn't specify sizes here that are larger than necessary.
-//
-// If your entries vary a lot in size, consider bucketizing them. For instance, you can create two
-// different maps, one for holding "small" entries, and another for holding "large" entries.
-const MAX_KEY_SIZE: u32 = 10;
-const MAX_VALUE_SIZE: u32 = 100;
 
 thread_local! {
     // The memory manager is used for simulating multiple memories. Given a `MemoryId` it can
@@ -20,23 +11,21 @@ thread_local! {
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
 
     // Initialize a `StableBTreeMap` with `MemoryId(0)`.
-    static MAP: RefCell<StableBTreeMap<Memory, String, Vec<u8>>> = RefCell::new(
+    static MAP: RefCell<StableBTreeMap<Memory, u128, u128>> = RefCell::new(
         StableBTreeMap::init(
             MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))),
-            MAX_KEY_SIZE,
-            MAX_VALUE_SIZE
         )
     );
 }
 
 // Retrieves the value associated with the given key if it exists.
 #[ic_cdk_macros::query]
-fn get(key: String) -> Option<Vec<u8>> {
+fn get(key: u128) -> Option<u128> {
     MAP.with(|p| p.borrow().get(&key))
 }
 
 // Inserts an entry into the map and returns the previous value of the key if it exists.
 #[ic_cdk_macros::update]
-fn insert(key: String, value: Vec<u8>) -> Option<Vec<u8>> {
+fn insert(key: u128, value: u128) -> Option<u128> {
     MAP.with(|p| p.borrow_mut().insert(key, value)).unwrap()
 }

--- a/examples/src/vecs_and_strings/Cargo.toml
+++ b/examples/src/vecs_and_strings/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vecs_and_strings"
+version = "0.2.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = "0.7.4"
+ic-cdk = "0.4"
+ic-cdk-macros = "0.4"
+ic-stable-structures = { path = "../../../" }

--- a/examples/src/vecs_and_strings/candid.did
+++ b/examples/src/vecs_and_strings/candid.did
@@ -1,0 +1,4 @@
+service : {
+    "get": (text) -> (opt vec nat8) query;
+    "set": (text, vec nat8) -> (opt vec nat8);
+}

--- a/examples/src/vecs_and_strings/src/lib.rs
+++ b/examples/src/vecs_and_strings/src/lib.rs
@@ -1,0 +1,80 @@
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::{BoundedStorable, DefaultMemoryImpl, StableBTreeMap, Storable};
+use std::cell::RefCell;
+
+type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+// `StableBTreeMap` requires specifying the maximum size in bytes that keys/values can hold. An
+// entry in the map always takes up the maximum size in memory (i.e. MAX_KEY_SIZE + MAX_VALUE_SIZE),
+// so you shouldn't specify sizes here that are larger than necessary.
+//
+// If your entries vary a lot in size, consider bucketizing them. For instance, you can create two
+// different maps, one for holding "small" entries, and another for holding "large" entries.
+const MAX_USER_NAME_SIZE: u32 = 10;
+const MAX_USER_DATA_SIZE: u32 = 100;
+
+struct UserName(String);
+
+impl Storable for UserName {
+    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
+        // String already implements `Storable`.
+        self.0.to_bytes()
+    }
+
+    fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self(String::from_bytes(bytes))
+    }
+}
+
+impl BoundedStorable for UserName {
+    fn max_size() -> u32 {
+        MAX_USER_NAME_SIZE
+    }
+}
+
+struct UserData(Vec<u8>);
+
+impl Storable for UserData {
+    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
+        // Vec<u8> already implements `Storable`.
+        self.0.to_bytes()
+    }
+
+    fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self(<Vec<u8>>::from_bytes(bytes))
+    }
+}
+
+impl BoundedStorable for UserData {
+    fn max_size() -> u32 {
+        MAX_USER_DATA_SIZE
+    }
+}
+
+thread_local! {
+    // The memory manager is used for simulating multiple memories. Given a `MemoryId` it can
+    // return a memory that can be used by stable structures.
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+
+    // Initialize a `StableBTreeMap` with `MemoryId(0)`.
+    static MAP: RefCell<StableBTreeMap<Memory, UserName, UserData>> = RefCell::new(
+        StableBTreeMap::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))),
+        )
+    );
+}
+
+// Retrieves the value associated with the given key if it exists.
+#[ic_cdk_macros::query]
+fn get(key: String) -> Option<Vec<u8>> {
+    MAP.with(|p| p.borrow().get(&UserName(key)).map(|v| v.0))
+}
+
+// Inserts an entry into the map and returns the previous value of the key if it exists.
+#[ic_cdk_macros::update]
+fn insert(key: String, value: Vec<u8>) -> Option<Vec<u8>> {
+    MAP.with(|p| p.borrow_mut().insert(UserName(key), UserData(value)))
+        .unwrap()
+        .map(|v| v.0)
+}

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -15,8 +15,8 @@ dfx start --background
 dfx deploy
 
 # Insert some data into the basic_example canister.
-dfx canister call basic_example insert '("alice", blob "12341234")'
-dfx canister call basic_example insert '("bob", blob "789789789")'
+dfx canister call basic_example insert '(1:nat, 2:nat)'
+dfx canister call basic_example insert '(3:nat, 4:nat)'
 
 # Upgrade the canister, which clears all the data in the heap.
 dfx deploy --upgrade-unchanged basic_example
@@ -24,19 +24,41 @@ dfx deploy --upgrade-unchanged basic_example
 # Even though the canister has been upgraded and its heap is cleared,
 # querying the canister should still return the data stored prior to
 # the upgrade.
-DATA=$(dfx canister call basic_example get '("alice")')
-if ! [[ $DATA = "(opt blob \"12341234\")" ]]; then
+DATA=$(dfx canister call basic_example get '(1:nat)')
+if ! [[ $DATA = "(opt (2 : nat))" ]]; then
   echo "FAIL"
   exit 1
 fi
 
-DATA=$(dfx canister call basic_example get '("bob")')
-if ! [[ $DATA = "(opt blob \"789789789\")" ]]; then
+DATA=$(dfx canister call basic_example get '(3:nat)')
+if ! [[ $DATA = "(opt (4 : nat))" ]]; then
   echo "FAIL"
   exit 1
 fi
 
-# Insert some data into the basic_example canister.
+# Insert some data into the vecs_and_strings canister.
+dfx canister call vecs_and_strings insert '("alice", blob "12341234")'
+dfx canister call vecs_and_strings insert '("bob", blob "789789789")'
+
+# Upgrade the canister, which clears all the data in the heap.
+dfx deploy --upgrade-unchanged vecs_and_strings
+
+# Even though the canister has been upgraded and its heap is cleared,
+# querying the canister should still return the data stored prior to
+# the upgrade.
+DATA=$(dfx canister call vecs_and_strings get '("alice")')
+if ! [[ $DATA = '(opt blob "12341234")' ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
+DATA=$(dfx canister call vecs_and_strings get '("bob")')
+if ! [[ $DATA = '(opt blob "789789789")' ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
+# Insert some data into the custom_types_example canister.
 dfx canister call custom_types_example insert '(1, record { age = 32; name = "Some Name"})'
 dfx canister call custom_types_example insert '(2, record { age = 48; name = "Other Name"})'
 

--- a/src/btreemap/iter.rs
+++ b/src/btreemap/iter.rs
@@ -2,7 +2,7 @@ use super::{
     node::{Node, NodeType},
     BTreeMap,
 };
-use crate::{types::NULL, Address, BoundedStorable, Memory};
+use crate::{types::NULL, Address, Memory, Storable};
 
 /// An indicator of the current position in the map.
 pub(crate) enum Cursor {
@@ -18,7 +18,7 @@ pub(crate) enum Index {
 
 /// An iterator over the entries of a [`BTreeMap`].
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct Iter<'a, M: Memory, K: BoundedStorable, V: BoundedStorable> {
+pub struct Iter<'a, M: Memory, K: Storable, V: Storable> {
     // A reference to the map being iterated on.
     map: &'a BTreeMap<M, K, V>,
 
@@ -34,7 +34,7 @@ pub struct Iter<'a, M: Memory, K: BoundedStorable, V: BoundedStorable> {
     offset: Option<Vec<u8>>,
 }
 
-impl<'a, M: Memory, K: BoundedStorable, V: BoundedStorable> Iter<'a, M, K, V> {
+impl<'a, M: Memory, K: Storable, V: Storable> Iter<'a, M, K, V> {
     pub(crate) fn new(map: &'a BTreeMap<M, K, V>) -> Self {
         Self {
             map,
@@ -83,7 +83,7 @@ impl<'a, M: Memory, K: BoundedStorable, V: BoundedStorable> Iter<'a, M, K, V> {
     }
 }
 
-impl<M: Memory + Clone, K: BoundedStorable, V: BoundedStorable> Iterator for Iter<'_, M, K, V> {
+impl<M: Memory + Clone, K: Storable, V: Storable> Iterator for Iter<'_, M, K, V> {
     type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use btreemap::{BTreeMap, BTreeMap as StableBTreeMap};
 pub use ic0_memory::Ic0StableMemory;
 use std::error;
 use std::fmt::{Display, Formatter};
-pub use storable::Storable;
+pub use storable::{BoundedStorable, Storable};
 use types::Address;
 pub use vec_mem::VectorMemory;
 

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -15,6 +15,12 @@ pub trait Storable {
     fn from_bytes(bytes: Vec<u8>) -> Self;
 }
 
+/// A trait indicating that a `Storable` element is bounded in size.
+pub trait BoundedStorable: Storable {
+    /// The maximum size, in bytes, of the type when serialized.
+    fn max_size() -> u32;
+}
+
 // NOTE: Below are a few implementations of `Storable` for common types.
 // Some of these implementations use `unwrap`, as opposed to returning a `Result`
 // with a possible error. The reason behind this decision is that these
@@ -34,6 +40,12 @@ impl Storable for () {
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
         assert!(bytes.is_empty());
+    }
+}
+
+impl BoundedStorable for () {
+    fn max_size() -> u32 {
+        0
     }
 }
 
@@ -67,6 +79,12 @@ impl Storable for u128 {
     }
 }
 
+impl BoundedStorable for u128 {
+    fn max_size() -> u32 {
+        16
+    }
+}
+
 impl Storable for u64 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
         std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
@@ -74,6 +92,12 @@ impl Storable for u64 {
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
         Self::from_be_bytes(bytes.try_into().unwrap())
+    }
+}
+
+impl BoundedStorable for u64 {
+    fn max_size() -> u32 {
+        8
     }
 }
 
@@ -87,6 +111,12 @@ impl Storable for u32 {
     }
 }
 
+impl BoundedStorable for u32 {
+    fn max_size() -> u32 {
+        4
+    }
+}
+
 impl Storable for u16 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
         std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
@@ -97,6 +127,12 @@ impl Storable for u16 {
     }
 }
 
+impl BoundedStorable for u16 {
+    fn max_size() -> u32 {
+        2
+    }
+}
+
 impl Storable for u8 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
         std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
@@ -104,5 +140,11 @@ impl Storable for u8 {
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
         Self::from_be_bytes(bytes.try_into().unwrap())
+    }
+}
+
+impl BoundedStorable for u8 {
+    fn max_size() -> u32 {
+        1
     }
 }


### PR DESCRIPTION
BTreeMap currently take the maximum size of the BTreeMap as arguments. Example:

```
let map: StableBTreeMap<_, Key, Value> = StableBTreeMap::init(memory, MAX_KEY_SIZE, MAX_VALUE_SIZE)
```

One issue with this API is that specifying the max sizes is independent of the type being used, and that poses a couple of usability issues:

1.  If you're using a primitive type as your key/value (e.g. `u64`), it's not obvious what size you should put as an argument. The correct answer is `8`, because the `Storable` implementation of `u64` serializes it to a vector of 8 bytes, but that's far from obvious.
2. It's easy to put an incorrect value by accident if you're managing a few stable structures. I already made this mistake in the bitcoin canister.

A more safe and clear implementation is that the `Key` and `Value` contain information about their size, so that users don't need to specify the size explicitly when initializing the map.

This commit introduces a `BoundedStorable` trait, where it now required for a type to be used in `StableBTreeMap`. The map is then able to fetch the maximum size of that type without it being passed explicitly.

```
impl BoundedStorable for Key {
  fn max_size() -> u32 {
     MAX_KEY_SIZE
  }
}

impl BoundedStorable for Value {
  fn max_size() -> u32 {
     MAX_VALUE_SIZE
  }
}
```

And now the syntax is closer to a standard `BTreeMap`:

```
let map: StableBTreeMap<_, Key, Value> = StableBTreeMap::init(memory)
```

Storing the maximum size in the type allows us in the future to also support blanket implementations of tuples, so one can then implement:

```
let map: StableBTreeMap<_, (A, B), (C, D)> = StableBTreeMap::init(memory)
```


The updated examples showcase how the new API is used.