### PR TITLE
feat: add more (bounded) storable types

### DIFF
--- a/src/storable.rs
+++ b/src/storable.rs
@@ -1,11 +1,16 @@
-use std::convert::TryInto;
+use std::borrow::{Borrow, Cow};
+use std::convert::{TryFrom, TryInto};
+use std::fmt;
+
+#[cfg(test)]
+mod tests;
 
 /// A trait with convenience methods for storing an element into a stable structure.
 pub trait Storable {
     /// Converts an element into bytes.
     ///
     /// NOTE: `Cow` is used here to avoid unnecessary cloning.
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]>;
+    fn to_bytes(&self) -> Cow<[u8]>;
 
     /// Converts bytes into an element.
     ///
@@ -30,6 +35,83 @@ pub trait BoundedStorable: Storable {
     const IS_FIXED_SIZE: bool = true;
 }
 
+/// Variable-size, but limited in capacity byte array.
+#[derive(Eq, Copy, Clone)]
+pub struct Bytes<const N: usize> {
+    storage: [u8; N],
+    size: u32,
+}
+
+impl<const N: usize> Bytes<N> {
+    /// Returns the contents of this array as a byte slice.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.storage[0..self.len()]
+    }
+
+    /// Returns true if the array is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the actual length of this array.
+    pub fn len(&self) -> usize {
+        self.size as usize
+    }
+}
+
+impl<const N: usize> Default for Bytes<N> {
+    fn default() -> Self {
+        Self {
+            storage: [0; N],
+            size: 0,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TryFromSliceError;
+
+impl<const N: usize> TryFrom<&[u8]> for Bytes<N> {
+    type Error = TryFromSliceError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() > N {
+            return Err(TryFromSliceError);
+        }
+        let mut result = Self::default();
+        result.storage[0..value.len()].copy_from_slice(value);
+        result.size = value.len() as u32;
+        Ok(result)
+    }
+}
+
+impl<const N: usize> PartialEq for Bytes<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice().eq(other.as_slice())
+    }
+}
+
+impl<const N: usize> fmt::Debug for Bytes<N> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_slice().fmt(fmt)
+    }
+}
+
+impl<const N: usize> BoundedStorable for Bytes<N> {
+    const MAX_SIZE: u32 = N as u32;
+    const IS_FIXED_SIZE: bool = false;
+}
+
+impl<const N: usize> Storable for Bytes<N> {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(self.as_slice())
+    }
+
+    fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self::try_from(&bytes[..]).unwrap()
+    }
+}
+
 // NOTE: Below are a few implementations of `Storable` for common types.
 // Some of these implementations use `unwrap`, as opposed to returning a `Result`
 // with a possible error. The reason behind this decision is that these
@@ -43,8 +125,8 @@ pub trait BoundedStorable: Storable {
 // in case of a detected error is preferable and safer.
 
 impl Storable for () {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Borrowed(&[])
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(&[])
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
@@ -58,8 +140,8 @@ impl BoundedStorable for () {
 }
 
 impl Storable for Vec<u8> {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Borrowed(self)
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(self)
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
@@ -68,8 +150,8 @@ impl Storable for Vec<u8> {
 }
 
 impl Storable for String {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Borrowed(self.as_bytes())
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(self.as_bytes())
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
@@ -78,8 +160,8 @@ impl Storable for String {
 }
 
 impl Storable for u128 {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.to_be_bytes().to_vec())
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
@@ -93,8 +175,8 @@ impl BoundedStorable for u128 {
 }
 
 impl Storable for u64 {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.to_be_bytes().to_vec())
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
@@ -108,8 +190,8 @@ impl BoundedStorable for u64 {
 }
 
 impl Storable for u32 {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.to_be_bytes().to_vec())
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
@@ -123,8 +205,8 @@ impl BoundedStorable for u32 {
 }
 
 impl Storable for u16 {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.to_be_bytes().to_vec())
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
@@ -138,8 +220,8 @@ impl BoundedStorable for u16 {
 }
 
 impl Storable for u8 {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Owned(self.to_be_bytes().to_vec())
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.to_be_bytes().to_vec())
     }
 
     fn from_bytes(bytes: Vec<u8>) -> Self {
@@ -150,4 +232,133 @@ impl Storable for u8 {
 impl BoundedStorable for u8 {
     const MAX_SIZE: u32 = 1;
     const IS_FIXED_SIZE: bool = true;
+}
+
+impl<const N: usize> Storable for [u8; N] {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(&self[..])
+    }
+
+    fn from_bytes(bytes: Vec<u8>) -> Self {
+        assert_eq!(bytes.len(), N);
+        let mut arr = [0; N];
+        arr[0..N].copy_from_slice(&bytes);
+        arr
+    }
+}
+
+impl<const N: usize> BoundedStorable for [u8; N] {
+    const MAX_SIZE: u32 = N as u32;
+    const IS_FIXED_SIZE: bool = true;
+}
+
+impl<A, B> Storable for (A, B)
+where
+    A: BoundedStorable + Default,
+    B: BoundedStorable + Default,
+{
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![0; Self::MAX_SIZE as usize];
+        let a_bytes = self.0.to_bytes();
+        let b_bytes = self.1.to_bytes();
+
+        let a_max_size = max_size(&self.0);
+        let b_max_size = max_size(&self.1);
+
+        debug_assert!(a_bytes.len() <= a_max_size);
+        debug_assert!(b_bytes.len() <= b_max_size);
+
+        bytes[0..a_bytes.len()].copy_from_slice(a_bytes.borrow());
+        bytes[a_max_size..a_max_size + b_bytes.len()].copy_from_slice(b_bytes.borrow());
+
+        let a_size_len = bytes_to_store_size::<A>() as usize;
+        let b_size_len = bytes_to_store_size::<B>() as usize;
+
+        let sizes_offset: usize = a_max_size + b_max_size;
+
+        encode_size::<A>(
+            &mut bytes[sizes_offset..sizes_offset + a_size_len],
+            a_bytes.len(),
+        );
+        encode_size::<B>(
+            &mut bytes[sizes_offset + a_size_len..sizes_offset + a_size_len + b_size_len],
+            b_bytes.len(),
+        );
+
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Vec<u8>) -> Self {
+        assert_eq!(bytes.len(), Self::MAX_SIZE as usize);
+
+        // Rust doesn't allow us to access A::MAX_SIZE here but type
+        // deduction from values seems to do the trick. Hence the
+        // Default bound on the Storable impl.
+        let (a, b) = Self::default();
+        let a_max_size = max_size(&a);
+        let b_max_size = max_size(&b);
+        let sizes_offset = a_max_size + b_max_size;
+
+        let a_size_len = bytes_to_store_size::<A>() as usize;
+        let b_size_len = bytes_to_store_size::<B>() as usize;
+        let a_len = decode_size::<A>(&bytes[sizes_offset..sizes_offset + a_size_len]);
+        let b_len = decode_size::<B>(
+            &bytes[sizes_offset + a_size_len..sizes_offset + a_size_len + b_size_len],
+        );
+
+        let a = A::from_bytes(bytes[0..a_len].to_vec());
+        let b = B::from_bytes(bytes[a_max_size..a_max_size + b_len].to_vec());
+
+        (a, b)
+    }
+}
+
+impl<A, B> BoundedStorable for (A, B)
+where
+    A: BoundedStorable + Default,
+    B: BoundedStorable + Default,
+{
+    const MAX_SIZE: u32 =
+        A::MAX_SIZE + B::MAX_SIZE + bytes_to_store_size::<A>() + bytes_to_store_size::<B>();
+    const IS_FIXED_SIZE: bool = A::IS_FIXED_SIZE && B::IS_FIXED_SIZE;
+}
+
+const fn max_size<A: BoundedStorable>(_: &A) -> usize {
+    A::MAX_SIZE as usize
+}
+
+fn decode_size<A: BoundedStorable>(src: &[u8]) -> usize {
+    if A::IS_FIXED_SIZE {
+        A::MAX_SIZE as usize
+    } else if A::MAX_SIZE <= u8::MAX as u32 {
+        src[0] as usize
+    } else if A::MAX_SIZE <= u16::MAX as u32 {
+        u16::from_be_bytes([src[0], src[1]]) as usize
+    } else {
+        u32::from_be_bytes([src[0], src[1], src[2], src[3]]) as usize
+    }
+}
+
+fn encode_size<A: BoundedStorable>(dst: &mut [u8], n: usize) {
+    if A::IS_FIXED_SIZE {
+        ()
+    } else if A::MAX_SIZE <= u8::MAX as u32 {
+        dst[0] = n as u8;
+    } else if A::MAX_SIZE <= u16::MAX as u32 {
+        dst[0..1].copy_from_slice(&(n as u16).to_be_bytes());
+    } else {
+        dst[0..4].copy_from_slice(&(n as u32).to_be_bytes());
+    }
+}
+
+const fn bytes_to_store_size<A: BoundedStorable>() -> u32 {
+    if A::IS_FIXED_SIZE {
+        0
+    } else if A::MAX_SIZE <= u8::MAX as u32 {
+        1
+    } else if A::MAX_SIZE <= u16::MAX as u32 {
+        2
+    } else {
+        4
+    }
 }

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -37,12 +37,12 @@ pub trait BoundedStorable: Storable {
 
 /// Variable-size, but limited in capacity byte array.
 #[derive(Eq, Copy, Clone)]
-pub struct Bytes<const N: usize> {
+pub struct Blob<const N: usize> {
     storage: [u8; N],
     size: u32,
 }
 
-impl<const N: usize> Bytes<N> {
+impl<const N: usize> Blob<N> {
     /// Returns the contents of this array as a byte slice.
     pub fn as_slice(&self) -> &[u8] {
         &self.storage[0..self.len()]
@@ -59,7 +59,7 @@ impl<const N: usize> Bytes<N> {
     }
 }
 
-impl<const N: usize> Default for Bytes<N> {
+impl<const N: usize> Default for Blob<N> {
     fn default() -> Self {
         Self {
             storage: [0; N],
@@ -71,7 +71,7 @@ impl<const N: usize> Default for Bytes<N> {
 #[derive(Debug)]
 pub struct TryFromSliceError;
 
-impl<const N: usize> TryFrom<&[u8]> for Bytes<N> {
+impl<const N: usize> TryFrom<&[u8]> for Blob<N> {
     type Error = TryFromSliceError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
@@ -85,24 +85,24 @@ impl<const N: usize> TryFrom<&[u8]> for Bytes<N> {
     }
 }
 
-impl<const N: usize> PartialEq for Bytes<N> {
+impl<const N: usize> PartialEq for Blob<N> {
     fn eq(&self, other: &Self) -> bool {
         self.as_slice().eq(other.as_slice())
     }
 }
 
-impl<const N: usize> fmt::Debug for Bytes<N> {
+impl<const N: usize> fmt::Debug for Blob<N> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_slice().fmt(fmt)
     }
 }
 
-impl<const N: usize> BoundedStorable for Bytes<N> {
+impl<const N: usize> BoundedStorable for Blob<N> {
     const MAX_SIZE: u32 = N as u32;
     const IS_FIXED_SIZE: bool = false;
 }
 
-impl<const N: usize> Storable for Bytes<N> {
+impl<const N: usize> Storable for Blob<N> {
     fn to_bytes(&self) -> Cow<[u8]> {
         Cow::Borrowed(self.as_slice())
     }

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -341,8 +341,10 @@ fn decode_size<A: BoundedStorable>(src: &[u8]) -> usize {
 
 fn encode_size<A: BoundedStorable>(dst: &mut [u8], n: usize) {
     if A::IS_FIXED_SIZE {
-        ()
-    } else if A::MAX_SIZE <= u8::MAX as u32 {
+        return;
+    }
+
+    if A::MAX_SIZE <= u8::MAX as u32 {
         dst[0] = n as u8;
     } else if A::MAX_SIZE <= u16::MAX as u32 {
         dst[0..1].copy_from_slice(&(n as u16).to_be_bytes());

--- a/src/storable/tests.rs
+++ b/src/storable/tests.rs
@@ -1,0 +1,22 @@
+use super::*;
+use proptest::array::uniform20;
+use proptest::collection::vec as pvec;
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn tuple_roundtrip(x in any::<u64>(), y in uniform20(any::<u8>())) {
+        let tuple = (x, y);
+        let bytes = tuple.to_bytes().to_vec();
+        prop_assert_eq!(bytes.len(), 28);
+        prop_assert_eq!(tuple, Storable::from_bytes(bytes));
+    }
+
+    #[test]
+    fn tuple_variable_width_rountrip(x in any::<u64>(), v in pvec(any::<u8>(), 0..40)) {
+        let bytes = Bytes::<48>::try_from(&v[..]).unwrap();
+        let tuple = (x, bytes);
+        prop_assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes().to_vec()));
+    }
+
+}

--- a/src/storable/tests.rs
+++ b/src/storable/tests.rs
@@ -14,7 +14,7 @@ proptest! {
 
     #[test]
     fn tuple_variable_width_rountrip(x in any::<u64>(), v in pvec(any::<u8>(), 0..40)) {
-        let bytes = Bytes::<48>::try_from(&v[..]).unwrap();
+        let bytes = Blob::<48>::try_from(&v[..]).unwrap();
         let tuple = (x, bytes);
         prop_assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes().to_vec()));
     }

--- a/src/storable/tests.rs
+++ b/src/storable/tests.rs
@@ -13,7 +13,7 @@ proptest! {
     }
 
     #[test]
-    fn tuple_variable_width_rountrip(x in any::<u64>(), v in pvec(any::<u8>(), 0..40)) {
+    fn tuple_variable_width_roundtrip(x in any::<u64>(), v in pvec(any::<u8>(), 0..40)) {
         let bytes = Blob::<48>::try_from(&v[..]).unwrap();
         let tuple = (x, bytes);
         prop_assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes().to_vec()));


### PR DESCRIPTION
This change introduces more storable types:

  1. Byte arrays `[u8; N]`.
  2. Variable-sized byte arrays of limited capacity `Blob<CAP>`.
  3. Tuples (A, B) where both components are storable.