### PR TITLE
fix: encoding of tuples with u16 entries

### DIFF
--- a/src/storable.rs
+++ b/src/storable.rs
@@ -362,7 +362,7 @@ fn encode_size<A: BoundedStorable>(dst: &mut [u8], n: usize) {
     if A::MAX_SIZE <= u8::MAX as u32 {
         dst[0] = n as u8;
     } else if A::MAX_SIZE <= u16::MAX as u32 {
-        dst[0..1].copy_from_slice(&(n as u16).to_be_bytes());
+        dst[0..2].copy_from_slice(&(n as u16).to_be_bytes());
     } else {
         dst[0..4].copy_from_slice(&(n as u32).to_be_bytes());
     }

--- a/src/storable/tests.rs
+++ b/src/storable/tests.rs
@@ -13,10 +13,16 @@ proptest! {
     }
 
     #[test]
-    fn tuple_variable_width_roundtrip(x in any::<u64>(), v in pvec(any::<u8>(), 0..40)) {
+    fn tuple_variable_width_u8_roundtrip(x in any::<u64>(), v in pvec(any::<u8>(), 0..40)) {
         let bytes = Blob::<48>::try_from(&v[..]).unwrap();
         let tuple = (x, bytes);
         prop_assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes()));
     }
 
+    #[test]
+    fn tuple_variable_width_u16_roundtrip(x in any::<u64>(), v in pvec(any::<u8>(), 0..40)) {
+        let bytes = Blob::<300>::try_from(&v[..]).unwrap();
+        let tuple = (x, bytes);
+        prop_assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes()));
+    }
 }


### PR DESCRIPTION
This commit fixes a bug in storable tuple encoding panicking on variable-size entries fitting into u16.