### PR TITLE
feat(btreemap): add iter_upper_bound api

### DIFF
--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -942,17 +942,8 @@ where
         loop {
             match node.keys.binary_search(bound) {
                 Ok(idx) | Err(idx) => {
-                    let child = match node.node_type {
-                        NodeType::Internal => {
-                            // Note that loading a child node cannot fail since
-                            // len(children) = len(entries) + 1
-                            Some(self.load_node(node.children[idx]))
-                        }
-                        NodeType::Leaf => None,
-                    };
-
-                    match child {
-                        None => {
+                    match node.node_type {
+                        NodeType::Leaf => {
                             if idx > 0 {
                                 cursors.push(Cursor::Node {
                                     node,
@@ -970,14 +961,16 @@ where
                                 return Iter::null(self);
                             }
                         }
-                        Some(child) => {
+                        NodeType::Internal => {
+                            let child = self.load_node(node.children[idx]);
+
                             if idx < node.keys.len() {
                                 cursors.push(Cursor::Node {
                                     node,
                                     next: Index::Entry(idx),
                                 });
                             }
-                            // Iterate over the child node.
+
                             node = child;
                         }
                     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -949,12 +949,11 @@ where
                     match node.node_type {
                         NodeType::Leaf => {
                             if idx == 0 {
-                                // We descended into a leaf but didn't manage to find a node
-                                // less than the upper bound. Thus we unwind the cursor stack
-                                // until we hit a cursor pointing to an element other than the
-                                // first key in the tablet, and we shift the position backward.
-                                // If there is no such cursor, the bound must be <= min element, so
-                                // we return an empty iterator.
+                                // We descended into a leaf but didn't find a node less than
+                                // the upper bound. Thus we unwind the cursor stack until we
+                                // hit a cursor pointing to an element other than the first key,
+                                // and we shift the position backward. If there is no such cursor,
+                                // the bound must be <= min element, so we return an empty iterator.
                                 while let Some(cursor) = cursors.pop() {
                                     match cursor {
                                         Cursor::Node {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -958,17 +958,17 @@ where
                                     node,
                                     next: Index::Entry(idx - 1),
                                 });
+                                // Leaf node. Return an iterator with the found cursors.
+                                return Iter::new_in_range(
+                                    self,
+                                    (Bound::Unbounded, Bound::Unbounded),
+                                    cursors,
+                                );
                             } else {
                                 // The upper bound is less than or equal to the first key in the map.
                                 // We return an empty iterator.
                                 return Iter::null(self);
                             }
-                            // Leaf node. Return an iterator with the found cursors.
-                            return Iter::new_in_range(
-                                self,
-                                (Bound::Unbounded, Bound::Unbounded),
-                                cursors,
-                            );
                         }
                         Some(child) => {
                             if idx < node.keys.len() {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -930,7 +930,7 @@ where
         }
     }
 
-    /// Returns an interator pointing to the first element below the given bound.
+    /// Returns an iterator pointing to the first element below the given bound.
     /// Returns an empty iterator if there are no keys below the given bound.
     pub fn iter_upper_bound(&self, bound: &K) -> Iter<K, V, M> {
         if self.root_addr == NULL {
@@ -939,7 +939,7 @@ where
         }
 
         let dummy_bounds = (Bound::Unbounded, Bound::Unbounded);
-        // INVARIANT: all cursors point to keys >= bound.
+        // INVARIANT: all cursors point to keys greater than or equal to bound.
         let mut cursors = vec![];
 
         let mut node = self.load_node(self.root_addr);
@@ -952,8 +952,9 @@ where
                                 // We descended into a leaf but didn't manage to find a node
                                 // less than the upper bound. Thus we unwind the cursor stack
                                 // until we hit a cursor pointing to an element other than the
-                                // first key in the tablet and shift the position backward.
-                                // If there is no such cursor, the bound must be <= min element.
+                                // first key in the tablet, and we shift the position backward.
+                                // If there is no such cursor, the bound must be <= min element, so
+                                // we return an empty iterator.
                                 while let Some(cursor) = cursors.pop() {
                                     match cursor {
                                         Cursor::Node {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -930,7 +930,8 @@ where
         }
     }
 
-    /// Returns an interator pointing to the first element below the specified key.
+    /// Returns an interator pointing to the first element below the given bound.
+    /// Returns an empty iterator if there are no keys below the given bound.
     pub fn iter_upper_bound(&self, bound: &K) -> Iter<K, V, M> {
         if self.root_addr == NULL {
             // Map is empty.
@@ -2442,10 +2443,17 @@ mod test {
         let mut stable_map = super::BTreeMap::new(make_memory());
         for k in 0..1000u64 {
             stable_map.insert(k, ());
-            println!("Getting a upper bound for {}", k + 1);
-            assert_eq!(Some((k, ())), stable_map.iter_upper_bound(&(k + 1)).next());
-            println!("Getting a upper bound for {}", 0);
-            assert_eq!(None, stable_map.iter_upper_bound(&0).next());
+            assert_eq!(
+                Some((k, ())),
+                stable_map.iter_upper_bound(&(k + 1)).next(),
+                "failed to get an upper bound for key {}",
+                k + 1
+            );
+            assert_eq!(
+                None,
+                stable_map.iter_upper_bound(&0).next(),
+                "key 0 must not have an upper bound"
+            );
         }
     }
 

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -39,7 +39,7 @@ pub type Entry<K> = (K, Vec<u8>);
 ///     - value (`max_value_size` bytes)
 ///
 /// Each node can contain up to `CAPACITY + 1` children, each child is 8 bytes.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Node<K: Storable + Ord + Clone> {
     pub address: Address,
     pub keys: Vec<K>,

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -39,7 +39,7 @@ pub type Entry<K> = (K, Vec<u8>);
 ///     - value (`max_value_size` bytes)
 ///
 /// Each node can contain up to `CAPACITY + 1` children, each child is 8 bytes.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Node<K: Storable + Ord + Clone> {
     pub address: Address,
     pub keys: Vec<K>,

--- a/src/btreemap/proptests.rs
+++ b/src/btreemap/proptests.rs
@@ -26,4 +26,15 @@ proptest! {
             prop_assert_eq!(map.last_key_value(), Some((*max, *max)))
         }
     }
+
+    #[test]
+    fn map_upper_bound_iter(keys in pvec(0u64..u64::MAX -1 , 10..100)) {
+        let mut map = StableBTreeMap::<u64, (), _>::new(make_memory());
+
+        for k in keys.iter() {
+            map.insert(*k, ());
+
+            prop_assert_eq!(Some((*k, ())), map.iter_upper_bound(&(k + 1)).next());
+        }
+    }
 }


### PR DESCRIPTION
This change introduces a new btree map method, `iter_upper_bound`. It returns an iterator pointing to the first element that is less than the given key.

We need this method for the time series API because we need to find the closest keys to the left and to the right of the given key. We can do the latter with the `range` API, but the former requires a new method.

We took inspiration from experimental API in BTreeMap: https://doc.rust-lang.org/nightly/std/collections/struct.BTreeMap.html#method.upper_bound