### PR TITLE
chore: fix warning about unaligned field references

### DIFF
--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2534,7 +2534,6 @@ mod test {
     }
 
     #[test]
-    #[allow(unaligned_references)]
     fn read_write_header_is_identical_to_read_write_struct() {
         #[repr(C, packed)]
         struct BTreePackedHeader {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2575,11 +2575,11 @@ mod test {
 
         let packed_header: BTreePackedHeader = crate::read_struct(Address::from(0), &v1_mem);
         let v1_header = BTreeMap::<Vec<_>, Vec<_>, RefCell<Vec<_>>>::read_header(&v1_mem);
-        assert_eq!(packed_header.magic, v1_header.magic);
-        assert_eq!(packed_header.version, v1_header.version);
-        assert_eq!(packed_header.max_key_size, v1_header.max_key_size);
-        assert_eq!(packed_header.max_value_size, v1_header.max_value_size);
-        assert_eq!(packed_header.root_addr, v1_header.root_addr);
-        assert_eq!(packed_header.length, v1_header.length);
+        assert!(packed_header.magic == v1_header.magic);
+        assert!(packed_header.version == v1_header.version);
+        assert!(packed_header.max_key_size == v1_header.max_key_size);
+        assert!(packed_header.max_value_size == v1_header.max_value_size);
+        assert!(packed_header.root_addr == v1_header.root_addr);
+        assert!(packed_header.length == v1_header.length);
     }
 }


### PR DESCRIPTION
When running the tests, Rust would show the following warning:

```
warning: reference to packed field is unaligned
```

This commit fixes the underlying issue causing these warnings.