### PR TITLE
feat: add quickstart example

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.65"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arrayvec"
@@ -126,9 +126,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "candid"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e4287605536419ac6ce9d76d3aa5733677ca8c7c2891079b2c71a345cc17a3"
+checksum = "d510cc32b8b991acc955dd3d5e0cb6f404069d1dccd9203ee90f5865557c9165"
 dependencies = [
  "anyhow",
  "binread",
@@ -168,6 +168,30 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "git+https://github.com/enarx/ciborium?rev=e719537c99b564c3674a56defe53713c702c6f46#e719537c99b564c3674a56defe53713c702c6f46"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "git+https://github.com/enarx/ciborium?rev=e719537c99b564c3674a56defe53713c702c6f46#e719537c99b564c3674a56defe53713c702c6f46"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "git+https://github.com/enarx/ciborium?rev=e719537c99b564c3674a56defe53713c702c6f46#e719537c99b564c3674a56defe53713c702c6f46"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -226,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "diff"
@@ -238,9 +262,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -306,14 +330,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -368,9 +398,9 @@ version = "0.3.0"
 
 [[package]]
 name = "ic-types"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d9569a4c91d5c9c202c1666f799a9761bab70a2b59464ee78c45b005e47b8"
+checksum = "79a17269dff0ec6ca4c3d04e18fca97d018ff53d809e6d92348fc22f9588e1a5"
 dependencies = [
  "crc32fast",
  "data-encoding",
@@ -383,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -393,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -446,15 +476,15 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "lock_api"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -558,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "parking_lot"
@@ -574,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -587,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "petgraph"
@@ -645,18 +675,30 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
+name = "quick_start"
+version = "0.2.0"
+dependencies = [
+ "candid",
+ "ciborium",
+ "ic-cdk",
+ "ic-cdk-macros",
+ "ic-stable-structures",
+ "serde",
+]
+
+[[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -683,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -694,15 +736,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "scopeguard"
@@ -712,27 +754,27 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -741,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "serde_tokenstream"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6deb15c3a535e81438110111d90168d91721652f502abb147f31cde129f683d"
+checksum = "2794f0ba0179a8ca422c30d9975d86faf8306be0164bfc3b0b1ca4f060ac639d"
 dependencies = [
  "proc-macro2",
  "serde",
@@ -752,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -769,9 +811,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "string_cache"
@@ -788,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -819,18 +861,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -848,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -863,15 +905,15 @@ checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-width"
@@ -881,9 +923,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "vecs_and_strings"
@@ -940,43 +982,57 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
+ "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,4 +3,5 @@ members = [
     "src/basic_example",
     "src/vecs_and_strings",
     "src/custom_types_example",
+    "src/quick_start",
 ]

--- a/examples/dfx.json
+++ b/examples/dfx.json
@@ -1,6 +1,11 @@
 {
   "dfx": "0.11.2",
   "canisters": {
+    "quick_start": {
+      "candid": "src/quick_start/candid.did",
+      "package": "quick_start",
+      "type": "rust"
+    },
     "basic_example": {
       "candid": "src/basic_example/candid.did",
       "package": "basic_example",

--- a/examples/src/quick_start/Cargo.toml
+++ b/examples/src/quick_start/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "quick_start"
+version = "0.2.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = "0.7.4"
+# NOTE: A specific commit of ciborium is used that includes efficient serializion/deserialization of
+#       blobs. At the time of this writing, a new version including this commit hasn't yet been released.
+ciborium = { git = "https://github.com/enarx/ciborium", rev = "e719537c99b564c3674a56defe53713c702c6f46" }
+ic-cdk = "0.4"
+ic-cdk-macros = "0.4"
+ic-stable-structures = { path = "../../../" }
+serde = "1.0.132"

--- a/examples/src/quick_start/README.md
+++ b/examples/src/quick_start/README.md
@@ -1,0 +1,29 @@
+# Quickstart Example
+
+An example that showcases how you can incorporate stable structures, and specifically `StableBTreeMap`, into existing canisters that already store some data on the heap.
+
+Example usage:
+
+```
+dfx start --background --clean
+
+# Insert some data into the quick_start canister.
+dfx canister call quick_start stable_insert '(1:nat, 2:nat)'
+dfx canister call quick_start stable_insert '(3:nat, 4:nat)'
+dfx canister call quick_start set_heap_data '(vec {1:nat8; 2:nat8; 3:nat8})'
+
+# Upgrade the canister, which clears all the data in the heap.
+dfx deploy --upgrade-unchanged quick_start
+
+# Even though the canister has been upgraded and its heap is cleared,
+# querying the canister should still return the data stored prior to
+# the upgrade.
+dfx canister call quick_start stable_get '(1:nat)'
+> (opt (2 : nat))
+
+dfx canister call quick_start stable_get '(3:nat)'
+> (opt (4 : nat))
+
+dfx canister call quick_start get_heap_data
+> (blob "\01\02\03")
+```

--- a/examples/src/quick_start/candid.did
+++ b/examples/src/quick_start/candid.did
@@ -1,0 +1,7 @@
+service : {
+    "stable_get": (nat) -> (opt nat) query;
+    "stable_insert": (nat, nat) -> (opt nat);
+
+    "set_heap_data": (blob) -> ();
+    "get_heap_data": () -> (blob);
+}

--- a/examples/src/quick_start/candid.old.did
+++ b/examples/src/quick_start/candid.old.did
@@ -1,4 +1,0 @@
-service : {
-    "get": (nat) -> (opt nat) query;
-    "set": (nat, nat) -> (opt nat);
-}

--- a/examples/src/quick_start/candid.old.did
+++ b/examples/src/quick_start/candid.old.did
@@ -1,0 +1,4 @@
+service : {
+    "get": (nat) -> (opt nat) query;
+    "set": (nat, nat) -> (opt nat);
+}

--- a/examples/src/quick_start/src/lib.rs
+++ b/examples/src/quick_start/src/lib.rs
@@ -1,0 +1,109 @@
+//! An example showcasing how stable structures, and specifically StableBTreeMap, can be used in
+//! production alongside other state that is stored on the heap and is serialized/deserialized on
+//! every upgrade.
+//!
+//! This example showcases how you can include stable structures in your projects. For simpler
+//! examples, checkout the other examples in the `examples` directory.
+use ic_cdk_macros::{post_upgrade, pre_upgrade, query, update};
+use ic_stable_structures::{writer::Writer, Memory as _, StableBTreeMap};
+use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
+mod memory;
+use memory::Memory;
+
+// The state of the canister.
+#[derive(Serialize, Deserialize)]
+struct State {
+    // Data that lives in the heap.
+    // This is an example for data that would need to be serialized/deserialized
+    // on every upgrade for it to be persisted.
+    data_on_the_heap: Vec<u8>,
+
+    // An example `StableBTreeMap`. Data stored in `StableBTreeMap` doesn't need to
+    // be serialized/deserialized in upgrades, so we tell serde to skip it.
+    #[serde(skip, default = "init_stable_data")]
+    stable_data: StableBTreeMap<Memory, u128, u128>,
+}
+
+thread_local! {
+    static STATE: RefCell<State> = RefCell::new(State::default());
+}
+
+// Retrieves the value associated with the given key in the stable data if it exists.
+#[query]
+fn stable_get(key: u128) -> Option<u128> {
+    STATE.with(|s| s.borrow().stable_data.get(&key))
+}
+
+// Inserts an entry into the map and returns the previous value of the key from stable data
+// if it exists.
+#[update]
+fn stable_insert(key: u128, value: u128) -> Option<u128> {
+    STATE
+        .with(|s| s.borrow_mut().stable_data.insert(key, value))
+        .unwrap()
+}
+
+// Inserts an entry into the map and returns the previous value of the key if it exists.
+#[update]
+fn set_heap_data(data: Vec<u8>) {
+    STATE.with(|s| s.borrow_mut().data_on_the_heap = data);
+}
+
+#[query]
+fn get_heap_data() -> Vec<u8> {
+    STATE.with(|s| s.borrow().data_on_the_heap.clone())
+}
+
+// A pre-upgrade hook for serializing the data stored on the heap.
+#[pre_upgrade]
+fn pre_upgrade() {
+    // Serialize the state.
+    // This example is using CBOR, but you can use any data format you like.
+    let mut state_bytes = vec![];
+    STATE.with(|s| ciborium::ser::into_writer(&*s.borrow(), &mut state_bytes))
+        .expect("failed to encode state");
+
+    // Write the length of the serialized bytes to memory, followed by the
+    // by the bytes themselves.
+    let len = state_bytes.len() as u32;
+    let mut memory = memory::get_upgrades_memory();
+    let mut writer = Writer::new(&mut memory, 0);
+    writer.write(&len.to_le_bytes()).unwrap();
+    writer.write(&state_bytes).unwrap()
+}
+
+// A post-upgrade hook for deserializing the data back into the heap.
+#[post_upgrade]
+fn post_upgrade() {
+    let memory = memory::get_upgrades_memory();
+
+    // Read the length of the state bytes.
+    let mut state_len_bytes = [0; 4];
+    memory.read(0, &mut state_len_bytes);
+    let state_len = u32::from_le_bytes(state_len_bytes) as usize;
+
+    // Read the bytes
+    let mut state_bytes = vec![0; state_len];
+    memory.read(4, &mut state_bytes);
+
+    // Deserialize and set the state.
+    let state = ciborium::de::from_reader(&*state_bytes).expect("failed to decode state");
+    STATE.with(|s| {
+        *s.borrow_mut() = state
+    });
+}
+
+fn init_stable_data() -> StableBTreeMap<Memory, u128, u128> {
+    StableBTreeMap::init(crate::memory::get_stable_btree_memory())
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            data_on_the_heap: vec![],
+            stable_data: init_stable_data(),
+        }
+    }
+}
+

--- a/examples/src/quick_start/src/lib.rs
+++ b/examples/src/quick_start/src/lib.rs
@@ -14,7 +14,7 @@ use memory::Memory;
 // The state of the canister.
 #[derive(Serialize, Deserialize)]
 struct State {
-    // Data that lives in the heap.
+    // Data that lives on the heap.
     // This is an example for data that would need to be serialized/deserialized
     // on every upgrade for it to be persisted.
     data_on_the_heap: Vec<u8>,
@@ -44,12 +44,13 @@ fn stable_insert(key: u128, value: u128) -> Option<u128> {
         .unwrap()
 }
 
-// Inserts an entry into the map and returns the previous value of the key if it exists.
+// Sets the data that lives on the heap.
 #[update]
 fn set_heap_data(data: Vec<u8>) {
     STATE.with(|s| s.borrow_mut().data_on_the_heap = data);
 }
 
+// Retrieves the data that lives on the heap.
 #[query]
 fn get_heap_data() -> Vec<u8> {
     STATE.with(|s| s.borrow().data_on_the_heap.clone())

--- a/examples/src/quick_start/src/memory.rs
+++ b/examples/src/quick_start/src/memory.rs
@@ -1,0 +1,27 @@
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::DefaultMemoryImpl;
+use std::cell::RefCell;
+
+// A memory for upgrades, where data from the heap can be serialized/deserialized.
+const UPGRADES: MemoryId = MemoryId::new(0);
+
+// A memory for the StableBTreeMap we're using. A new memory should be created for
+// every additional stable structure.
+const STABLE_BTREE: MemoryId = MemoryId::new(1);
+
+pub type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+thread_local! {
+    // The memory manager is used for simulating multiple memories. Given a `MemoryId` it can
+    // return a memory that can be used by stable structures.
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+}
+
+pub fn get_upgrades_memory() -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(UPGRADES))
+}
+
+pub fn get_stable_btree_memory() -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(STABLE_BTREE))
+}

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -14,6 +14,72 @@ dfx start --background
 # Deploys the examples.
 dfx deploy
 
+# Insert some data into the basic_example canister.
+dfx canister call basic_example insert '(1:nat, 2:nat)'
+dfx canister call basic_example insert '(3:nat, 4:nat)'
+
+# Upgrade the canister, which clears all the data in the heap.
+dfx deploy --upgrade-unchanged basic_example
+
+# Even though the canister has been upgraded and its heap is cleared,
+# querying the canister should still return the data stored prior to
+# the upgrade.
+DATA=$(dfx canister call basic_example get '(1:nat)')
+if ! [[ $DATA = "(opt (2 : nat))" ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
+DATA=$(dfx canister call basic_example get '(3:nat)')
+if ! [[ $DATA = "(opt (4 : nat))" ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
+# Insert some data into the vecs_and_strings canister.
+dfx canister call vecs_and_strings insert '("alice", blob "12341234")'
+dfx canister call vecs_and_strings insert '("bob", blob "789789789")'
+
+# Upgrade the canister, which clears all the data in the heap.
+dfx deploy --upgrade-unchanged vecs_and_strings
+
+# Even though the canister has been upgraded and its heap is cleared,
+# querying the canister should still return the data stored prior to
+# the upgrade.
+DATA=$(dfx canister call vecs_and_strings get '("alice")')
+if ! [[ $DATA = '(opt blob "12341234")' ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
+DATA=$(dfx canister call vecs_and_strings get '("bob")')
+if ! [[ $DATA = '(opt blob "789789789")' ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
+# Insert some data into the custom_types_example canister.
+dfx canister call custom_types_example insert '(1, record { age = 32; name = "Some Name"})'
+dfx canister call custom_types_example insert '(2, record { age = 48; name = "Other Name"})'
+
+# Upgrade the canister, which clears all the data in the heap.
+dfx deploy --upgrade-unchanged custom_types_example
+
+# Even though the canister has been upgraded and its heap is cleared,
+# querying the canister should still return the data stored prior to
+# the upgrade.
+DATA=$(dfx canister call custom_types_example get '(1)')
+if ! [[ $DATA = "(opt record { age = 32 : nat8; name = \"Some Name\" })" ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
+DATA=$(dfx canister call custom_types_example get '(2)')
+if ! [[ $DATA = "(opt record { age = 48 : nat8; name = \"Other Name\" })" ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
 # Insert some data into the quick_start canister.
 dfx canister call quick_start stable_insert '(1:nat, 2:nat)'
 dfx canister call quick_start stable_insert '(3:nat, 4:nat)'

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -14,68 +14,31 @@ dfx start --background
 # Deploys the examples.
 dfx deploy
 
-# Insert some data into the basic_example canister.
-dfx canister call basic_example insert '(1:nat, 2:nat)'
-dfx canister call basic_example insert '(3:nat, 4:nat)'
+# Insert some data into the quick_start canister.
+dfx canister call quick_start stable_insert '(1:nat, 2:nat)'
+dfx canister call quick_start stable_insert '(3:nat, 4:nat)'
+dfx canister call quick_start set_heap_data '(vec {1:nat8; 2:nat8; 3:nat8})'
 
 # Upgrade the canister, which clears all the data in the heap.
-dfx deploy --upgrade-unchanged basic_example
+dfx deploy --upgrade-unchanged quick_start
 
 # Even though the canister has been upgraded and its heap is cleared,
 # querying the canister should still return the data stored prior to
 # the upgrade.
-DATA=$(dfx canister call basic_example get '(1:nat)')
+DATA=$(dfx canister call quick_start stable_get '(1:nat)')
 if ! [[ $DATA = "(opt (2 : nat))" ]]; then
   echo "FAIL"
   exit 1
 fi
 
-DATA=$(dfx canister call basic_example get '(3:nat)')
+DATA=$(dfx canister call quick_start stable_get '(3:nat)')
 if ! [[ $DATA = "(opt (4 : nat))" ]]; then
   echo "FAIL"
   exit 1
 fi
 
-# Insert some data into the vecs_and_strings canister.
-dfx canister call vecs_and_strings insert '("alice", blob "12341234")'
-dfx canister call vecs_and_strings insert '("bob", blob "789789789")'
-
-# Upgrade the canister, which clears all the data in the heap.
-dfx deploy --upgrade-unchanged vecs_and_strings
-
-# Even though the canister has been upgraded and its heap is cleared,
-# querying the canister should still return the data stored prior to
-# the upgrade.
-DATA=$(dfx canister call vecs_and_strings get '("alice")')
-if ! [[ $DATA = '(opt blob "12341234")' ]]; then
-  echo "FAIL"
-  exit 1
-fi
-
-DATA=$(dfx canister call vecs_and_strings get '("bob")')
-if ! [[ $DATA = '(opt blob "789789789")' ]]; then
-  echo "FAIL"
-  exit 1
-fi
-
-# Insert some data into the custom_types_example canister.
-dfx canister call custom_types_example insert '(1, record { age = 32; name = "Some Name"})'
-dfx canister call custom_types_example insert '(2, record { age = 48; name = "Other Name"})'
-
-# Upgrade the canister, which clears all the data in the heap.
-dfx deploy --upgrade-unchanged custom_types_example
-
-# Even though the canister has been upgraded and its heap is cleared,
-# querying the canister should still return the data stored prior to
-# the upgrade.
-DATA=$(dfx canister call custom_types_example get '(1)')
-if ! [[ $DATA = "(opt record { age = 32 : nat8; name = \"Some Name\" })" ]]; then
-  echo "FAIL"
-  exit 1
-fi
-
-DATA=$(dfx canister call custom_types_example get '(2)')
-if ! [[ $DATA = "(opt record { age = 48 : nat8; name = \"Other Name\" })" ]]; then
+DATA=$(dfx canister call quick_start get_heap_data)
+if ! [[ $DATA = '(blob "\01\02\03")' ]]; then
   echo "FAIL"
   exit 1
 fi


### PR DESCRIPTION
Adds an example that developers can use as a starting point for their projects, showcasing
the very common use-case of wanting to store part of the state in stable structures and other parts on the heap.