### PR TITLE
Add benchmarks with u64 values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,40 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
 
 [[package]]
 name = "atty"
@@ -24,6 +54,45 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "benchmarks"
+version = "0.1.0"
+dependencies = [
+ "ic-cdk",
+ "ic-cdk-macros",
+ "ic-stable-structures",
+ "tiny-rng",
+]
+
+[[package]]
+name = "binread"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16598dfc8e6578e9b597d9910ba2e73618385dc9f4b1d43dd92c349d6be6418f"
+dependencies = [
+ "binread_derive",
+ "lazy_static",
+ "rustversion",
+]
+
+[[package]]
+name = "binread_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9672209df1714ee804b1f4d4f68c8eb2a90b1f7a07acf472f88ce198ef1fed"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bit-set"
@@ -47,6 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +135,47 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "candid"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244005a1917bb7614cd775ca8a5d59efeb5ac74397bb14ba29a19347ebd78591"
+dependencies = [
+ "anyhow",
+ "binread",
+ "byteorder",
+ "candid_derive",
+ "codespan-reporting",
+ "crc32fast",
+ "data-encoding",
+ "hex",
+ "lalrpop",
+ "lalrpop-util",
+ "leb128",
+ "logos",
+ "num-bigint",
+ "num-traits",
+ "num_enum",
+ "paste",
+ "pretty",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "candid_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f1f4db7c7d04b87b70b3a35c5dc5c2c9dd73cef8bdf6760e2f18a0d45350dd"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "cast"
@@ -116,6 +235,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -198,10 +345,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "ena"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "fastrand"
@@ -213,10 +428,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -260,6 +491,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "ic-cdk"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98b304a2657bad15bcb547625a018e13cf596676d834cfd93023395a6e2e03a"
+dependencies = [
+ "candid",
+ "cfg-if",
+ "ic-cdk-macros",
+ "ic0",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic-cdk-macros"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf50458685a0fc6b0e414cdba487610aeb199ac94db52d9fd76270565debee7"
+dependencies = [
+ "candid",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream",
+ "syn",
+]
+
+[[package]]
 name = "ic-stable-structures"
 version = "0.5.2"
 dependencies = [
@@ -269,6 +534,12 @@ dependencies = [
  "proptest",
  "tempfile",
 ]
+
+[[package]]
+name = "ic0"
+version = "0.18.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978b91fc78de9d2eb0144db717839cde3b35470199ea51aca362cb6310e93dfd"
 
 [[package]]
 name = "indexmap"
@@ -314,16 +585,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
+dependencies = [
+ "ascii-canvas",
+ "atty",
+ "bit-set",
+ "diff",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "libc"
 version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -335,10 +654,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -347,6 +695,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -369,6 +745,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +782,60 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "plotters"
@@ -419,6 +870,32 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9940b913ee56ddd94aec2d3cd179dd47068236f42a1a6415ccf9d880ce2a61"
+dependencies = [
+ "arrayvec",
+ "typed-arena",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -541,11 +1018,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -563,6 +1053,12 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "rusty-fork"
@@ -607,6 +1103,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +1131,53 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_tokenstream"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
+dependencies = [
+ "proc-macro2",
+ "serde",
+ "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
 ]
 
 [[package]]
@@ -654,10 +1206,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
+name = "thiserror"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tiny-rng"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d63628286617a0c67ee3c4ef92ccf62044e3813ed7376bb82a4586d2ff7974dd"
 
 [[package]]
 name = "tinytemplate"
@@ -670,10 +1277,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"
@@ -795,3 +1449,78 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "winnow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,8 @@ tempfile = "3.3.0"
 name = "benches"
 harness = false
 path = "benches/benches.rs"
+
+[workspace]
+members = [
+	"benchmark-canisters"
+]

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -175,11 +175,12 @@ fn execution_instructions(arguments: ExecutionArguments) -> u64 {
         .args(args)
         .output()
         .unwrap();
-    assert!(output.status.success());
-    let output = String::from_utf8(output.stdout).unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(output.status.success(), "{stdout}\n{stderr}");
 
     // Convert result formatted as "(1_000_000 : nat64)" to u64.
-    let result = output
+    let result = stdout
         .trim()
         .strip_prefix('(')
         .unwrap()
@@ -241,6 +242,9 @@ pub fn criterion_benchmark(c: &mut Criterion<Instructions>) {
         "btreemap_insert_blob_512_1024",
         false,
     );
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_u64_u64", true);
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_u64_blob_8", true);
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_8_u64", true);
 
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_4_1024", true);
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_8_1024", true);
@@ -248,6 +252,9 @@ pub fn criterion_benchmark(c: &mut Criterion<Instructions>) {
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_32_1024", true);
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_64_1024", true);
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_128_1024", true);
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_u64_u64", true);
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_u64_blob_8", true);
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_8_u64", true);
     // These tests go over the instruction limit, so we can't run them currently.
     // bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_256_1024", true);
     // bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_512_1024", true);
@@ -291,6 +298,9 @@ pub fn criterion_benchmark(c: &mut Criterion<Instructions>) {
         "btreemap_remove_blob_512_1024",
         false,
     );
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_u64_u64", false);
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_u64_blob_8", false);
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_8_u64", false);
 
     // Vec benchmarks
     bench_function(c, *BENCHMARK_CANISTER, "vec_insert_blob_4", false);
@@ -298,12 +308,14 @@ pub fn criterion_benchmark(c: &mut Criterion<Instructions>) {
     bench_function(c, *BENCHMARK_CANISTER, "vec_insert_blob_16", false);
     bench_function(c, *BENCHMARK_CANISTER, "vec_insert_blob_32", false);
     bench_function(c, *BENCHMARK_CANISTER, "vec_insert_blob_128", false);
+    bench_function(c, *BENCHMARK_CANISTER, "vec_insert_u64", false);
 
     bench_function(c, *BENCHMARK_CANISTER, "vec_get_blob_4", true);
     bench_function(c, *BENCHMARK_CANISTER, "vec_get_blob_8", true);
     bench_function(c, *BENCHMARK_CANISTER, "vec_get_blob_16", true);
     bench_function(c, *BENCHMARK_CANISTER, "vec_get_blob_32", true);
     bench_function(c, *BENCHMARK_CANISTER, "vec_get_blob_128", true);
+    bench_function(c, *BENCHMARK_CANISTER, "vec_get_u64", true);
 }
 
 fn benches() {

--- a/benchmark-canisters/build.sh
+++ b/benchmark-canisters/build.sh
@@ -6,4 +6,4 @@ SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 pushd "$SCRIPT_DIR"
 
 cargo build --release --target wasm32-unknown-unknown
-gzip -n -f ./target/wasm32-unknown-unknown/release/benchmarks.wasm
+gzip -n -f ../target/wasm32-unknown-unknown/release/benchmarks.wasm

--- a/benchmark-canisters/src/btreemap.rs
+++ b/benchmark-canisters/src/btreemap.rs
@@ -1,4 +1,4 @@
-use crate::count_instructions;
+use crate::{count_instructions, Random};
 use ic_cdk_macros::{query, update};
 use ic_stable_structures::{storable::Blob, BTreeMap, BoundedStorable, DefaultMemoryImpl};
 use tiny_rng::{Rand, Rng};
@@ -83,6 +83,21 @@ pub fn btreemap_insert_blob_1024_512() -> u64 {
     insert_blob_helper::<1024, 512>()
 }
 
+#[query]
+pub fn btreemap_insert_u64_u64() -> u64 {
+    insert_helper::<u64, u64>()
+}
+
+#[query]
+pub fn btreemap_insert_u64_blob_8() -> u64 {
+    insert_helper::<u64, Blob<8>>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_8_u64() -> u64 {
+    insert_helper::<Blob<8>, u64>()
+}
+
 /// Benchmarks removing keys from a BTreeMap.
 #[update]
 pub fn btreemap_remove_blob_4_1024() -> u64 {
@@ -122,6 +137,21 @@ pub fn btreemap_remove_blob_256_1024() -> u64 {
 #[update]
 pub fn btreemap_remove_blob_512_1024() -> u64 {
     get_blob_helper::<512, 1024>()
+}
+
+#[update]
+pub fn btreemap_remove_u64_u64() -> u64 {
+    remove_helper::<u64, u64>()
+}
+
+#[update]
+pub fn btreemap_remove_u64_blob_8() -> u64 {
+    remove_helper::<u64, Blob<8>>()
+}
+
+#[update]
+pub fn btreemap_remove_blob_8_u64() -> u64 {
+    remove_helper::<Blob<8>, u64>()
 }
 
 /// Benchmarks getting keys from a BTreeMap.
@@ -165,50 +195,67 @@ pub fn btreemap_get_blob_512_1024() -> u64 {
     get_blob_helper::<512, 1024>()
 }
 
+#[query]
+pub fn btreemap_get_u64_u64() -> u64 {
+    get_helper::<u64, u64>()
+}
+
+#[query]
+pub fn btreemap_get_u64_blob_8() -> u64 {
+    get_helper::<u64, Blob<8>>()
+}
+
+#[query]
+pub fn btreemap_get_blob_8_u64() -> u64 {
+    get_helper::<Blob<8>, u64>()
+}
+
 // Profiles inserting a large number of random blobs into a btreemap.
 fn insert_blob_helper<const K: usize, const V: usize>() -> u64 {
-    let mut btree: BTreeMap<Blob<K>, Blob<V>, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    insert_helper::<Blob<K>, Blob<V>>()
+}
+
+// Profiles inserting a large number of random blobs into a btreemap.
+fn insert_helper<K: Clone + Ord + BoundedStorable + Random, V: BoundedStorable + Random>() -> u64 {
+    let mut btree: BTreeMap<K, V, _> = BTreeMap::new(DefaultMemoryImpl::default());
     let num_keys = 10_000;
     let mut rng = Rng::from_seed(0);
     let mut random_keys = Vec::with_capacity(num_keys);
     let mut random_values = Vec::with_capacity(num_keys);
 
     for _ in 0..num_keys {
-        let key_size = rng.rand_u32() % Blob::<K>::MAX_SIZE;
-        let value_size = rng.rand_u32() % Blob::<V>::MAX_SIZE;
-        random_keys.push(random_vec(&mut rng, key_size));
-        random_values.push(random_vec(&mut rng, value_size));
+        random_keys.push(K::random(&mut rng));
+        random_values.push(V::random(&mut rng));
     }
 
     count_instructions(|| {
         // Insert the keys into the btree.
         for (k, v) in random_keys.into_iter().zip(random_values.into_iter()) {
-            btree.insert(
-                Blob::try_from(k.as_slice()).unwrap(),
-                Blob::try_from(v.as_slice()).unwrap(),
-            );
+            btree.insert(k, v);
         }
     })
 }
 
 // Profiles getting a large number of random blobs from a btreemap.
 fn get_blob_helper<const K: usize, const V: usize>() -> u64 {
-    let mut btree: BTreeMap<Blob<K>, Blob<V>, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    get_helper::<Blob<K>, Blob<V>>()
+}
+
+fn get_helper<K: Clone + Ord + BoundedStorable + Random, V: BoundedStorable + Random>() -> u64 {
+    let mut btree: BTreeMap<K, V, _> = BTreeMap::new(DefaultMemoryImpl::default());
     let num_keys = 10_000;
     let mut rng = Rng::from_seed(0);
     let mut random_keys = Vec::with_capacity(num_keys);
     let mut random_values = Vec::with_capacity(num_keys);
 
     for _ in 0..num_keys {
-        let key_size = rng.rand_u32() % Blob::<K>::MAX_SIZE;
-        let value_size = rng.rand_u32() % Blob::<V>::MAX_SIZE;
-        random_keys.push(Blob::try_from(random_vec(&mut rng, key_size).as_slice()).unwrap());
-        random_values.push(Blob::try_from(random_vec(&mut rng, value_size).as_slice()).unwrap());
+        random_keys.push(K::random(&mut rng));
+        random_values.push(V::random(&mut rng));
     }
 
     // Insert the keys into the btree.
     for (k, v) in random_keys.iter().zip(random_values.into_iter()) {
-        btree.insert(*k, v);
+        btree.insert(k.clone(), v);
     }
 
     // Get all the keys from the map.
@@ -221,22 +268,24 @@ fn get_blob_helper<const K: usize, const V: usize>() -> u64 {
 
 // Inserts a large number of random blobs into a btreemap, then profiles removing them.
 fn remove_blob_helper<const K: usize, const V: usize>() -> u64 {
-    let mut btree: BTreeMap<Blob<K>, Blob<V>, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    remove_helper::<Blob<K>, Blob<V>>()
+}
+
+fn remove_helper<K: Clone + Ord + BoundedStorable + Random, V: BoundedStorable + Random>() -> u64 {
+    let mut btree: BTreeMap<K, V, _> = BTreeMap::new(DefaultMemoryImpl::default());
     let num_keys = 10_000;
     let mut rng = Rng::from_seed(0);
     let mut random_keys = Vec::with_capacity(num_keys);
     let mut random_values = Vec::with_capacity(num_keys);
 
     for _ in 0..num_keys {
-        let key_size = rng.rand_u32() % Blob::<K>::MAX_SIZE;
-        let value_size = rng.rand_u32() % Blob::<V>::MAX_SIZE;
-        random_keys.push(Blob::try_from(random_vec(&mut rng, key_size).as_slice()).unwrap());
-        random_values.push(Blob::try_from(random_vec(&mut rng, value_size).as_slice()).unwrap());
+        random_keys.push(K::random(&mut rng));
+        random_values.push(V::random(&mut rng));
     }
 
     // Insert the keys into the btree.
     for (k, v) in random_keys.iter().zip(random_values.into_iter()) {
-        btree.insert(*k, v);
+        btree.insert(k.clone(), v);
     }
 
     count_instructions(|| {
@@ -245,8 +294,4 @@ fn remove_blob_helper<const K: usize, const V: usize>() -> u64 {
             btree.remove(&k);
         }
     })
-}
-
-fn random_vec(rng: &mut Rng, len: u32) -> Vec<u8> {
-    rng.iter(Rand::rand_u8).take(len as usize).collect()
 }

--- a/benchmark-canisters/src/main.rs
+++ b/benchmark-canisters/src/main.rs
@@ -1,3 +1,6 @@
+use ic_stable_structures::{storable::Blob, BoundedStorable};
+use tiny_rng::{Rand, Rng};
+
 mod btreemap;
 mod memory_manager;
 mod vec;
@@ -7,6 +10,29 @@ pub(crate) fn count_instructions<R>(f: impl FnOnce() -> R) -> u64 {
     let start = ic_cdk::api::performance_counter(0);
     f();
     ic_cdk::api::performance_counter(0) - start
+}
+
+trait Random {
+    fn random(rng: &mut Rng) -> Self;
+}
+
+impl<const K: usize> Random for Blob<K> {
+    fn random(rng: &mut Rng) -> Self {
+        let size = rng.rand_u32() % Blob::<K>::MAX_SIZE;
+        Blob::try_from(
+            rng.iter(Rand::rand_u8)
+                .take(size as usize)
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )
+        .unwrap()
+    }
+}
+
+impl Random for u64 {
+    fn random(rng: &mut Rng) -> Self {
+        rng.rand_u64()
+    }
 }
 
 fn main() {}

--- a/benchmark-canisters/src/vec.rs
+++ b/benchmark-canisters/src/vec.rs
@@ -1,7 +1,7 @@
-use crate::count_instructions;
+use crate::{count_instructions, Random};
 use ic_cdk_macros::{query, update};
 use ic_stable_structures::storable::Blob;
-use ic_stable_structures::{DefaultMemoryImpl, StableVec};
+use ic_stable_structures::{BoundedStorable, DefaultMemoryImpl, StableVec};
 use tiny_rng::{Rand, Rng};
 
 #[update]
@@ -34,6 +34,11 @@ pub fn vec_insert_blob_128() -> u64 {
     vec_insert_blob::<128>()
 }
 
+#[update]
+pub fn vec_insert_u64() -> u64 {
+    vec_insert::<u64>()
+}
+
 #[query]
 pub fn vec_get_blob_4() -> u64 {
     vec_get_blob::<4>()
@@ -64,16 +69,24 @@ pub fn vec_get_blob_128() -> u64 {
     vec_get_blob::<128>()
 }
 
+#[query]
+pub fn vec_get_u64() -> u64 {
+    vec_get::<u64>()
+}
+
 fn vec_insert_blob<const N: usize>() -> u64 {
+    vec_insert::<Blob<N>>()
+}
+
+fn vec_insert<T: BoundedStorable + Random>() -> u64 {
     let num_items = 10_000;
-    let svec: StableVec<Blob<N>, _> = StableVec::new(DefaultMemoryImpl::default()).unwrap();
+    let svec: StableVec<T, _> = StableVec::new(DefaultMemoryImpl::default()).unwrap();
 
     let mut rng = Rng::from_seed(0);
     let mut random_items = Vec::with_capacity(num_items);
 
     for _ in 0..num_items {
-        let key_size = rng.rand_u32() % (N as u32 + 1);
-        random_items.push(Blob::try_from(random_vec(&mut rng, key_size).as_slice()).unwrap());
+        random_items.push(T::random(&mut rng));
     }
 
     count_instructions(|| {
@@ -84,15 +97,17 @@ fn vec_insert_blob<const N: usize>() -> u64 {
 }
 
 fn vec_get_blob<const N: usize>() -> u64 {
+    vec_get::<Blob<N>>()
+}
+
+fn vec_get<T: BoundedStorable + Random>() -> u64 {
     let num_items = 10_000;
-    let svec: StableVec<Blob<N>, _> = StableVec::new(DefaultMemoryImpl::default()).unwrap();
+    let svec: StableVec<T, _> = StableVec::new(DefaultMemoryImpl::default()).unwrap();
 
     let mut rng = Rng::from_seed(0);
 
     for _ in 0..num_items {
-        let key_size = rng.rand_u32() % (N as u32 + 1);
-        svec.push(&Blob::try_from(random_vec(&mut rng, key_size).as_slice()).unwrap())
-            .unwrap();
+        svec.push(&T::random(&mut rng)).unwrap();
     }
 
     count_instructions(|| {
@@ -100,8 +115,4 @@ fn vec_get_blob<const N: usize>() -> u64 {
             svec.get(i as u64).unwrap();
         }
     })
-}
-
-fn random_vec(rng: &mut Rng, len: u32) -> Vec<u8> {
-    rng.iter(Rand::rand_u8).take(len as usize).collect()
 }


### PR DESCRIPTION
These changes add some benchmarks with `u64`s for the data in btreemaps
and vecs. They also add a `Random` trait so that benchmarks for other
types can easily be added.