### PR TITLE
feat: add benchmarks for BTreeMap

### DIFF
--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "ena"
@@ -329,9 +329,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ic-cdk"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2693ba66f3d54284643713ca2be0b23f91a02cb3ab793a22ffd75f95593305e"
+checksum = "c98b304a2657bad15bcb547625a018e13cf596676d834cfd93023395a6e2e03a"
 dependencies = [
  "candid",
  "cfg-if",
@@ -361,9 +361,9 @@ version = "0.5.0"
 
 [[package]]
 name = "ic0"
-version = "0.18.7"
+version = "0.18.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17ec1438d667907ee275368801390f45ba0b4f6e6c2a45221e5d01199187f4f"
+checksum = "978b91fc78de9d2eb0144db717839cde3b35470199ea51aca362cb6310e93dfd"
 
 [[package]]
 name = "indexmap"
@@ -489,6 +489,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,18 +530,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+checksum = "8d829733185c1ca374f17e52b762f24f535ec625d2cc1f070e34c8a9068f341b"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+checksum = "2be1598bf1c313dcdd12092e3f1920f463462525a21b7b4e11b4168353d0123e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -558,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
@@ -618,20 +627,19 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
 dependencies = [
  "once_cell",
- "thiserror",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -667,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -794,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -837,19 +845,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d63628286617a0c67ee3c4ef92ccf62044e3813ed7376bb82a4586d2ff7974dd"
 
 [[package]]
-name = "toml"
-version = "0.5.10"
+name = "toml_datetime"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+
+[[package]]
+name = "toml_edit"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
 dependencies = [
- "serde",
+ "indexmap",
+ "nom8",
+ "toml_datetime",
 ]
 
 [[package]]
 name = "typed-arena"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
@@ -935,42 +951,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/benchmarks/build.sh
+++ b/benchmarks/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -Eexuo pipefail
+
+# Move to the script directory.
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+pushd "$SCRIPT_DIR"
+
+cargo build --release --target wasm32-unknown-unknown
+gzip -n -f ./target/wasm32-unknown-unknown/release/benchmarks.wasm

--- a/benchmarks/dfx.json
+++ b/benchmarks/dfx.json
@@ -4,7 +4,9 @@
     "benchmarks": {
       "candid": "candid.did",
       "package": "benchmarks",
-      "type": "rust"
+      "type": "custom",
+      "build": "bash build.sh",
+      "wasm": "./target/wasm32-unknown-unknown/release/benchmarks.wasm.gz"
     }
   },
   "defaults": {

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -12,14 +12,40 @@ trap "dfx stop" ERR EXIT
 dfx start --background --clean
 dfx deploy --no-wallet benchmarks
 
-# BTreeMap benchmarks
-dfx canister call benchmarks btreemap_insert --query
-dfx canister call benchmarks btreemap_remove --query
-
 # MemoryManager benchmarks
 dfx canister call benchmarks memory_manager_baseline --query
-dfx canister call benchmarks memory_manager_interleaved "(64:nat16)" --query
-dfx canister call benchmarks memory_manager_interleaved "(128:nat16)" --query
-dfx canister call benchmarks memory_manager_interleaved "(512:nat16)" --query
-dfx canister call benchmarks memory_manager_interleaved "(1024:nat16)" --query
-dfx canister call benchmarks memory_manager_interleaved "(2048:nat16)" --query
+dfx canister call benchmarks memory_manager_overhead --query
+
+# BTreeMap benchmarks
+dfx canister call benchmarks btreemap_insert_blob_4_1024 --query
+dfx canister call benchmarks btreemap_insert_blob_8_1024 --query
+dfx canister call benchmarks btreemap_insert_blob_16_1024 --query
+dfx canister call benchmarks btreemap_insert_blob_32_1024 --query
+dfx canister call benchmarks btreemap_insert_blob_64_1024 --query
+dfx canister call benchmarks btreemap_insert_blob_128_1024 --query
+
+# These tests are called as update calls as they exceed the instruction limit
+# for query calls.
+dfx canister call benchmarks btreemap_insert_blob_256_1024
+dfx canister call benchmarks btreemap_insert_blob_512_1024
+
+dfx canister call benchmarks btreemap_get_blob_4_1024 --query
+dfx canister call benchmarks btreemap_get_blob_8_1024 --query
+dfx canister call benchmarks btreemap_get_blob_16_1024 --query
+dfx canister call benchmarks btreemap_get_blob_32_1024 --query
+dfx canister call benchmarks btreemap_get_blob_64_1024 --query
+dfx canister call benchmarks btreemap_get_blob_128_1024 --query
+# These tests go over the instruction limit, so we can't run them currently.
+#dfx canister call benchmarks btreemap_get_blob_256_1024
+#dfx canister call benchmarks btreemap_get_blob_512_1024
+
+dfx canister call benchmarks btreemap_remove_blob_4_1024
+dfx canister call benchmarks btreemap_remove_blob_8_1024
+dfx canister call benchmarks btreemap_remove_blob_16_1024
+dfx canister call benchmarks btreemap_remove_blob_32_1024
+dfx canister call benchmarks btreemap_remove_blob_64_1024
+dfx canister call benchmarks btreemap_remove_blob_128_1024
+dfx canister call benchmarks btreemap_remove_blob_256_1024
+
+# This test goes over the instructions limit, so we can't run it currently.
+#dfx canister call benchmarks btreemap_remove_blob_512_1024

--- a/benchmarks/src/btreemap.rs
+++ b/benchmarks/src/btreemap.rs
@@ -1,47 +1,252 @@
 use crate::count_instructions;
-use ic_stable_structures::{BTreeMap, DefaultMemoryImpl};
+use ic_cdk_macros::{query, update};
+use ic_stable_structures::{storable::Blob, BTreeMap, BoundedStorable, DefaultMemoryImpl};
 use tiny_rng::{Rand, Rng};
 
-/// Benchmarks inserting keys into a BTreeMap.
-#[ic_cdk_macros::query]
-pub fn btreemap_insert() -> u64 {
-    let mut btree: BTreeMap<u64, (), _> = BTreeMap::init(DefaultMemoryImpl::default());
+#[query]
+pub fn btreemap_insert_blob_4_1024() -> u64 {
+    insert_blob_helper::<4, 1024>()
+}
 
+#[query]
+pub fn btreemap_insert_blob_8_1024() -> u64 {
+    insert_blob_helper::<8, 1024>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_16_1024() -> u64 {
+    insert_blob_helper::<16, 1024>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_32_1024() -> u64 {
+    insert_blob_helper::<32, 1024>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_64_1024() -> u64 {
+    insert_blob_helper::<64, 1024>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_128_1024() -> u64 {
+    insert_blob_helper::<128, 1024>()
+}
+
+#[update]
+pub fn btreemap_insert_blob_256_1024() -> u64 {
+    insert_blob_helper::<256, 1024>()
+}
+
+#[update]
+pub fn btreemap_insert_blob_512_1024() -> u64 {
+    insert_blob_helper::<512, 1024>()
+}
+
+#[update]
+pub fn btreemap_insert_blob_1024_4() -> u64 {
+    insert_blob_helper::<1024, 4>()
+}
+
+#[update]
+pub fn btreemap_insert_blob_1024_8() -> u64 {
+    insert_blob_helper::<1024, 8>()
+}
+
+#[update]
+pub fn btreemap_insert_blob_1024_16() -> u64 {
+    insert_blob_helper::<1024, 16>()
+}
+
+#[update]
+pub fn btreemap_insert_blob_1024_32() -> u64 {
+    insert_blob_helper::<1024, 32>()
+}
+
+#[update]
+pub fn btreemap_insert_blob_1024_64() -> u64 {
+    insert_blob_helper::<1024, 64>()
+}
+
+#[update]
+pub fn btreemap_insert_blob_1024_128() -> u64 {
+    insert_blob_helper::<1024, 128>()
+}
+
+#[update]
+pub fn btreemap_insert_blob_1024_256() -> u64 {
+    insert_blob_helper::<1024, 256>()
+}
+
+#[update]
+pub fn btreemap_insert_blob_1024_512() -> u64 {
+    insert_blob_helper::<1024, 512>()
+}
+
+/// Benchmarks removing keys from a BTreeMap.
+#[update]
+pub fn btreemap_remove_blob_4_1024() -> u64 {
+    remove_blob_helper::<4, 1024>()
+}
+
+#[update]
+pub fn btreemap_remove_blob_8_1024() -> u64 {
+    remove_blob_helper::<8, 1024>()
+}
+
+#[update]
+pub fn btreemap_remove_blob_16_1024() -> u64 {
+    remove_blob_helper::<16, 1024>()
+}
+
+#[update]
+pub fn btreemap_remove_blob_32_1024() -> u64 {
+    remove_blob_helper::<32, 1024>()
+}
+
+#[update]
+pub fn btreemap_remove_blob_64_1024() -> u64 {
+    remove_blob_helper::<64, 1024>()
+}
+
+#[update]
+pub fn btreemap_remove_blob_128_1024() -> u64 {
+    remove_blob_helper::<128, 1024>()
+}
+
+#[update]
+pub fn btreemap_remove_blob_256_1024() -> u64 {
+    remove_blob_helper::<256, 1024>()
+}
+
+#[update]
+pub fn btreemap_remove_blob_512_1024() -> u64 {
+    get_blob_helper::<512, 1024>()
+}
+
+/// Benchmarks getting keys from a BTreeMap.
+#[query]
+pub fn btreemap_get_blob_4_1024() -> u64 {
+    get_blob_helper::<4, 1024>()
+}
+
+#[query]
+pub fn btreemap_get_blob_8_1024() -> u64 {
+    get_blob_helper::<8, 1024>()
+}
+
+#[query]
+pub fn btreemap_get_blob_16_1024() -> u64 {
+    get_blob_helper::<16, 1024>()
+}
+
+#[query]
+pub fn btreemap_get_blob_32_1024() -> u64 {
+    get_blob_helper::<32, 1024>()
+}
+
+#[query]
+pub fn btreemap_get_blob_64_1024() -> u64 {
+    get_blob_helper::<64, 1024>()
+}
+
+#[query]
+pub fn btreemap_get_blob_128_1024() -> u64 {
+    get_blob_helper::<128, 1024>()
+}
+
+#[query]
+pub fn btreemap_get_blob_256_1024() -> u64 {
+    get_blob_helper::<256, 1024>()
+}
+
+#[query]
+pub fn btreemap_get_blob_512_1024() -> u64 {
+    get_blob_helper::<512, 1024>()
+}
+
+// Profiles inserting a large number of random blobs into a btreemap.
+fn insert_blob_helper<const K: usize, const V: usize>() -> u64 {
+    let mut btree: BTreeMap<Blob<K>, Blob<V>, _> = BTreeMap::new(DefaultMemoryImpl::default());
     let num_keys = 10_000;
     let mut rng = Rng::from_seed(0);
     let mut random_keys = Vec::with_capacity(num_keys);
+    let mut random_values = Vec::with_capacity(num_keys);
+
     for _ in 0..num_keys {
-        random_keys.push(rng.rand_u64());
+        let key_size = rng.rand_u32() % Blob::<K>::MAX_SIZE;
+        let value_size = rng.rand_u32() % Blob::<V>::MAX_SIZE;
+        random_keys.push(random_vec(&mut rng, key_size));
+        random_values.push(random_vec(&mut rng, value_size));
     }
 
     count_instructions(|| {
-        // Insert the keys in to the btree.
-        for k in random_keys.into_iter() {
-            btree.insert(k, ());
+        // Insert the keys into the btree.
+        for (k, v) in random_keys.into_iter().zip(random_values.into_iter()) {
+            btree.insert(
+                Blob::try_from(k.as_slice()).unwrap(),
+                Blob::try_from(v.as_slice()).unwrap(),
+            );
         }
     })
 }
 
-/// Benchmarks removing keys from a BTreeMap.
-#[ic_cdk_macros::query]
-pub fn btreemap_remove() -> u64 {
-    let mut btree: BTreeMap<u64, (), _> = BTreeMap::init(DefaultMemoryImpl::default());
-
+// Profiles getting a large number of random blobs from a btreemap.
+fn get_blob_helper<const K: usize, const V: usize>() -> u64 {
+    let mut btree: BTreeMap<Blob<K>, Blob<V>, _> = BTreeMap::new(DefaultMemoryImpl::default());
     let num_keys = 10_000;
     let mut rng = Rng::from_seed(0);
     let mut random_keys = Vec::with_capacity(num_keys);
+    let mut random_values = Vec::with_capacity(num_keys);
+
     for _ in 0..num_keys {
-        random_keys.push(rng.rand_u64());
+        let key_size = rng.rand_u32() % Blob::<K>::MAX_SIZE;
+        let value_size = rng.rand_u32() % Blob::<V>::MAX_SIZE;
+        random_keys.push(Blob::try_from(random_vec(&mut rng, key_size).as_slice()).unwrap());
+        random_values.push(Blob::try_from(random_vec(&mut rng, value_size).as_slice()).unwrap());
     }
 
-    for k in random_keys.clone().into_iter() {
-        btree.insert(k, ());
+    // Insert the keys into the btree.
+    for (k, v) in random_keys.iter().zip(random_values.into_iter()) {
+        btree.insert(*k, v);
+    }
+
+    // Get all the keys from the map.
+    count_instructions(|| {
+        for k in random_keys.into_iter() {
+            btree.get(&k).unwrap();
+        }
+    })
+}
+
+// Inserts a large number of random blobs into a btreemap, then profiles removing them.
+fn remove_blob_helper<const K: usize, const V: usize>() -> u64 {
+    let mut btree: BTreeMap<Blob<K>, Blob<V>, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    let num_keys = 10_000;
+    let mut rng = Rng::from_seed(0);
+    let mut random_keys = Vec::with_capacity(num_keys);
+    let mut random_values = Vec::with_capacity(num_keys);
+
+    for _ in 0..num_keys {
+        let key_size = rng.rand_u32() % Blob::<K>::MAX_SIZE;
+        let value_size = rng.rand_u32() % Blob::<V>::MAX_SIZE;
+        random_keys.push(Blob::try_from(random_vec(&mut rng, key_size).as_slice()).unwrap());
+        random_values.push(Blob::try_from(random_vec(&mut rng, value_size).as_slice()).unwrap());
+    }
+
+    // Insert the keys into the btree.
+    for (k, v) in random_keys.iter().zip(random_values.into_iter()) {
+        btree.insert(*k, v);
     }
 
     count_instructions(|| {
         // Remove the keys from the btree.
         for k in random_keys.into_iter() {
-            btree.remove(&k).unwrap();
+            btree.remove(&k);
         }
     })
+}
+
+fn random_vec(rng: &mut Rng, len: u32) -> Vec<u8> {
+    rng.iter(Rand::rand_u8).take(len as usize).collect()
 }

--- a/benchmarks/src/memory_manager.rs
+++ b/benchmarks/src/memory_manager.rs
@@ -32,13 +32,13 @@ pub fn memory_manager_baseline() -> u64 {
 /// The virtual memories of the `MemoryManager` are written in small chunks so that they are
 /// interleaved in the underlying stable memory.
 #[ic_cdk_macros::query]
-pub fn memory_manager_interleaved(bucket_size: u16) -> u64 {
+pub fn memory_manager_overhead() -> u64 {
     // A buffer of 100MiB.
     let num_chunks = 100;
     let buf_size = num_chunks * MB;
     let mut buf = vec![0; buf_size];
 
-    let mem_mgr = MemoryManager::init_with_bucket_size(DefaultMemoryImpl::default(), bucket_size);
+    let mem_mgr = MemoryManager::init(DefaultMemoryImpl::default());
     let num_memories = 5;
     crate::count_instructions(|| {
         for i in 0..num_memories {


### PR DESCRIPTION
# Problem
The benchmarks we have aren't comprehensive enough to get an accurate picture of the performance of `BTreeMap`. For example, in the `0.4.0` release, the benchmarking numbers showed us an improvement of ~40% in the `insert` and `remove` operations, but when I profiled the Bitcoin canister with that upgrade I saw a _regression_ of about 40%.

# Solution
Add more thorough benchmarks for `insert`, `remove`, and `get` to get a more accurate picture of the performance impact of our changes. These will then be used to address the performance regressions we've seen with `0.4.0+`