### PR TITLE
Enforce the ordering of the fields

### DIFF
--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -48,7 +48,7 @@ where
     _phantom: PhantomData<(K, V)>,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct BTreeHeader {
     magic: [u8; 3],
     version: u8,

--- a/src/btreemap/allocator.rs
+++ b/src/btreemap/allocator.rs
@@ -45,7 +45,7 @@ pub struct Allocator<M: Memory> {
     memory: M,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct AllocatorHeader {
     magic: [u8; 3],
     version: u8,
@@ -243,7 +243,7 @@ impl<M: Memory> Allocator<M> {
 }
 
 #[derive(Debug)]
-#[repr(packed)]
+#[repr(C, packed)]
 struct ChunkHeader {
     magic: [u8; 3],
     version: u8,

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -314,7 +314,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
 }
 
 // A transient data structure for reading/writing metadata into/from stable memory.
-#[repr(packed)]
+#[repr(C, packed)]
 struct NodeHeader {
     magic: [u8; 3],
     version: u8,

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -157,7 +157,7 @@ impl<M: Memory> MemoryManager<M> {
     }
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct Header {
     magic: [u8; 3],
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@ use core::ops::{Add, AddAssign, Mul, Sub, SubAssign};
 
 pub const NULL: Address = Address(0);
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq)]
 pub struct Address(u64);
 
@@ -45,7 +45,7 @@ impl AddAssign<Bytes> for Address {
     }
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct Bytes(u64);
 


### PR DESCRIPTION
Note, packed does not provide any guarantee about field ordering, and dereferencing un unaligned pointers is an undefined behavior.

See: https://doc.rust-lang.org/reference/type-layout.html#the-alignment-modifiers