### PR TITLE
chore(btreemap): remove errors from 'insert' API

### DIFF
--- a/examples/src/basic_example/src/lib.rs
+++ b/examples/src/basic_example/src/lib.rs
@@ -27,5 +27,5 @@ fn get(key: u128) -> Option<u128> {
 // Inserts an entry into the map and returns the previous value of the key if it exists.
 #[ic_cdk_macros::update]
 fn insert(key: u128, value: u128) -> Option<u128> {
-    MAP.with(|p| p.borrow_mut().insert(key, value)).unwrap()
+    MAP.with(|p| p.borrow_mut().insert(key, value))
 }

--- a/examples/src/custom_types_example/src/lib.rs
+++ b/examples/src/custom_types_example/src/lib.rs
@@ -59,5 +59,5 @@ fn get(key: u64) -> Option<UserProfile> {
 
 #[ic_cdk_macros::update]
 fn insert(key: u64, value: UserProfile) -> Option<UserProfile> {
-    MAP.with(|p| p.borrow_mut().insert(key, value)).unwrap()
+    MAP.with(|p| p.borrow_mut().insert(key, value))
 }

--- a/examples/src/quick_start/src/lib.rs
+++ b/examples/src/quick_start/src/lib.rs
@@ -41,7 +41,6 @@ fn stable_get(key: u128) -> Option<u128> {
 fn stable_insert(key: u128, value: u128) -> Option<u128> {
     STATE
         .with(|s| s.borrow_mut().stable_data.insert(key, value))
-        .unwrap()
 }
 
 // Sets the data that lives on the heap.

--- a/examples/src/vecs_and_strings/src/lib.rs
+++ b/examples/src/vecs_and_strings/src/lib.rs
@@ -74,6 +74,5 @@ fn get(key: String) -> Option<Vec<u8>> {
 #[ic_cdk_macros::update]
 fn insert(key: String, value: Vec<u8>) -> Option<Vec<u8>> {
     MAP.with(|p| p.borrow_mut().insert(UserName(key), UserData(value)))
-        .unwrap()
         .map(|v| v.0)
 }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -229,8 +229,7 @@ where
             }
         };
 
-        self
-            .insert_nonfull(root, key, value)
+        self.insert_nonfull(root, key, value)
             .map(Cow::Owned)
             .map(V::from_bytes)
     }
@@ -2325,7 +2324,7 @@ mod test {
         struct K;
         impl crate::Storable for K {
             fn to_bytes(&self) -> Cow<[u8]> {
-                Cow::Borrowed(&[1,2,3,4])
+                Cow::Borrowed(&[1, 2, 3, 4])
             }
 
             fn from_bytes(_: Cow<[u8]>) -> Self {
@@ -2351,7 +2350,7 @@ mod test {
         struct V;
         impl crate::Storable for V {
             fn to_bytes(&self) -> Cow<[u8]> {
-                Cow::Borrowed(&[1,2,3,4])
+                Cow::Borrowed(&[1, 2, 3, 4])
             }
 
             fn from_bytes(_: Cow<[u8]>) -> Self {

--- a/src/btreemap/iter.rs
+++ b/src/btreemap/iter.rs
@@ -178,7 +178,7 @@ mod test {
         let mut btree = BTreeMap::new(mem);
 
         for i in 0..CAPACITY as u8 {
-            btree.insert(i, i + 1).unwrap();
+            btree.insert(i, i + 1);
         }
 
         let mut i = 0;
@@ -198,7 +198,7 @@ mod test {
 
         // Insert the elements in reverse order.
         for i in (0..100u64).rev() {
-            btree.insert(i, i + 1).unwrap();
+            btree.insert(i, i + 1);
         }
 
         // Iteration should be in ascending order.


### PR DESCRIPTION
`BTreeMap::insert` returned an `InsertError` if the key/value inserted was too large. Now that keys/values are required to implement `BoundedStorable`, the only scenario where an `InsertError` can be triggered is if the implementation of `Storable` and/or `BoundedStorable` for the key/value has a bug.

This commit changes the API to remove the `InsertError`, replacing it with a precondition that assumes that the implementations of `Storable`/`BoundedStorable` are correct. This has the advantage that the API is now cleaner, and panicking whenever we detect a bug in the implementation is safer for the developer.