### PR TITLE
refactor: generalize the `Node` in `BTreeMap`

### DIFF
--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -861,7 +861,7 @@ where
                                 };
 
                                 if idx + 1 != node.entries_len()
-                                    && key_range.contains(&node.key(idx + 1))
+                                    && key_range.contains(node.key(idx + 1))
                                 {
                                     cursors.push(Cursor::Node {
                                         node,
@@ -898,7 +898,7 @@ where
                                 NodeType::Leaf => None,
                             };
 
-                            if idx < node.entries_len() && key_range.contains(&node.key(idx)) {
+                            if idx < node.entries_len() && key_range.contains(node.key(idx)) {
                                 cursors.push(Cursor::Node {
                                     node,
                                     next: Index::Entry(idx),

--- a/src/btreemap/iter.rs
+++ b/src/btreemap/iter.rs
@@ -126,7 +126,7 @@ where
                 node,
                 next: Index::Entry(entry_idx),
             }) => {
-                if entry_idx >= node.keys.len() {
+                if entry_idx >= node.entries_len() {
                     // No more entries to iterate on in this node.
                     return self.next();
                 }

--- a/src/btreemap/iter.rs
+++ b/src/btreemap/iter.rs
@@ -164,7 +164,6 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::btreemap::node::CAPACITY;
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -177,7 +176,7 @@ mod test {
         let mem = make_memory();
         let mut btree = BTreeMap::new(mem);
 
-        for i in 0..CAPACITY as u8 {
+        for i in 0..10u8 {
             btree.insert(i, i + 1);
         }
 
@@ -188,7 +187,7 @@ mod test {
             i += 1;
         }
 
-        assert_eq!(i, CAPACITY as u8);
+        assert_eq!(i, 10u8);
     }
 
     #[test]

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -42,8 +42,8 @@ pub type Entry<K> = (K, Vec<u8>);
 #[derive(Debug, PartialEq, Eq)]
 pub struct Node<K: Storable + Ord + Clone> {
     pub address: Address,
-    pub keys: Vec<K>,
-    pub encoded_values: Vec<Vec<u8>>,
+    keys: Vec<K>,
+    encoded_values: Vec<Vec<u8>>,
     /// For the key at position I, children[I] points to the left
     /// child of this key and children[I + 1] points to the right child.
     pub children: Vec<Address>,
@@ -267,6 +267,16 @@ impl<K: Storable + Ord + Clone> Node<K> {
         (self.keys[idx].clone(), self.encoded_values[idx].clone())
     }
 
+    /// Returns a reference to the encoded value at the specified index.
+    pub fn value(&self, idx: usize) -> &Vec<u8> {
+        &self.encoded_values[idx]
+    }
+
+    /// Returns a reference to the key at the specified index.
+    pub fn key(&self, idx: usize) -> &K {
+        &self.keys[idx]
+    }
+
     /// Inserts a new entry at the specified index.
     pub fn insert_entry(&mut self, idx: usize, (key, encoded_value): Entry<K>) {
         self.keys.insert(idx, key);
@@ -304,13 +314,18 @@ impl<K: Storable + Ord + Clone> Node<K> {
             .collect()
     }
 
+    /// Returns the number of entries in the node.
+    pub fn entries_len(&self) -> usize {
+        self.keys.len()
+    }
+
     /// Searches for the key in the node's entries.
     ///
     /// If the key is found then `Result::Ok` is returned, containing the index
     /// of the matching key. If the value is not found then `Result::Err` is
     /// returned, containing the index where a matching key could be inserted
     /// while maintaining sorted order.
-    pub fn get_key_idx(&mut self, key: &K) -> Result<usize, usize> {
+    pub fn search(&self, key: &K) -> Result<usize, usize> {
         self.keys.binary_search(key)
     }
 


### PR DESCRIPTION
This commit lays some of the groundwork for EXC-1395, which is to support variable-length keys and values in the BTreeMap.

The code that is specific to the node containing a fixed number of elements is abstracted away from the `BTreeMap` and into the `Node` itself. Once the concept of a node is completely abstracted, then we can drop in a new implementation of Node that supports a variable number of entries.

As part of this abstraction:
* Some of the fields/constants in `node.rs` are made private. Follow-up commits will make all fields in the `Node` private.
* Some tests were rewritten to be more generic, but still offers the same or better coverage.
