### PR TITLE
fix: do not make `BoundedStorable` fixed size by default

### DIFF
--- a/src/storable.rs
+++ b/src/storable.rs
@@ -27,7 +27,7 @@ pub trait BoundedStorable: Storable {
     ///
     /// Examples: little-/big-endian encoding of u16/u32/u64, tuples
     /// and arrays of fixed-size types.
-    const IS_FIXED_SIZE: bool = true;
+    const IS_FIXED_SIZE: bool;
 }
 
 // NOTE: Below are a few implementations of `Storable` for common types.


### PR DESCRIPTION
It's clearer to make developers explicitly specify whether or not a type is fixed or variable in size.

With new optimizations that we'll be doing to `BTreeMap`, variable sized elements can end up having a smaller memory footprint. If we assume by default that a type is fixed in size, developers won't benefit from this optimization.