### PR TITLE
feat(log, vec): implement random-access iterators

### DIFF
--- a/src/log/tests.rs
+++ b/src/log/tests.rs
@@ -192,3 +192,37 @@ fn test_index_grow() {
     let (index_memory, _) = log.into_memories();
     assert_eq!(index_memory.size(), 2)
 }
+
+#[test]
+fn test_iter() {
+    let log = Log::<String, _, _>::new(VectorMemory::default(), VectorMemory::default());
+    assert_eq!(log.iter().next(), None);
+    log.append(&"apple".to_string()).unwrap();
+    log.append(&"banana".to_string()).unwrap();
+    log.append(&"cider".to_string()).unwrap();
+
+    let mut iter = log.iter();
+    assert_eq!(iter.size_hint(), (3, None));
+    assert_eq!(iter.next(), Some("apple".to_string()));
+    assert_eq!(iter.size_hint(), (2, None));
+    assert_eq!(iter.next(), Some("banana".to_string()));
+    assert_eq!(iter.size_hint(), (1, None));
+    assert_eq!(iter.next(), Some("cider".to_string()));
+    assert_eq!(iter.size_hint(), (0, None));
+    assert_eq!(iter.next(), None);
+
+    assert_eq!(log.iter().nth(0), Some("apple".to_string()));
+    assert_eq!(log.iter().nth(1), Some("banana".to_string()));
+    assert_eq!(log.iter().nth(2), Some("cider".to_string()));
+    assert_eq!(log.iter().nth(3), None);
+    assert_eq!(log.iter().nth(4), None);
+    assert_eq!(log.iter().nth(usize::MAX), None);
+
+    assert_eq!(log.iter().count(), 3);
+    assert_eq!(log.iter().skip(0).count(), 3);
+    assert_eq!(log.iter().skip(1).count(), 2);
+    assert_eq!(log.iter().skip(2).count(), 1);
+    assert_eq!(log.iter().skip(3).count(), 0);
+    assert_eq!(log.iter().skip(4).count(), 0);
+    assert_eq!(log.iter().skip(usize::MAX).count(), 0);
+}

--- a/src/log/tests.rs
+++ b/src/log/tests.rs
@@ -193,6 +193,7 @@ fn test_index_grow() {
     assert_eq!(index_memory.size(), 2)
 }
 
+#[allow(clippy::iter_nth_zero)]
 #[test]
 fn test_iter() {
     let log = Log::<String, _, _>::new(VectorMemory::default(), VectorMemory::default());

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -368,7 +368,7 @@ fn encode_size<A: BoundedStorable>(dst: &mut [u8], n: usize) {
     }
 }
 
-const fn bytes_to_store_size<A: BoundedStorable>() -> u32 {
+pub(crate) const fn bytes_to_store_size<A: BoundedStorable>() -> u32 {
     if A::IS_FIXED_SIZE {
         0
     } else if A::MAX_SIZE <= u8::MAX as u32 {

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -163,6 +163,7 @@ fn test_init_failures() {
     );
 }
 
+#[allow(clippy::iter_nth_zero)]
 #[test]
 fn test_iter() {
     let sv = StableVec::<u64, M>::new(M::default()).unwrap();

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -162,3 +162,37 @@ fn test_init_failures() {
         InitError::IncompatibleVersion(15),
     );
 }
+
+#[test]
+fn test_iter() {
+    let sv = StableVec::<u64, M>::new(M::default()).unwrap();
+    assert_eq!(sv.iter().next(), None);
+    sv.push(&1).unwrap();
+    sv.push(&2).unwrap();
+    sv.push(&3).unwrap();
+
+    let mut iter = sv.iter();
+    assert_eq!(iter.size_hint(), (3, None));
+    assert_eq!(iter.next(), Some(1));
+    assert_eq!(iter.size_hint(), (2, None));
+    assert_eq!(iter.next(), Some(2));
+    assert_eq!(iter.size_hint(), (1, None));
+    assert_eq!(iter.next(), Some(3));
+    assert_eq!(iter.size_hint(), (0, None));
+    assert_eq!(iter.next(), None);
+
+    assert_eq!(sv.iter().nth(0), Some(1));
+    assert_eq!(sv.iter().nth(1), Some(2));
+    assert_eq!(sv.iter().nth(2), Some(3));
+    assert_eq!(sv.iter().nth(3), None);
+    assert_eq!(sv.iter().nth(4), None);
+    assert_eq!(sv.iter().nth(usize::MAX), None);
+
+    assert_eq!(sv.iter().count(), 3);
+    assert_eq!(sv.iter().skip(0).count(), 3);
+    assert_eq!(sv.iter().skip(1).count(), 2);
+    assert_eq!(sv.iter().skip(2).count(), 1);
+    assert_eq!(sv.iter().skip(3).count(), 0);
+    assert_eq!(sv.iter().skip(4).count(), 0);
+    assert_eq!(sv.iter().skip(usize::MAX).count(), 0);
+}


### PR DESCRIPTION
This change adds iterator implementations for StableLog and StableVec. The vectors support random access, so iterating over a slice of items will not required decoding a prefix of a stable structure.