### PR TITLE
refactor(btreemap): change the type argument order

### DIFF
--- a/examples/src/basic_example/src/lib.rs
+++ b/examples/src/basic_example/src/lib.rs
@@ -11,7 +11,7 @@ thread_local! {
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
 
     // Initialize a `StableBTreeMap` with `MemoryId(0)`.
-    static MAP: RefCell<StableBTreeMap<Memory, u128, u128>> = RefCell::new(
+    static MAP: RefCell<StableBTreeMap<u128, u128, Memory>> = RefCell::new(
         StableBTreeMap::init(
             MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))),
         )

--- a/examples/src/custom_types_example/src/lib.rs
+++ b/examples/src/custom_types_example/src/lib.rs
@@ -44,7 +44,7 @@ thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
 
-    static MAP: RefCell<StableBTreeMap<Memory, u64, UserProfile>> = RefCell::new(
+    static MAP: RefCell<StableBTreeMap<u64, UserProfile, Memory>> = RefCell::new(
         StableBTreeMap::init(
             MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))),
         )

--- a/examples/src/quick_start/src/lib.rs
+++ b/examples/src/quick_start/src/lib.rs
@@ -22,7 +22,7 @@ struct State {
     // An example `StableBTreeMap`. Data stored in `StableBTreeMap` doesn't need to
     // be serialized/deserialized in upgrades, so we tell serde to skip it.
     #[serde(skip, default = "init_stable_data")]
-    stable_data: StableBTreeMap<Memory, u128, u128>,
+    stable_data: StableBTreeMap<u128, u128, Memory>,
 }
 
 thread_local! {
@@ -95,7 +95,7 @@ fn post_upgrade() {
     });
 }
 
-fn init_stable_data() -> StableBTreeMap<Memory, u128, u128> {
+fn init_stable_data() -> StableBTreeMap<u128, u128, Memory> {
     StableBTreeMap::init(crate::memory::get_stable_btree_memory())
 }
 

--- a/examples/src/vecs_and_strings/src/lib.rs
+++ b/examples/src/vecs_and_strings/src/lib.rs
@@ -56,7 +56,7 @@ thread_local! {
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
 
     // Initialize a `StableBTreeMap` with `MemoryId(0)`.
-    static MAP: RefCell<StableBTreeMap<Memory, UserName, UserData>> = RefCell::new(
+    static MAP: RefCell<StableBTreeMap<UserName, UserData, Memory>> = RefCell::new(
         StableBTreeMap::init(
             MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))),
         )

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2222,11 +2222,4 @@ mod test {
         // Equal key size
         let _btree: BTreeMap<Vec<u8>, Vec<u8>, _> = BTreeMap::init_with_sizes(mem, 4, 3);
     }
-
-    #[test]
-    fn supports_unbounded_storable_types() {
-        let mem = make_memory();
-        // `String` doesn't implement `BoundedStorable` but can still be used in the `BTreeMap`.
-        let _btree: BTreeMap<String, String, _> = BTreeMap::init_with_sizes(mem.clone(), 4, 3);
-    }
 }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2222,4 +2222,11 @@ mod test {
         // Equal key size
         let _btree: BTreeMap<Vec<u8>, Vec<u8>, _> = BTreeMap::init_with_sizes(mem, 4, 3);
     }
+
+    #[test]
+    fn supports_unbounded_storable_types() {
+        let mem = make_memory();
+        // `String` doesn't implement `BoundedStorable` but can still be used in the `BTreeMap`.
+        let _btree: BTreeMap<String, String, _> = BTreeMap::init_with_sizes(mem.clone(), 4, 3);
+    }
 }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -397,8 +397,8 @@ impl<K: BoundedStorable, V: BoundedStorable, M: Memory> BTreeMap<K, V, M> {
     }
 
     /// Returns the underlying memory.
-    pub fn forget(self) -> M {
-        self.allocator.forget()
+    pub fn into_memory(self) -> M {
+        self.allocator.into_memory()
     }
 
     fn memory(&self) -> &M {

--- a/src/btreemap/allocator.rs
+++ b/src/btreemap/allocator.rs
@@ -228,6 +228,18 @@ impl<M: Memory> Allocator<M> {
     fn chunk_size(&self) -> Bytes {
         self.allocation_size + ChunkHeader::size()
     }
+
+    /// Destroys the allocator and returns the underlying memory.
+    #[inline]
+    pub fn forget(self) -> M {
+        self.memory
+    }
+
+    /// Returns a reference to the underlying memory.
+    #[inline]
+    pub fn memory(&self) -> &M {
+        &self.memory
+    }
 }
 
 #[derive(Debug)]

--- a/src/btreemap/allocator.rs
+++ b/src/btreemap/allocator.rs
@@ -231,7 +231,7 @@ impl<M: Memory> Allocator<M> {
 
     /// Destroys the allocator and returns the underlying memory.
     #[inline]
-    pub fn forget(self) -> M {
+    pub fn into_memory(self) -> M {
         self.memory
     }
 

--- a/src/btreemap/iter.rs
+++ b/src/btreemap/iter.rs
@@ -2,7 +2,7 @@ use super::{
     node::{Node, NodeType},
     BTreeMap,
 };
-use crate::{types::NULL, Address, Memory, Storable};
+use crate::{types::NULL, Address, BoundedStorable, Memory};
 
 /// An indicator of the current position in the map.
 pub(crate) enum Cursor {
@@ -18,9 +18,9 @@ pub(crate) enum Index {
 
 /// An iterator over the entries of a [`BTreeMap`].
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct Iter<'a, M: Memory, K: Storable, V: Storable> {
+pub struct Iter<'a, K: BoundedStorable, V: BoundedStorable, M: Memory> {
     // A reference to the map being iterated on.
-    map: &'a BTreeMap<M, K, V>,
+    map: &'a BTreeMap<K, V, M>,
 
     // A stack of cursors indicating the current position in the tree.
     cursors: Vec<Cursor>,
@@ -34,8 +34,8 @@ pub struct Iter<'a, M: Memory, K: Storable, V: Storable> {
     offset: Option<Vec<u8>>,
 }
 
-impl<'a, M: Memory, K: Storable, V: Storable> Iter<'a, M, K, V> {
-    pub(crate) fn new(map: &'a BTreeMap<M, K, V>) -> Self {
+impl<'a, K: BoundedStorable, V: BoundedStorable, M: Memory> Iter<'a, K, V, M> {
+    pub(crate) fn new(map: &'a BTreeMap<K, V, M>) -> Self {
         Self {
             map,
             // Initialize the cursors with the address of the root of the map.
@@ -46,7 +46,7 @@ impl<'a, M: Memory, K: Storable, V: Storable> Iter<'a, M, K, V> {
     }
 
     /// Returns an empty iterator.
-    pub(crate) fn null(map: &'a BTreeMap<M, K, V>) -> Self {
+    pub(crate) fn null(map: &'a BTreeMap<K, V, M>) -> Self {
         Self {
             map,
             cursors: vec![],
@@ -56,7 +56,7 @@ impl<'a, M: Memory, K: Storable, V: Storable> Iter<'a, M, K, V> {
     }
 
     pub(crate) fn new_with_prefix(
-        map: &'a BTreeMap<M, K, V>,
+        map: &'a BTreeMap<K, V, M>,
         prefix: Vec<u8>,
         cursors: Vec<Cursor>,
     ) -> Self {
@@ -69,7 +69,7 @@ impl<'a, M: Memory, K: Storable, V: Storable> Iter<'a, M, K, V> {
     }
 
     pub(crate) fn new_with_prefix_and_offset(
-        map: &'a BTreeMap<M, K, V>,
+        map: &'a BTreeMap<K, V, M>,
         prefix: Vec<u8>,
         offset: Vec<u8>,
         cursors: Vec<Cursor>,
@@ -83,7 +83,7 @@ impl<'a, M: Memory, K: Storable, V: Storable> Iter<'a, M, K, V> {
     }
 }
 
-impl<M: Memory + Clone, K: Storable, V: Storable> Iterator for Iter<'_, M, K, V> {
+impl<K: BoundedStorable, V: BoundedStorable, M: Memory> Iterator for Iter<'_, K, V, M> {
     type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -140,8 +140,8 @@ impl<T: Storable, M: Memory> Cell<T, M> {
         &self.value
     }
 
-    /// Forgets the value in this cell and returns the underlying memory.
-    pub fn forget(self) -> M {
+    /// Returns the underlying memory.
+    pub fn into_memory(self) -> M {
         self.memory
     }
 

--- a/src/cell/tests.rs
+++ b/src/cell/tests.rs
@@ -4,7 +4,7 @@ use crate::vec_mem::VectorMemory;
 use crate::{Memory, RestrictedMemory, WASM_PAGE_SIZE};
 
 fn reload<T: Default + Storable, M: Memory>(c: Cell<T, M>) -> Cell<T, M> {
-    Cell::init(c.forget(), T::default()).unwrap()
+    Cell::init(c.into_memory(), T::default()).unwrap()
 }
 
 #[test]
@@ -12,13 +12,13 @@ fn test_cell_init() {
     let mem = VectorMemory::default();
     let cell = Cell::init(mem, 1024u64).unwrap();
     assert_eq!(*cell.get(), 1024u64);
-    let mem = cell.forget();
+    let mem = cell.into_memory();
     assert_ne!(mem.size(), 0);
     let cell = Cell::init(mem, 0u64).unwrap();
     assert_eq!(1024u64, *cell.get());
 
     // Check that Cell::new overwrites the contents unconditionally.
-    let cell = Cell::new(cell.forget(), 2048u64).unwrap();
+    let cell = Cell::new(cell.into_memory(), 2048u64).unwrap();
     assert_eq!(2048u64, *cell.get());
 }
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -242,7 +242,7 @@ impl<INDEX: Memory, DATA: Memory> Log<INDEX, DATA> {
     }
 
     /// Returns the underlying memory trait objects of the log.
-    pub fn forget(self) -> (INDEX, DATA) {
+    pub fn into_memories(self) -> (INDEX, DATA) {
         (self.index_memory, self.data_memory)
     }
 

--- a/src/log/tests.rs
+++ b/src/log/tests.rs
@@ -9,7 +9,7 @@ fn test_log_construct() {
     assert_eq!(log.len(), 0);
     assert_eq!(log.log_size_bytes(), 0);
     assert_eq!(log.index_size_bytes(), 40);
-    let (index_memory, data_memory) = log.forget();
+    let (index_memory, data_memory) = log.into_memories();
 
     let log = Log::init(index_memory, data_memory).expect("failed to init log");
     assert_eq!(log.len(), 0);
@@ -24,7 +24,7 @@ fn test_new_overwrites() {
 
     assert_eq!(log.len(), 1);
 
-    let (index_memory, data_memory) = log.forget();
+    let (index_memory, data_memory) = log.into_memories();
     let log = Log::new(index_memory, data_memory);
     assert_eq!(log.len(), 0);
 }
@@ -117,7 +117,7 @@ fn test_log_append_persistence() {
     let log = Log::new(VectorMemory::default(), VectorMemory::default());
     let idx = log.append(b"DEADBEEF").expect("failed to append entry");
 
-    let (index_memory, data_memory) = log.forget();
+    let (index_memory, data_memory) = log.into_memories();
 
     let log = Log::init(index_memory, data_memory).unwrap();
     assert_eq!(log.len(), 1);
@@ -175,6 +175,6 @@ fn test_index_grow() {
         log.append(b"log").expect("failed to append entry");
     }
     assert_eq!(log.index_size_bytes(), 65_544); // more than WASM_PAGE_SIZE
-    let (index_memory, _) = log.forget();
+    let (index_memory, _) = log.into_memories();
     assert_eq!(index_memory.size(), 2)
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -152,7 +152,7 @@ impl<T: BoundedStorable, M: Memory> Vec<T, M> {
     }
 
     /// Returns the underlying memory instance.
-    pub fn forget(self) -> M {
+    pub fn into_memory(self) -> M {
         self.memory
     }
 

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -72,7 +72,7 @@ proptest! {
             sv.push(&v).unwrap();
         }
         let vec = sv.to_vec();
-        prop_assert_eq!(StableVec::<u64, M>::init(sv.forget()).unwrap().to_vec(), vec);
+        prop_assert_eq!(StableVec::<u64, M>::init(sv.into_memory()).unwrap().to_vec(), vec);
     }
 }
 
@@ -103,13 +103,13 @@ fn test_init_type_compatibility() {
     let v = StableVec::<u64, M>::new(M::default()).unwrap();
 
     assert_eq!(
-        StableVec::<u32, M>::init(v.forget()).unwrap_err(),
+        StableVec::<u32, M>::init(v.into_memory()).unwrap_err(),
         InitError::IncompatibleElementType
     );
 
     let v = StableVec::<u64, M>::new(M::default()).unwrap();
     assert_eq!(
-        StableVec::<UnfixedU64<8>, M>::init(v.forget()).unwrap_err(),
+        StableVec::<UnfixedU64<8>, M>::init(v.into_memory()).unwrap_err(),
         InitError::IncompatibleElementType
     );
 }


### PR DESCRIPTION
This change changes the order of the type arguments in BTreeMap to be more consistent with other data structures and with the standard library (Allocators are the last type arguments in Rust).