### PR TITLE
feat(log): make the stable log typed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,12 @@ extern crate core;
 
 pub mod btreemap;
 pub mod cell;
+pub use cell::{Cell as StableCell, Cell};
 pub mod file_mem;
 #[cfg(target_arch = "wasm32")]
 mod ic0_memory; // Memory API for canisters.
 pub mod log;
+pub use log::{Log as StableLog, Log};
 pub mod memory_manager;
 pub mod reader;
 pub mod storable;

--- a/src/log.rs
+++ b/src/log.rs
@@ -54,7 +54,8 @@
 //! ----------------------------------------
 //! Unallocated space
 //! ```
-use crate::{read_u64, safe_write, write_u64, Address, GrowFailed, Memory};
+use crate::{read_u64, safe_write, write_u64, Address, GrowFailed, Memory, Storable};
+use std::marker::PhantomData;
 
 #[cfg(test)]
 mod tests;
@@ -96,7 +97,6 @@ pub enum InitError {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum WriteError {
-    IndexFull { max_entries: u32 },
     GrowFailed { current_size: u64, delta: u64 },
 }
 
@@ -118,17 +118,19 @@ impl From<GrowFailed> for WriteError {
 pub struct NoSuchEntry;
 
 /// Append-only list of variable-size entries stored in stable memory.
-pub struct Log<INDEX: Memory, DATA: Memory> {
+pub struct Log<T: Storable, INDEX: Memory, DATA: Memory> {
     index_memory: INDEX,
     data_memory: DATA,
+    _marker: PhantomData<T>,
 }
 
-impl<INDEX: Memory, DATA: Memory> Log<INDEX, DATA> {
+impl<T: Storable, INDEX: Memory, DATA: Memory> Log<T, INDEX, DATA> {
     /// Creates a new empty growable stable log backed by the memory trait objects, overwriting the previous contents.
     pub fn new(index_memory: INDEX, data_memory: DATA) -> Self {
         let log = Self {
             index_memory,
             data_memory,
+            _marker: PhantomData,
         };
         Self::write_header(
             &log.index_memory,
@@ -190,6 +192,7 @@ impl<INDEX: Memory, DATA: Memory> Log<INDEX, DATA> {
         Ok(Self {
             index_memory,
             data_memory,
+            _marker: PhantomData,
         })
     }
 
@@ -282,9 +285,10 @@ impl<INDEX: Memory, DATA: Memory> Log<INDEX, DATA> {
 
     /// Returns the entry at the specified index.
     /// Returns None if the entry does not exist.
-    pub fn get(&self, idx: usize) -> Option<Vec<u8>> {
+    pub fn get(&self, idx: usize) -> Option<T> {
         let mut buf = vec![];
-        self.read_entry(idx, &mut buf).ok().map(|_| buf)
+        self.read_entry(idx, &mut buf).ok()?;
+        Some(T::from_bytes(buf))
     }
 
     /// Reads the contents of the entry with the specified index into
@@ -305,7 +309,7 @@ impl<INDEX: Memory, DATA: Memory> Log<INDEX, DATA> {
     /// If successful, returns the index of the entry.
     ///
     /// POST-CONDITION: Ok(idx) = log.append(E) ⇒ log.get(idx) = Some(E)
-    pub fn append(&self, bytes: &[u8]) -> Result<usize, WriteError> {
+    pub fn append(&self, item: &T) -> Result<usize, WriteError> {
         let idx = self.len() as u64;
         let data_offset = if idx == 0 {
             0
@@ -313,6 +317,7 @@ impl<INDEX: Memory, DATA: Memory> Log<INDEX, DATA> {
             read_u64(&self.index_memory, self.index_entry_offset(idx - 1))
         };
 
+        let bytes = item.to_bytes();
         let new_offset = data_offset
             .checked_add(bytes.len() as u64)
             .expect("address overflow");
@@ -324,7 +329,7 @@ impl<INDEX: Memory, DATA: Memory> Log<INDEX, DATA> {
         debug_assert!(new_offset >= data_offset);
 
         // NB. we attempt to write the data first so we won't need to undo changes to the index if the write fails.
-        safe_write(&self.data_memory, entry_offset, bytes)?;
+        safe_write(&self.data_memory, entry_offset, &bytes[..])?;
 
         // NB. append to index first as it might need to grow the index memory.
         safe_write(
@@ -339,7 +344,7 @@ impl<INDEX: Memory, DATA: Memory> Log<INDEX, DATA> {
             idx as u64 + 1,
         );
 
-        debug_assert_eq!(self.get(idx as usize), Some(bytes.to_vec()));
+        debug_assert_eq!(self.get(idx as usize).unwrap().to_bytes(), bytes);
 
         Ok(idx as usize)
     }

--- a/src/log.rs
+++ b/src/log.rs
@@ -55,6 +55,7 @@
 //! Unallocated space
 //! ```
 use crate::{read_u64, safe_write, write_u64, Address, GrowFailed, Memory, Storable};
+use std::borrow::Cow;
 use std::marker::PhantomData;
 
 #[cfg(test)]
@@ -288,7 +289,7 @@ impl<T: Storable, INDEX: Memory, DATA: Memory> Log<T, INDEX, DATA> {
     pub fn get(&self, idx: usize) -> Option<T> {
         let mut buf = vec![];
         self.read_entry(idx, &mut buf).ok()?;
-        Some(T::from_bytes(buf))
+        Some(T::from_bytes(Cow::Owned(buf)))
     }
 
     /// Reads the contents of the entry with the specified index into

--- a/src/log/tests.rs
+++ b/src/log/tests.rs
@@ -4,14 +4,14 @@ use crate::{Memory, RestrictedMemory, WASM_PAGE_SIZE};
 
 #[test]
 fn test_log_construct() {
-    let log = Log::new(VectorMemory::default(), VectorMemory::default());
+    let log = Log::<Vec<u8>, _, _>::new(VectorMemory::default(), VectorMemory::default());
 
     assert_eq!(log.len(), 0);
     assert_eq!(log.log_size_bytes(), 0);
     assert_eq!(log.index_size_bytes(), 40);
     let (index_memory, data_memory) = log.into_memories();
 
-    let log = Log::init(index_memory, data_memory).expect("failed to init log");
+    let log = Log::<Vec<u8>, _, _>::init(index_memory, data_memory).expect("failed to init log");
     assert_eq!(log.len(), 0);
     assert_eq!(log.log_size_bytes(), 0);
     assert_eq!(log.index_size_bytes(), 40);
@@ -19,20 +19,21 @@ fn test_log_construct() {
 
 #[test]
 fn test_new_overwrites() {
-    let log = Log::new(VectorMemory::default(), VectorMemory::default());
-    log.append(b"DEADBEEF").expect("failed to append entry");
+    let log = Log::<Vec<u8>, _, _>::new(VectorMemory::default(), VectorMemory::default());
+    log.append(&b"DEADBEEF".to_vec())
+        .expect("failed to append entry");
 
     assert_eq!(log.len(), 1);
 
     let (index_memory, data_memory) = log.into_memories();
-    let log = Log::new(index_memory, data_memory);
+    let log = Log::<Vec<u8>, _, _>::new(index_memory, data_memory);
     assert_eq!(log.len(), 0);
 }
 
 #[test]
 fn test_log_init_empty() {
-    let log =
-        Log::init(VectorMemory::default(), VectorMemory::default()).expect("failed to init log");
+    let log = Log::<Vec<u8>, _, _>::init(VectorMemory::default(), VectorMemory::default())
+        .expect("failed to init log");
 
     assert_eq!(log.len(), 0);
     assert_eq!(log.log_size_bytes(), 0);
@@ -44,7 +45,7 @@ fn test_log_init_with_different_data_magic() {
     let mem = VectorMemory::default();
     assert_eq!(mem.grow(1), 0);
     mem.write(0, b"WAS");
-    let log = Log::init(VectorMemory::default(), mem).expect("failed to init log");
+    let log = Log::<Vec<u8>, _, _>::init(VectorMemory::default(), mem).expect("failed to init log");
     assert_eq!(log.len(), 0);
 }
 
@@ -57,7 +58,9 @@ fn test_log_init_with_different_index_magic() {
     assert_eq!(data_mem.grow(1), 0);
     data_mem.write(0, b"GLD\x01");
     assert_eq!(
-        Log::init(index_mem, data_mem).map(|_| ()).unwrap_err(),
+        Log::<Vec<u8>, _, _>::init(index_mem, data_mem)
+            .map(|_| ())
+            .unwrap_err(),
         InitError::InvalidIndex
     );
 }
@@ -72,7 +75,7 @@ fn test_log_load_bad_index_version() {
     assert_eq!(data_memory.grow(1), 0);
     data_memory.write(0, b"GLD\x01");
     assert_eq!(
-        Log::init(index_memory, data_memory)
+        Log::<Vec<u8>, _, _>::init(index_memory, data_memory)
             .map(|_| ())
             .unwrap_err(),
         InitError::IncompatibleIndexVersion {
@@ -89,7 +92,7 @@ fn test_log_load_bad_data_version() {
     mem.write(0, b"GLD\x02");
 
     assert_eq!(
-        Log::init(VectorMemory::default(), mem)
+        Log::<Vec<u8>, _, _>::init(VectorMemory::default(), mem)
             .map(|_| ())
             .unwrap_err(),
         InitError::IncompatibleDataVersion {
@@ -101,9 +104,13 @@ fn test_log_load_bad_data_version() {
 
 #[test]
 fn test_log_append() {
-    let log = Log::new(VectorMemory::default(), VectorMemory::default());
-    let idx1 = log.append(b"DEADBEEF").expect("failed to append entry");
-    let idx2 = log.append(b"FEEDBAD").expect("failed to append entry");
+    let log = Log::<Vec<u8>, _, _>::new(VectorMemory::default(), VectorMemory::default());
+    let idx1 = log
+        .append(&b"DEADBEEF".to_vec())
+        .expect("failed to append entry");
+    let idx2 = log
+        .append(&b"FEEDBAD".to_vec())
+        .expect("failed to append entry");
 
     assert_eq!(idx1, 0);
     assert_eq!(idx2, 1);
@@ -114,12 +121,14 @@ fn test_log_append() {
 
 #[test]
 fn test_log_append_persistence() {
-    let log = Log::new(VectorMemory::default(), VectorMemory::default());
-    let idx = log.append(b"DEADBEEF").expect("failed to append entry");
+    let log = Log::<Vec<u8>, _, _>::new(VectorMemory::default(), VectorMemory::default());
+    let idx = log
+        .append(&b"DEADBEEF".to_vec())
+        .expect("failed to append entry");
 
     let (index_memory, data_memory) = log.into_memories();
 
-    let log = Log::init(index_memory, data_memory).unwrap();
+    let log = Log::<Vec<u8>, _, _>::init(index_memory, data_memory).unwrap();
     assert_eq!(log.len(), 1);
     assert_eq!(log.get(idx).unwrap(), b"DEADBEEF".to_vec());
     assert_eq!(log.log_size_bytes(), b"DEADBEEF".len());
@@ -131,48 +140,53 @@ fn test_log_append_persistence() {
 
 #[test]
 fn test_append_data_out_of_memory() {
-    let log = Log::new(
+    let log = Log::<Vec<u8>, _, _>::new(
         VectorMemory::default(),
         RestrictedMemory::new(VectorMemory::default(), 0..1),
     );
 
-    assert_eq!(Ok(0), log.append(b"small entry that fits into one page"));
-    assert_eq!(Ok(1), log.append(b"another small entry"));
+    assert_eq!(
+        Ok(0),
+        log.append(&b"small entry that fits into one page".to_vec())
+    );
+    assert_eq!(Ok(1), log.append(&b"another small entry".to_vec()));
     assert_eq!(
         Err(WriteError::GrowFailed {
             current_size: 1,
             delta: 1
         }),
-        log.append(&[1; WASM_PAGE_SIZE as usize])
+        log.append(&[1; WASM_PAGE_SIZE as usize].to_vec())
     );
     assert_eq!(2, log.len());
 }
 
 #[test]
 fn test_append_index_out_of_memory() {
-    let log = Log::new(
+    let log = Log::<Vec<u8>, _, _>::new(
         RestrictedMemory::new(VectorMemory::default(), 0..1),
         VectorMemory::default(),
     );
 
     for _ in 0..8_187 {
-        log.append(b"log").expect("failed to append entry");
+        log.append(&b"log".to_vec())
+            .expect("failed to append entry");
     }
     assert_eq!(
         Err(WriteError::GrowFailed {
             current_size: 1,
             delta: 1
         }),
-        log.append(b"log")
+        log.append(&b"log".to_vec())
     );
     assert_eq!(8_187, log.len());
 }
 
 #[test]
 fn test_index_grow() {
-    let log = Log::new(VectorMemory::default(), VectorMemory::default());
+    let log = Log::<Vec<u8>, _, _>::new(VectorMemory::default(), VectorMemory::default());
     for _ in 0..8_188 {
-        log.append(b"log").expect("failed to append entry");
+        log.append(&b"log".to_vec())
+            .expect("failed to append entry");
     }
     assert_eq!(log.index_size_bytes(), 65_544); // more than WASM_PAGE_SIZE
     let (index_memory, _) = log.into_memories();


### PR DESCRIPTION
With this change, the Log type has an explicit Storable type argument instead of working with raw bytes.

This interface is more convenient and consistent with other data structures.