### PR TITLE
refactor(storable): eliminate unnecessary buffer clones

### DIFF
--- a/examples/src/custom_types_example/src/lib.rs
+++ b/examples/src/custom_types_example/src/lib.rs
@@ -28,8 +28,8 @@ impl Storable for UserProfile {
         Cow::Owned(Encode!(self).unwrap())
     }
 
-    fn from_bytes(bytes: Vec<u8>) -> Self {
-        Decode!(&bytes, Self).unwrap()
+    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
+        Decode!(bytes.as_ref(), Self).unwrap()
     }
 }
 

--- a/examples/src/vecs_and_strings/src/lib.rs
+++ b/examples/src/vecs_and_strings/src/lib.rs
@@ -21,7 +21,7 @@ impl Storable for UserName {
         self.0.to_bytes()
     }
 
-    fn from_bytes(bytes: Vec<u8>) -> Self {
+    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
         Self(String::from_bytes(bytes))
     }
 }
@@ -39,7 +39,7 @@ impl Storable for UserData {
         self.0.to_bytes()
     }
 
-    fn from_bytes(bytes: Vec<u8>) -> Self {
+    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
         Self(<Vec<u8>>::from_bytes(bytes))
     }
 }

--- a/src/btreemap/iter.rs
+++ b/src/btreemap/iter.rs
@@ -3,6 +3,7 @@ use super::{
     BTreeMap,
 };
 use crate::{types::NULL, Address, BoundedStorable, Memory};
+use std::borrow::Cow;
 
 /// An indicator of the current position in the map.
 pub(crate) enum Cursor {
@@ -169,7 +170,10 @@ impl<K: BoundedStorable, V: BoundedStorable, M: Memory> Iterator for Iter<'_, K,
                     }
                 }
 
-                Some((K::from_bytes(entry.0), V::from_bytes(entry.1)))
+                Some((
+                    K::from_bytes(Cow::Owned(entry.0)),
+                    V::from_bytes(Cow::Owned(entry.1)),
+                ))
             }
             None => {
                 // The cursors are empty. Iteration is complete.

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,7 +1,7 @@
 //! A serializable value stored in the stable memory.
 use crate::storable::Storable;
 use crate::{Memory, WASM_PAGE_SIZE};
-use std::borrow::Borrow;
+use std::borrow::{Borrow, Cow};
 
 #[cfg(test)]
 mod tests;
@@ -113,7 +113,7 @@ impl<T: Storable, M: Memory> Cell<T, M> {
     fn read_value(memory: &M, len: u32) -> T {
         let mut buf = vec![0; len as usize];
         memory.read(HEADER_V1_SIZE, &mut buf);
-        T::from_bytes(buf)
+        T::from_bytes(Cow::Owned(buf))
     }
 
     /// Reads the header from the specified memory.

--- a/src/storable/tests.rs
+++ b/src/storable/tests.rs
@@ -7,7 +7,7 @@ proptest! {
     #[test]
     fn tuple_roundtrip(x in any::<u64>(), y in uniform20(any::<u8>())) {
         let tuple = (x, y);
-        let bytes = tuple.to_bytes().to_vec();
+        let bytes = tuple.to_bytes();
         prop_assert_eq!(bytes.len(), 28);
         prop_assert_eq!(tuple, Storable::from_bytes(bytes));
     }
@@ -16,7 +16,7 @@ proptest! {
     fn tuple_variable_width_roundtrip(x in any::<u64>(), v in pvec(any::<u8>(), 0..40)) {
         let bytes = Blob::<48>::try_from(&v[..]).unwrap();
         let tuple = (x, bytes);
-        prop_assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes().to_vec()));
+        prop_assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes()));
     }
 
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -37,7 +37,7 @@ use crate::{
     read_u32, read_u64, safe_write, write_u32, write_u64, Address, BoundedStorable, GrowFailed,
     Memory,
 };
-use std::borrow::Borrow;
+use std::borrow::{Borrow, Cow};
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -231,7 +231,7 @@ impl<T: BoundedStorable, M: Memory> Vec<T, M> {
         let (data_offset, data_size) = self.read_entry_size(offset);
         let mut data = vec![0; data_size];
         self.memory.read(data_offset, &mut data[..]);
-        T::from_bytes(data)
+        T::from_bytes(Cow::Owned(data))
     }
 
     /// Sets the vector's length.

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -4,6 +4,7 @@ use crate::vec_mem::VectorMemory as M;
 use crate::{GrowFailed, Memory};
 use proptest::collection::vec as pvec;
 use proptest::prelude::*;
+use std::borrow::Cow;
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -14,7 +15,7 @@ impl<const N: u32> Storable for UnfixedU64<N> {
         self.0.to_bytes()
     }
 
-    fn from_bytes(bytes: Vec<u8>) -> Self {
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
         assert!(bytes.len() == 8);
         Self(u64::from_bytes(bytes))
     }


### PR DESCRIPTION
This change modifies the `Storable::from_bytes` method to accept `Cow<[u8]>` instead of a byte vector. Often, a storable type does not need to own the original byte array (the exceptions are only `Vec<u8>` and `String`).

There are a few places (such as iterators) where we can eliminate unnecessary byte array clones with this optimization.

The new signature is also more symmetrical:
`T::from_bytes(t.to_bytes())` becomes valid code.