### PR TITLE
chore: setup path for benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ tempfile = "3.3.0"
 [[bench]]
 name = "benches"
 harness = false
+path = "benches/benches.rs"

--- a/benchmark-canisters/Cargo.lock
+++ b/benchmark-canisters/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.5.1"
+version = "0.5.2"
 
 [[package]]
 name = "ic0"


### PR DESCRIPTION
The path for benchmarks needs to be explicitly specified, otherwise `cargo publish` fails.