### PR TITLE
Add stable BinaryHeap implementation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,11 +81,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "ic-stable-structures"
 version = "0.3.0"
 dependencies = [
  "maplit",
  "proptest",
+ "rand 0.8.5",
  "tempfile",
 ]
 
@@ -126,6 +138,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proptest"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,8 +155,8 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error",
- "rand",
- "rand_chacha",
+ "rand 0.6.5",
+ "rand_chacha 0.1.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -159,7 +177,7 @@ checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
  "autocfg 0.1.8",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.1.1",
  "rand_core 0.4.2",
  "rand_hc",
  "rand_isaac",
@@ -171,6 +189,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +207,16 @@ checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
  "autocfg 0.1.8",
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -194,6 +233,15 @@ name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rand_hc"
@@ -324,6 +372,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ repository = "https://github.com/dfinity/stable-structures"
 [dev-dependencies]
 maplit = "1.0.2"
 proptest = "0.9.4"
+rand = "0.8.5"
 tempfile = "3.3.0"

--- a/examples/src/custom_types_example/src/lib.rs
+++ b/examples/src/custom_types_example/src/lib.rs
@@ -34,9 +34,8 @@ impl Storable for UserProfile {
 }
 
 impl BoundedStorable for UserProfile {
-    fn max_size() -> u32 {
-        MAX_VALUE_SIZE
-    }
+    const MAX_SIZE: u32 = MAX_VALUE_SIZE;
+    const FIXED_SIZE: bool = false;
 }
 
 thread_local! {

--- a/examples/src/vecs_and_strings/src/lib.rs
+++ b/examples/src/vecs_and_strings/src/lib.rs
@@ -27,9 +27,8 @@ impl Storable for UserName {
 }
 
 impl BoundedStorable for UserName {
-    fn max_size() -> u32 {
-        MAX_USER_NAME_SIZE
-    }
+    const MAX_SIZE: u32 = MAX_USER_NAME_SIZE;
+    const FIXED_SIZE: bool = false;
 }
 
 struct UserData(Vec<u8>);
@@ -46,9 +45,8 @@ impl Storable for UserData {
 }
 
 impl BoundedStorable for UserData {
-    fn max_size() -> u32 {
-        MAX_USER_DATA_SIZE
-    }
+    const MAX_SIZE: u32 = MAX_USER_DATA_SIZE;
+    const FIXED_SIZE: bool = false;
 }
 
 thread_local! {

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -1,0 +1,291 @@
+use crate::{BoundedStorable, vec::StableVec, Memory};
+
+pub struct BinaryHeap<M, T> {
+    data: StableVec<M, T>,
+}
+
+impl<M: Memory, T: Ord + BoundedStorable> BinaryHeap<M, T> {
+    #[must_use]
+    pub fn new(memory: M) -> BinaryHeap<M, T> {
+        Self { data: StableVec::new(memory) }
+    }
+
+    #[must_use]
+    pub fn new_with_sizes(memory: M, max_value_size: u64) -> Self {
+        let data = StableVec::new_with_sizes(memory, max_value_size);
+        Self { data }
+    }
+
+    pub fn load(memory: M) -> Self {
+        Self::load_with_sizes(memory, T::MAX_SIZE as u64)
+    }
+
+    pub fn load_with_sizes(memory: M, max_value_size: u64) -> Self {
+        // Read the header from memory.
+        let data = StableVec::load_with_sizes(memory, max_value_size);
+        data.into()
+    }
+
+    #[must_use]
+    pub fn peek(&self) -> Option<T> {
+        self.data.get(0)
+    }
+
+    pub fn clear(&mut self) {
+        self.data.clear();
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        self.data.pop().map(|element| {
+            if !self.is_empty() {
+                let ret = self.data.get(0).unwrap();
+                self.data.set(0, &element);
+                self.sift_down_to_bottom(0);
+                ret
+            } else {
+                element
+            }
+        })
+    }
+
+    pub fn push(&mut self, item: T) {
+        let old_len = self.len();
+        self.data.push(&item);
+        self.sift_up(0, old_len);
+    }
+
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.data.capacity()
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.data.reserve(additional);
+    }
+
+    fn sift_up(&mut self, start: usize, pos: usize) -> usize {
+        assert!(pos < self.len());
+        // Take out the value at `pos` and create a hole.
+        // SAFETY: Assert guarantees that pos < self.len()
+        let mut hole = unsafe{Hole::new(&mut self.data, pos)};
+
+        while hole.pos() > start {
+            let parent = (hole.pos() - 1) / 2;
+
+            // SAFETY: hole.pos() > start >= 0, which means hole.pos() > 0
+            //  and so hole.pos() - 1 can't underflow.
+            //  This guarantees that parent < hole.pos() so
+            //  it's a valid index and also != hole.pos().
+            if hole.element() <= unsafe { &hole.get(parent) } {
+                break;
+            }
+
+            // SAFETY: Same as above
+            unsafe { hole.move_to(parent) };
+        }
+
+        hole.pos()
+    }
+
+    fn sift_down_range(&mut self, pos: usize, end: usize) {
+        assert!(pos < end && end <= self.len());
+        // SAFETY: Assert guarantees that pos < end <= self.len().
+        let mut hole = unsafe { Hole::new(&mut self.data, pos) };
+        let mut child = 2 * hole.pos() + 1;
+
+        // Loop invariant: child == 2 * hole.pos() + 1.
+        while child <= end.saturating_sub(2) {
+            // compare with the greater of the two children
+            // SAFETY: child < end - 1 < self.len() and
+            //  child + 1 < end <= self.len(), so they're valid indexes.
+            //  child == 2 * hole.pos() + 1 != hole.pos() and
+            //  child + 1 == 2 * hole.pos() + 2 != hole.pos().
+            // FIXME: 2 * hole.pos() + 1 or 2 * hole.pos() + 2 could overflow
+            //  if T is a ZST
+            child += unsafe { hole.get(child) <= hole.get(child + 1) } as usize;
+
+            // if we are already in order, stop.
+            // SAFETY: child is now either the old child or the old child+1
+            //  We already proven that both are < self.len() and != hole.pos()
+            if hole.element() >= unsafe { &hole.get(child) } {
+                return;
+            }
+
+            // SAFETY: same as above.
+            unsafe { hole.move_to(child) };
+            child = 2 * hole.pos() + 1;
+        }
+
+        // SAFETY: && short circuit, which means that in the
+        //  second condition it's already true that child == end - 1 < self.len().
+        if child == end - 1 && hole.element() < unsafe { &hole.get(child) } {
+            // SAFETY: child is already proven to be a valid index and
+            //  child == 2 * hole.pos() + 1 != hole.pos().
+            unsafe { hole.move_to(child) };
+        }
+    }
+
+    fn sift_down(&mut self, pos: usize) {
+        assert!(pos < self.len());
+
+        let len = self.len();
+        self.sift_down_range(pos, len);
+    }
+
+    fn sift_down_to_bottom(&mut self, mut pos: usize) {
+        assert!(pos < self.len());
+        let end = self.len();
+        let start = pos;
+
+        // SAFETY: The caller guarantees that pos < self.len().
+        let mut hole = unsafe { Hole::new(&mut self.data, pos) };
+        let mut child = 2 * hole.pos() + 1;
+
+        // Loop invariant: child == 2 * hole.pos() + 1.
+        while child <= end.saturating_sub(2) {
+            // SAFETY: child < end - 1 < self.len() and
+            //  child + 1 < end <= self.len(), so they're valid indexes.
+            //  child == 2 * hole.pos() + 1 != hole.pos() and
+            //  child + 1 == 2 * hole.pos() + 2 != hole.pos().
+            // FIXME: 2 * hole.pos() + 1 or 2 * hole.pos() + 2 could overflow
+            //  if T is a ZST
+            child += unsafe { hole.get(child) <= hole.get(child + 1) } as usize;
+
+            // SAFETY: Same as above
+            unsafe { hole.move_to(child) };
+            child = 2 * hole.pos() + 1;
+        }
+
+        if child == end - 1 {
+            // SAFETY: child == end - 1 < self.len(), so it's a valid index
+            //  and child == 2 * hole.pos() + 1 != hole.pos().
+            unsafe { hole.move_to(child) };
+        }
+        pos = hole.pos();
+        drop(hole);
+
+        // SAFETY: pos is the position in the hole and was already proven
+        //  to be a valid index.
+        self.sift_up(start, pos);
+    }
+
+    fn rebuild(&mut self) {
+        let mut n = self.len() / 2;
+        while n > 0 {
+            n -= 1;
+            self.sift_down(n);
+        }
+    }
+}
+
+impl<M, T> BinaryHeap<M, T> {
+    #[must_use]
+    pub fn into_vec(self) -> StableVec<M, T> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+
+struct Hole<'a, M, T> 
+where M: Memory, T: BoundedStorable
+{
+    data: &'a mut StableVec<M, T>,
+    value: T,
+    pos: usize,
+}
+
+impl<'a, M, T> Hole<'a, M, T> 
+where M: Memory, T: BoundedStorable 
+{
+    /// Create a new `Hole` at index `pos`.
+    ///
+    /// Unsafe because pos must be within the data slice.
+    #[inline]
+    unsafe fn new(data: &'a mut StableVec<M, T>, pos: usize) -> Self {
+        debug_assert!(pos < data.len());
+        // SAFE: pos should be inside the slice
+        let value = data.get_unchecked(pos);
+        Hole { data, value, pos }
+    }
+
+    #[inline]
+    fn pos(&self) -> usize {
+        self.pos
+    }
+
+    /// Returns a reference to the element removed.
+    #[inline]
+    fn element(&self) -> &T {
+        &self.value
+    }
+
+    /// Returns a reference to the element at `index`.
+    ///
+    /// Unsafe because index must be within the data slice and not equal to pos.
+    #[inline]
+    unsafe fn get(&self, index: usize) -> T {
+        debug_assert!(index != self.pos);
+        debug_assert!(index < self.data.len());
+        // Safe because caller guarantees that index < len && index != pos.
+        self.data.get_unchecked(index)
+    }
+
+    /// Move hole to new location
+    ///
+    /// Unsafe because index must be within the data slice and not equal to pos.
+    #[inline]
+    unsafe fn move_to(&mut self, index: usize) {
+        debug_assert!(index != self.pos);
+        debug_assert!(index < self.data.len());
+
+        // SAFE: caller guarantees that index < len && index != pos.
+        let val = self.data.get_unchecked(index);
+        self.data.set(self.pos, &val);
+        self.pos = index;
+    }
+}
+
+impl<M, T> Drop for Hole<'_, M, T> where M: Memory, T: BoundedStorable {
+    #[inline]
+    fn drop(&mut self) {
+        // fill the hole again
+        self.data.set(self.pos, &self.value);
+    }
+}
+
+impl<M, T: Ord> From<StableVec<M, T>> for BinaryHeap<M, T> where M: Memory, T: BoundedStorable {
+    /// Converts a `Vec<T>` into a `BinaryHeap<T>`.
+    ///
+    /// This conversion happens in-place, and has *O*(*n*) time complexity.
+    fn from(vec: StableVec<M, T>) -> BinaryHeap<M, T> {
+        let mut heap = BinaryHeap { data: vec };
+        heap.rebuild();
+        heap
+    }
+}
+
+impl<M: Memory + Clone, T: BoundedStorable + Ord, const N: usize> From<(M, [T; N])> for BinaryHeap<M, T> {
+    fn from(arr: (M, [T; N])) -> Self {
+        Self::from(StableVec::from(arr))
+    }
+}
+
+impl<M, T> From<BinaryHeap<M, T>> for StableVec<M, T> {
+    /// Converts a `BinaryHeap<T>` into a `Vec<T>`.
+    ///
+    /// This conversion requires no data movement or allocation, and has
+    /// constant time complexity.
+    fn from(heap: BinaryHeap<M, T>) -> StableVec<M, T> {
+        heap.data
+    }
+}

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -67,7 +67,7 @@ impl<M: Memory + Clone, K: BoundedStorable, V: BoundedStorable> BTreeMap<M, K, V
     /// If the memory provided already contains a `BTreeMap`, then that
     /// map is loaded. Otherwise, a new `BTreeMap` instance is created.
     pub fn init(memory: M) -> Self {
-        Self::init_with_sizes(memory, K::max_size(), V::max_size())
+        Self::init_with_sizes(memory, K::MAX_SIZE, V::MAX_SIZE)
     }
 
     /// Creates a new instance a `BTreeMap`.
@@ -82,12 +82,12 @@ impl<M: Memory + Clone, K: BoundedStorable, V: BoundedStorable> BTreeMap<M, K, V
     ///
     /// See `Allocator` for more details on its own memory layout.
     pub fn new(memory: M) -> Self {
-        Self::new_with_sizes(memory, K::max_size(), V::max_size())
+        Self::new_with_sizes(memory, K::MAX_SIZE, V::MAX_SIZE)
     }
 
     /// Loads the map from memory.
     pub fn load(memory: M) -> Self {
-        Self::load_with_sizes(memory, K::max_size(), V::max_size())
+        Self::load_with_sizes(memory, K::MAX_SIZE, V::MAX_SIZE)
     }
 }
 
@@ -960,9 +960,7 @@ mod test {
 
     // Make `Vec<u8>` bounded so that it can be used as a key/value in the btree.
     impl BoundedStorable for Vec<u8> {
-        fn max_size() -> u32 {
-            10
-        }
+        const MAX_SIZE: u32 = 10;
     }
 
     #[test]

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -961,6 +961,7 @@ mod test {
     // Make `Vec<u8>` bounded so that it can be used as a key/value in the btree.
     impl BoundedStorable for Vec<u8> {
         const MAX_SIZE: u32 = 10;
+        const FIXED_SIZE: bool = true;
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use file_mem::FileMemory;
 pub use ic0_memory::Ic0StableMemory;
 use std::error;
 use std::fmt::{Display, Formatter};
-pub use storable::{EncodableStorable, BoundedStorable, Storable};
+pub use storable::{BoundedStorable, EncodableStorable, Storable};
 use types::{Address, Bytes};
 pub use vec_mem::VectorMemory;
 
@@ -148,23 +148,22 @@ fn write<M: Memory>(memory: &M, offset: u64, bytes: &[u8]) {
     }
 }
 
-fn copy<T: EncodableStorable, M: Memory>(memory: &M, src: Address, dest: Address, count: u64) {
-    let entry_size = (T::max_size() + if T::FIXED_LEN {0} else {4}) as usize;
+fn copy<M: Memory>(memory: &M, src: Address, dest: Address, count: u64, chunk_size: usize) {
     if dest <= src {
         for i in 0..count {
-            let index = i * entry_size as u64;
+            let index = i * chunk_size as u64;
             let src_addr = src + Bytes::from(index);
             let dst_addr = dest + Bytes::from(index);
-            let mut tmp = vec![0; entry_size];
+            let mut tmp = vec![0; chunk_size];
             memory.read(src_addr.get(), tmp.as_mut());
             memory.write(dst_addr.get(), tmp.as_ref());
         }
     } else {
         for i in 0..count {
-            let index = (count - i - 1) * entry_size as u64;
+            let index = (count - i - 1) * chunk_size as u64;
             let src_addr = src + Bytes::from(index);
             let dst_addr = dest + Bytes::from(index);
-            let mut tmp = vec![0; entry_size];
+            let mut tmp = vec![0; chunk_size];
             memory.read(src_addr.get(), tmp.as_mut());
             memory.write(dst_addr.get(), tmp.as_ref());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! them to grow to GiBs in size without the need for `pre_upgrade`/`post_upgrade` hooks.
 extern crate core;
 
+pub mod binary_heap;
 pub mod btreemap;
 pub mod cell;
 pub mod file_mem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use file_mem::FileMemory;
 pub use ic0_memory::Ic0StableMemory;
 use std::error;
 use std::fmt::{Display, Formatter};
-pub use storable::{BoundedStorable, EncodableStorable, Storable};
+pub use storable::{BoundedStorable, Storable};
 use types::{Address, Bytes};
 pub use vec_mem::VectorMemory;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use file_mem::FileMemory;
 pub use ic0_memory::Ic0StableMemory;
 use std::error;
 use std::fmt::{Display, Formatter};
-pub use storable::{BoundedStorable, Storable};
+pub use storable::{EncodableStorable, BoundedStorable, Storable};
 use types::{Address, Bytes};
 pub use vec_mem::VectorMemory;
 
@@ -148,22 +148,25 @@ fn write<M: Memory>(memory: &M, offset: u64, bytes: &[u8]) {
     }
 }
 
-fn copy<T: BoundedStorable, M: Memory>(memory: &M, src: Address, dest: Address, count: u64) {
+fn copy<T: EncodableStorable, M: Memory>(memory: &M, src: Address, dest: Address, count: u64) {
+    let entry_size = (T::max_size() + if T::FIXED_LEN {0} else {4}) as usize;
     if dest <= src {
         for i in 0..count {
-            let index = i * T::max_size() as u64;
+            let index = i * entry_size as u64;
             let src_addr = src + Bytes::from(index);
             let dst_addr = dest + Bytes::from(index);
-            let tmp: T = read_struct(src_addr, memory);
-            write_struct(&tmp, dst_addr, memory);
+            let mut tmp = vec![0; entry_size];
+            memory.read(src_addr.get(), tmp.as_mut());
+            memory.write(dst_addr.get(), tmp.as_ref());
         }
     } else {
         for i in 0..count {
-            let index = (count - i - 1) * T::max_size() as u64;
+            let index = (count - i - 1) * entry_size as u64;
             let src_addr = src + Bytes::from(index);
             let dst_addr = dest + Bytes::from(index);
-            let tmp: T = read_struct(src_addr, memory);
-            write_struct(&tmp, dst_addr, memory);
+            let mut tmp = vec![0; entry_size];
+            memory.read(src_addr.get(), tmp.as_mut());
+            memory.write(dst_addr.get(), tmp.as_ref());
         }
     }
 }

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -18,7 +18,7 @@ pub trait Storable {
 /// A trait indicating that a `Storable` element is bounded in size.
 pub trait BoundedStorable: Storable {
     /// The maximum size, in bytes, of the type when serialized.
-    fn max_size() -> u32;
+    const MAX_SIZE: u32;
 }
 
 pub trait EncodableStorable: BoundedStorable {
@@ -48,9 +48,7 @@ impl Storable for () {
 }
 
 impl BoundedStorable for () {
-    fn max_size() -> u32 {
-        0
-    }
+    const MAX_SIZE: u32 = 0;
 }
 
 impl EncodableStorable for () {
@@ -88,9 +86,7 @@ impl Storable for u128 {
 }
 
 impl BoundedStorable for u128 {
-    fn max_size() -> u32 {
-        16
-    }
+    const MAX_SIZE: u32 = 16;
 }
 
 impl EncodableStorable for u128 {
@@ -108,9 +104,7 @@ impl Storable for u64 {
 }
 
 impl BoundedStorable for u64 {
-    fn max_size() -> u32 {
-        8
-    }
+    const MAX_SIZE: u32 = 8;
 }
 
 impl EncodableStorable for u64 {
@@ -128,9 +122,7 @@ impl Storable for u32 {
 }
 
 impl BoundedStorable for u32 {
-    fn max_size() -> u32 {
-        4
-    }
+    const MAX_SIZE: u32 = 4;
 }
 
 impl EncodableStorable for u32 {
@@ -148,9 +140,7 @@ impl Storable for u16 {
 }
 
 impl BoundedStorable for u16 {
-    fn max_size() -> u32 {
-        2
-    }
+    const MAX_SIZE: u32 = 2;
 }
 
 impl EncodableStorable for u16 {
@@ -168,9 +158,7 @@ impl Storable for u8 {
 }
 
 impl BoundedStorable for u8 {
-    fn max_size() -> u32 {
-        1
-    }
+    const MAX_SIZE: u32 = 1;
 }
 
 impl EncodableStorable for u8 {

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -21,6 +21,10 @@ pub trait BoundedStorable: Storable {
     fn max_size() -> u32;
 }
 
+pub trait EncodableStorable: BoundedStorable {
+    const FIXED_LEN: bool;
+}
+
 // NOTE: Below are a few implementations of `Storable` for common types.
 // Some of these implementations use `unwrap`, as opposed to returning a `Result`
 // with a possible error. The reason behind this decision is that these
@@ -47,6 +51,10 @@ impl BoundedStorable for () {
     fn max_size() -> u32 {
         0
     }
+}
+
+impl EncodableStorable for () {
+    const FIXED_LEN: bool = true;
 }
 
 impl Storable for Vec<u8> {
@@ -85,6 +93,10 @@ impl BoundedStorable for u128 {
     }
 }
 
+impl EncodableStorable for u128 {
+    const FIXED_LEN: bool = true;
+}
+
 impl Storable for u64 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
         std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
@@ -99,6 +111,10 @@ impl BoundedStorable for u64 {
     fn max_size() -> u32 {
         8
     }
+}
+
+impl EncodableStorable for u64 {
+    const FIXED_LEN: bool = true;
 }
 
 impl Storable for u32 {
@@ -117,6 +133,10 @@ impl BoundedStorable for u32 {
     }
 }
 
+impl EncodableStorable for u32 {
+    const FIXED_LEN: bool = true;
+}
+
 impl Storable for u16 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
         std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
@@ -133,6 +153,10 @@ impl BoundedStorable for u16 {
     }
 }
 
+impl EncodableStorable for u16 {
+    const FIXED_LEN: bool = true;
+}
+
 impl Storable for u8 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
         std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
@@ -147,4 +171,8 @@ impl BoundedStorable for u8 {
     fn max_size() -> u32 {
         1
     }
+}
+
+impl EncodableStorable for u8 {
+    const FIXED_LEN: bool = true;
 }

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -19,10 +19,9 @@ pub trait Storable {
 pub trait BoundedStorable: Storable {
     /// The maximum size, in bytes, of the type when serialized.
     const MAX_SIZE: u32;
-}
 
-pub trait EncodableStorable: BoundedStorable {
-    const FIXED_LEN: bool;
+    /// Indicates if the serialized type has a fixed length.
+    const FIXED_SIZE: bool;
 }
 
 // NOTE: Below are a few implementations of `Storable` for common types.
@@ -49,10 +48,7 @@ impl Storable for () {
 
 impl BoundedStorable for () {
     const MAX_SIZE: u32 = 0;
-}
-
-impl EncodableStorable for () {
-    const FIXED_LEN: bool = true;
+    const FIXED_SIZE: bool = true;
 }
 
 impl Storable for Vec<u8> {
@@ -87,10 +83,7 @@ impl Storable for u128 {
 
 impl BoundedStorable for u128 {
     const MAX_SIZE: u32 = 16;
-}
-
-impl EncodableStorable for u128 {
-    const FIXED_LEN: bool = true;
+    const FIXED_SIZE: bool = true;
 }
 
 impl Storable for u64 {
@@ -105,10 +98,7 @@ impl Storable for u64 {
 
 impl BoundedStorable for u64 {
     const MAX_SIZE: u32 = 8;
-}
-
-impl EncodableStorable for u64 {
-    const FIXED_LEN: bool = true;
+    const FIXED_SIZE: bool = true;
 }
 
 impl Storable for u32 {
@@ -123,10 +113,7 @@ impl Storable for u32 {
 
 impl BoundedStorable for u32 {
     const MAX_SIZE: u32 = 4;
-}
-
-impl EncodableStorable for u32 {
-    const FIXED_LEN: bool = true;
+    const FIXED_SIZE: bool = true;
 }
 
 impl Storable for u16 {
@@ -141,10 +128,7 @@ impl Storable for u16 {
 
 impl BoundedStorable for u16 {
     const MAX_SIZE: u32 = 2;
-}
-
-impl EncodableStorable for u16 {
-    const FIXED_LEN: bool = true;
+    const FIXED_SIZE: bool = true;
 }
 
 impl Storable for u8 {
@@ -159,8 +143,5 @@ impl Storable for u8 {
 
 impl BoundedStorable for u8 {
     const MAX_SIZE: u32 = 1;
-}
-
-impl EncodableStorable for u8 {
-    const FIXED_LEN: bool = true;
+    const FIXED_SIZE: bool = true;
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,0 +1,296 @@
+use std::marker::PhantomData;
+
+use crate::{
+    copy, read_struct,
+    types::{Address, Bytes},
+    write_struct, BoundedStorable, Memory,
+};
+
+const LAYOUT_VERSION: u8 = 1;
+const MAGIC: &[u8; 3] = b"VEC";
+
+pub struct StableVec<M, T> {
+    memory: M,
+    max_value_size: u64,
+    base: Address,
+
+    len: usize,
+
+    // A marker to communicate to the Rust compiler that we own these types.
+    _phantom: PhantomData<T>,
+}
+
+#[repr(packed)]
+struct StableVecHeader {
+    magic: [u8; 3],
+    version: u8,
+    max_value_size: u64,
+    len: usize,
+    // Additional space reserved to add new fields without breaking backward-compatibility.
+    _buffer: [u8; 24],
+}
+
+impl StableVecHeader {
+    fn size() -> Bytes {
+        Bytes::from(core::mem::size_of::<Self>() as u64)
+    }
+}
+
+impl<M: Memory + Clone, T: BoundedStorable> StableVec<M, T> {
+    #[must_use]
+    pub fn new(memory: M) -> Self {
+        Self::new_with_sizes(memory, T::max_size() as u64)
+    }
+
+    pub fn new_with_sizes(memory: M, max_value_size: u64) -> Self {
+        let heap = Self {
+            memory,
+            max_value_size,
+            base: Address::from(0) + StableVecHeader::size(),
+            len: 0,
+            _phantom: PhantomData,
+        };
+
+        heap.save();
+        heap
+    }
+
+    pub fn load(memory: M) -> Self {
+        Self::load_with_sizes(memory, T::max_size() as u64)
+    }
+
+    pub fn load_with_sizes(memory: M, max_value_size: u64) -> Self {
+        // Read the header from memory.
+        let header: StableVecHeader = read_struct(Address::from(0), &memory);
+        assert_eq!(&header.magic, MAGIC, "Bad magic.");
+        assert_eq!(header.version, LAYOUT_VERSION, "Unsupported version.");
+        let expected_value_size = header.max_value_size;
+        assert!(
+            max_value_size <= expected_value_size,
+            "max_value_size must be <= {}",
+            expected_value_size
+        );
+
+        Self {
+            memory,
+            max_value_size: header.max_value_size,
+            base: Address::from(0) + StableVecHeader::size(),
+            len: header.len,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn save(&self) {
+        let header = StableVecHeader {
+            magic: *MAGIC,
+            version: LAYOUT_VERSION,
+            max_value_size: self.max_value_size,
+            len: self.len,
+            _buffer: [0; 24],
+        };
+
+        write_struct(&header, Address::from(0), &self.memory);
+    }
+
+    fn index_to_addr(&self, index: usize) -> Address {
+        self.base + Bytes::from(self.max_value_size * (index as u64))
+    }
+}
+
+impl<M: Memory + Clone, T: BoundedStorable> StableVec<M, T> {
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        let page_size = 64 * 1024;
+        let bytes = self.memory.size() * page_size;
+        let free_bytes = bytes - StableVecHeader::size().get();
+        (free_bytes / self.max_value_size) as usize
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        let page_size = 64 * 1024;
+        let round_up = |x| ((x + page_size - 1) & !(page_size - 1));
+
+        let add_bytes = additional as u64 * self.max_value_size;
+        let add_pages = round_up(add_bytes) / page_size;
+
+        self.memory.grow(add_pages);
+    }
+
+    pub fn insert(&mut self, index: usize, element: &T) {
+        #[cold]
+        #[inline(never)]
+        fn assert_failed(index: usize, len: usize) -> ! {
+            panic!("insertion index (is {index}) should be <= len (is {len})");
+        }
+
+        let len = self.len();
+        if index > len {
+            assert_failed(index, len);
+        }
+
+        // space for the new element
+        if len == self.capacity() {
+            self.reserve(1);
+        }
+
+        let p = self.index_to_addr(index);
+        let src = p;
+        let dst = p + Bytes::from(self.max_value_size as u64);
+        copy::<T, M>(&self.memory, src, dst, (len - index) as u64);
+        write_struct(element, p, &self.memory);
+
+        self.len += 1;
+    }
+
+    pub fn remove(&mut self, index: usize) -> T {
+        #[cold]
+        #[inline(never)]
+        fn assert_failed(index: usize, len: usize) -> ! {
+            panic!("removal index (is {index}) should be < len (is {len})");
+        }
+
+        let len = self.len();
+        if index >= len {
+            assert_failed(index, len);
+        }
+
+        let ret;
+        {
+            let ptr = self.index_to_addr(index);
+            ret = read_struct(ptr, &self.memory);
+
+            // Shift everything down to fill in that spot.
+            copy::<T, M>(
+                &self.memory,
+                self.index_to_addr(index + 1),
+                ptr,
+                (len - index - 1) as u64,
+            );
+        }
+        self.len -= 1;
+        ret
+    }
+
+    #[inline]
+    pub fn push(&mut self, value: &T) {
+        let end = self.index_to_addr(self.len);
+        write_struct(value, end, &self.memory);
+        self.len += 1;
+    }
+
+    #[inline]
+    pub fn pop(&mut self) -> Option<T> {
+        if self.len == 0 {
+            None
+        } else {
+            self.len -= 1;
+            Some(read_struct(self.index_to_addr(self.len()), &self.memory))
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn get(&self, index: usize) -> T {
+        assert!(index < self.len());
+        read_struct(self.index_to_addr(index), &self.memory)
+    }
+
+    pub fn set(&self, index: usize, value: T) {
+        assert!(index < self.len());
+        write_struct(&value, self.index_to_addr(index), &self.memory);
+    }
+}
+
+impl<M: Memory + Clone, T: Clone + BoundedStorable> From<(M, &[T])> for StableVec<M, T> {
+    fn from(s: (M, &[T])) -> Self {
+        let mut v: StableVec<M, T> = StableVec::new(s.0);
+        for t in s.1 {
+            v.push(t);
+        }
+        v
+    }
+}
+
+impl<M: Memory + Clone, T: Clone + BoundedStorable, const N: usize> From<(M, [T; N])>
+    for StableVec<M, T>
+{
+    fn from(s: (M, [T; N])) -> Self {
+        let slice: &[T] = &s.1;
+        StableVec::from((s.0, slice))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    fn make_memory() -> Rc<RefCell<Vec<u8>>> {
+        Rc::new(RefCell::new(Vec::new()))
+    }
+
+    #[test]
+    pub fn test_insert() {
+        let mem = make_memory();
+        let mut v = StableVec::new(mem);
+        v.insert(0, &0u32);
+        v.insert(1, &1u32);
+
+        assert_eq!(v.len(), 2);
+        assert_eq!(v.get(1), 1);
+        assert_eq!(v.get(0), 0);
+    }
+
+    #[test]
+    pub fn test_remove() {
+        let mem = make_memory();
+        let mut v = StableVec::from((mem, [0u32, 1u32]));
+
+        assert_eq!(v.len(), 2);
+        assert_eq!(v.get(1), 1);
+        assert_eq!(v.get(0), 0);
+
+        assert_eq!(v.remove(0), 0);
+        assert_eq!(v.len(), 1);
+
+        assert_eq!(v.remove(0), 1);
+        assert_eq!(v.len(), 0);
+    }
+
+    #[test]
+    pub fn test_push_pop() {
+        let mem = make_memory();
+        let mut v = StableVec::new(mem);
+        v.push(&0u32);
+        v.push(&1u32);
+
+        assert_eq!(v.pop(), Some(1));
+        assert_eq!(v.pop(), Some(0));
+        assert_eq!(v.pop(), None);
+        assert_eq!(v.len(), 0);
+    }
+
+    #[test]
+    pub fn test_clear() {
+        let mem = make_memory();
+        let mut v = StableVec::from((mem, [0u32, 1u32]));
+
+        v.clear();
+
+        let val = 42;
+        assert_eq!(v.pop(), None);
+        v.push(&val);
+        assert_eq!(v.pop(), Some(val));
+    }
+}

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -23,7 +23,7 @@ const MAGIC: &[u8; 3] = b"VEC";
 /// size: u32
 ///
 /// Returns the pointer to the entry (read: not necessarily the value).
-pub struct StableVec<M, T> {
+pub struct Vec<M, T> {
     memory: M,
     max_value_size: u64,
     base: Address,
@@ -51,7 +51,7 @@ impl StableVecHeader {
     }
 }
 
-impl<M: Memory, T: BoundedStorable> StableVec<M, T> {
+impl<M: Memory, T: BoundedStorable> Vec<M, T> {
     const ENTRY_SIZE: usize = (T::MAX_SIZE + if T::FIXED_SIZE { 0 } else { 4 }) as usize;
 
     #[must_use]
@@ -253,7 +253,7 @@ impl<M: Memory, T: BoundedStorable> StableVec<M, T> {
     }
 }
 
-impl<M, T> StableVec<M, T> {
+impl<M, T> Vec<M, T> {
     pub fn len(&self) -> usize {
         self.len
     }
@@ -263,9 +263,9 @@ impl<M, T> StableVec<M, T> {
     }
 }
 
-impl<M: Memory, T: BoundedStorable> From<(M, &[T])> for StableVec<M, T> {
+impl<M: Memory, T: BoundedStorable> From<(M, &[T])> for Vec<M, T> {
     fn from(s: (M, &[T])) -> Self {
-        let mut v: StableVec<M, T> = StableVec::new(s.0);
+        let mut v: Vec<M, T> = Vec::new(s.0);
         for t in s.1 {
             v.push(t);
         }
@@ -273,10 +273,10 @@ impl<M: Memory, T: BoundedStorable> From<(M, &[T])> for StableVec<M, T> {
     }
 }
 
-impl<M: Memory, T: BoundedStorable, const N: usize> From<(M, [T; N])> for StableVec<M, T> {
+impl<M: Memory, T: BoundedStorable, const N: usize> From<(M, [T; N])> for Vec<M, T> {
     fn from(s: (M, [T; N])) -> Self {
         let slice: &[T] = &s.1;
-        StableVec::from((s.0, slice))
+        Vec::from((s.0, slice))
     }
 }
 
@@ -286,14 +286,14 @@ mod test {
     use std::cell::RefCell;
     use std::rc::Rc;
 
-    fn make_memory() -> Rc<RefCell<Vec<u8>>> {
-        Rc::new(RefCell::new(Vec::new()))
+    fn make_memory() -> Rc<RefCell<std::vec::Vec<u8>>> {
+        Rc::new(RefCell::new(std::vec::Vec::new()))
     }
 
     #[test]
     pub fn test_insert() {
         let mem = make_memory();
-        let mut v = StableVec::new(mem);
+        let mut v = Vec::new(mem);
         v.insert(0, &0u32);
         v.insert(1, &1u32);
 
@@ -305,7 +305,7 @@ mod test {
     #[test]
     pub fn test_remove() {
         let mem = make_memory();
-        let mut v = StableVec::from((mem, [0u32, 1u32]));
+        let mut v = Vec::from((mem, [0u32, 1u32]));
 
         assert_eq!(v.len(), 2);
         assert_eq!(v.get(1), Some(1));
@@ -321,7 +321,7 @@ mod test {
     #[test]
     pub fn test_push_pop() {
         let mem = make_memory();
-        let mut v = StableVec::new(mem);
+        let mut v = Vec::new(mem);
         v.push(&0u32);
         v.push(&1u32);
 
@@ -334,7 +334,7 @@ mod test {
     #[test]
     pub fn test_clear() {
         let mem = make_memory();
-        let mut v = StableVec::from((mem, [0u32, 1u32]));
+        let mut v = Vec::from((mem, [0u32, 1u32]));
 
         v.clear();
 
@@ -348,10 +348,10 @@ mod test {
     pub fn test_load_from_mem() {
         let mem = make_memory();
         {
-            let _v = StableVec::from((mem.clone(), [0u32, 1u32, 2u32, 3u32, 4u32]));
+            let _v = Vec::from((mem.clone(), [0u32, 1u32, 2u32, 3u32, 4u32]));
         }
 
-        let mut v: StableVec<Rc<RefCell<Vec<u8>>>, u32> = StableVec::load(mem);
+        let mut v: Vec<Rc<RefCell<std::vec::Vec<u8>>>, u32> = Vec::load(mem);
 
         assert_eq!(v.pop(), Some(4u32));
         assert_eq!(v.pop(), Some(3u32));

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -212,6 +212,10 @@ impl<M: Memory, T: BoundedStorable> StableVec<M, T> {
         }
     }
 
+    /// # Safety
+    ///
+    /// Calling this method with an out-of-bounds index is *[undefined behavior]*
+    /// even if the resulting reference is not used.
     pub unsafe fn get_unchecked(&self, index: usize) -> T {
         self.read_value(index)
     }


### PR DESCRIPTION
A stable Binary Heap using StableVec.

This is a port of https://doc.rust-lang.org/stable/std/collections/struct.BinaryHeap.html