### PR TITLE
fix(memorymanager): remove unneeded assertion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "maplit",
  "proptest",

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -237,11 +237,7 @@ impl<M: Memory> MemoryManagerInner<M> {
             MemoryManagerInner::new(memory, bucket_size_in_pages)
         } else {
             // The memory already contains a memory manager. Load it.
-            let mem_mgr = MemoryManagerInner::load(memory);
-
-            // Assert that the bucket size passed is the same as the one previously stored.
-            assert_eq!(mem_mgr.bucket_size_in_pages, bucket_size_in_pages);
-            mem_mgr
+            MemoryManagerInner::load(memory)
         }
     }
 


### PR DESCRIPTION
Problem:
When loading a `MemoryManager`, the code asserts that the bucket size is equal to the `BUCKET_SIZE_IN_PAGES` constant. In practice, this makes upgrading to 0.4.0 from previous versions fail, given that the `BUCKET_SIZE_IN_PAGES` has been changed.

Solution:
Remove the assertion, as it is no longer required.