### PR TITLE
refactor: make all fields in BTreeMap Node private

### DIFF
--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -861,7 +861,7 @@ where
                                 };
 
                                 if idx + 1 != node.entries_len()
-                                    && key_range.contains(&node.key(idx + 1))
+                                    && key_range.contains(node.key(idx + 1))
                                 {
                                     cursors.push(Cursor::Node {
                                         node,
@@ -898,7 +898,7 @@ where
                                 NodeType::Leaf => None,
                             };
 
-                            if idx < node.entries_len() && key_range.contains(&node.key(idx)) {
+                            if idx < node.entries_len() && key_range.contains(node.key(idx)) {
                                 cursors.push(Cursor::Node {
                                     node,
                                     next: Index::Entry(idx),

--- a/src/btreemap/iter.rs
+++ b/src/btreemap/iter.rs
@@ -88,7 +88,7 @@ where
                     // Load the node at the given address, and add it to the cursors.
                     let node = self.map.load_node(address);
                     self.cursors.push(Cursor::Node {
-                        next: match node.node_type {
+                        next: match node.node_type() {
                             // Iterate on internal nodes starting from the first child.
                             NodeType::Internal => Index::Child(0),
                             // Iterate on leaf nodes starting from the first entry.
@@ -104,10 +104,7 @@ where
                 node,
                 next: Index::Child(child_idx),
             }) => {
-                let child_address = *node
-                    .children
-                    .get(child_idx)
-                    .expect("Iterating over children went out of bounds.");
+                let child_address = node.child(child_idx);
 
                 // After iterating on the child, iterate on the next _entry_ in this node.
                 // The entry immediately after the child has the same index as the child's.
@@ -135,7 +132,7 @@ where
 
                 // Add to the cursors the next element to be traversed.
                 self.cursors.push(Cursor::Node {
-                    next: match node.node_type {
+                    next: match node.node_type() {
                         // If this is an internal node, add the next child to the cursors.
                         NodeType::Internal => Index::Child(entry_idx + 1),
                         // If this is a leaf node, add the next entry to the cursors.

--- a/src/btreemap/iter.rs
+++ b/src/btreemap/iter.rs
@@ -126,7 +126,7 @@ where
                 node,
                 next: Index::Entry(entry_idx),
             }) => {
-                if entry_idx >= node.keys.len() {
+                if entry_idx >= node.entries_len() {
                     // No more entries to iterate on in this node.
                     return self.next();
                 }

--- a/src/btreemap/iter.rs
+++ b/src/btreemap/iter.rs
@@ -164,7 +164,6 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::btreemap::node::CAPACITY;
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -177,7 +176,7 @@ mod test {
         let mem = make_memory();
         let mut btree = BTreeMap::new(mem);
 
-        for i in 0..CAPACITY as u8 {
+        for i in 0..10u8 {
             btree.insert(i, i + 1);
         }
 
@@ -188,7 +187,7 @@ mod test {
             i += 1;
         }
 
-        assert_eq!(i, CAPACITY as u8);
+        assert_eq!(i, 10u8);
     }
 
     #[test]

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -42,8 +42,8 @@ pub type Entry<K> = (K, Vec<u8>);
 #[derive(Debug, PartialEq, Eq)]
 pub struct Node<K: Storable + Ord + Clone> {
     pub address: Address,
-    pub keys: Vec<K>,
-    pub encoded_values: Vec<Vec<u8>>,
+    keys: Vec<K>,
+    encoded_values: Vec<Vec<u8>>,
     /// For the key at position I, children[I] points to the left
     /// child of this key and children[I + 1] points to the right child.
     pub children: Vec<Address>,
@@ -267,6 +267,16 @@ impl<K: Storable + Ord + Clone> Node<K> {
         (self.keys[idx].clone(), self.encoded_values[idx].clone())
     }
 
+    /// Returns a reference to the encoded value at the specified index.
+    pub fn value(&self, idx: usize) -> &Vec<u8> {
+        &self.encoded_values[idx]
+    }
+
+    /// Returns a reference to the key at the specified index.
+    pub fn key(&self, idx: usize) -> &K {
+        &self.keys[idx]
+    }
+
     /// Inserts a new entry at the specified index.
     pub fn insert_entry(&mut self, idx: usize, (key, encoded_value): Entry<K>) {
         self.keys.insert(idx, key);
@@ -304,13 +314,18 @@ impl<K: Storable + Ord + Clone> Node<K> {
             .collect()
     }
 
+    /// Returns the number of entries in the node.
+    pub fn entries_len(&self) -> usize {
+        self.keys.len()
+    }
+
     /// Searches for the key in the node's entries.
     ///
     /// If the key is found then `Result::Ok` is returned, containing the index
     /// of the matching key. If the value is not found then `Result::Err` is
     /// returned, containing the index where a matching key could be inserted
     /// while maintaining sorted order.
-    pub fn get_key_idx(&mut self, key: &K) -> Result<usize, usize> {
+    pub fn search(&self, key: &K) -> Result<usize, usize> {
         self.keys.binary_search(key)
     }
 


### PR DESCRIPTION
Continues the refactor in #74 by making all the fields in the `Node` private.