### PR TITLE
fix: use drun for running the benchmarks.

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -181,22 +181,9 @@ pub fn criterion_benchmark(c: &mut Criterion<Instructions>) {
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_16_1024");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_32_1024");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_64_1024");
-    bench_function(
-        c,
-        *BENCHMARK_CANISTER,
-        "btreemap_insert_blob_128_1024",
-    );
-
-    bench_function(
-        c,
-        *BENCHMARK_CANISTER,
-        "btreemap_insert_blob_256_1024",
-    );
-    bench_function(
-        c,
-        *BENCHMARK_CANISTER,
-        "btreemap_insert_blob_512_1024",
-    );
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_128_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_256_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_512_1024");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_u64_u64");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_u64_blob_8");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_8_u64");

--- a/benches/run-benchmark.sh
+++ b/benches/run-benchmark.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Runs a benchmark using drun. The script assumes drun is available on the caller's path.
+set -euo pipefail
+
+BENCH_NAME=$1
+FILE=mktemp
+
+if ! type "drun" > /dev/null; then
+  echo "drun is not installed. Please add drun to your path from commit d35535c96184be039aaa31f68b48bbe45909494e."
+  exit 1
+fi
+
+cat > $FILE << EOF
+create
+install rwlgt-iiaaa-aaaaa-aaaaa-cai ../target/wasm32-unknown-unknown/release/benchmarks.wasm ""
+query rwlgt-iiaaa-aaaaa-aaaaa-cai ${BENCH_NAME} "DIDL\x00\x00"
+EOF
+
+# Run the benchmarks, decode the output.
+drun $FILE --instruction-limit 99999999999999 \
+    | awk '{ print $3 }' \
+    | grep "44.*" -o \
+    | xargs didc decode

--- a/benchmark-canisters/src/btreemap.rs
+++ b/benchmark-canisters/src/btreemap.rs
@@ -1,5 +1,5 @@
 use crate::{count_instructions, Random};
-use ic_cdk_macros::{query};
+use ic_cdk_macros::query;
 use ic_stable_structures::{storable::Blob, BTreeMap, BoundedStorable, DefaultMemoryImpl};
 use tiny_rng::{Rand, Rng};
 

--- a/benchmark-canisters/src/btreemap.rs
+++ b/benchmark-canisters/src/btreemap.rs
@@ -1,5 +1,5 @@
 use crate::{count_instructions, Random};
-use ic_cdk_macros::{query, update};
+use ic_cdk_macros::{query};
 use ic_stable_structures::{storable::Blob, BTreeMap, BoundedStorable, DefaultMemoryImpl};
 use tiny_rng::{Rand, Rng};
 
@@ -33,52 +33,52 @@ pub fn btreemap_insert_blob_128_1024() -> u64 {
     insert_blob_helper::<128, 1024>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_insert_blob_256_1024() -> u64 {
     insert_blob_helper::<256, 1024>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_insert_blob_512_1024() -> u64 {
     insert_blob_helper::<512, 1024>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_insert_blob_1024_4() -> u64 {
     insert_blob_helper::<1024, 4>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_insert_blob_1024_8() -> u64 {
     insert_blob_helper::<1024, 8>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_insert_blob_1024_16() -> u64 {
     insert_blob_helper::<1024, 16>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_insert_blob_1024_32() -> u64 {
     insert_blob_helper::<1024, 32>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_insert_blob_1024_64() -> u64 {
     insert_blob_helper::<1024, 64>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_insert_blob_1024_128() -> u64 {
     insert_blob_helper::<1024, 128>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_insert_blob_1024_256() -> u64 {
     insert_blob_helper::<1024, 256>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_insert_blob_1024_512() -> u64 {
     insert_blob_helper::<1024, 512>()
 }
@@ -99,57 +99,57 @@ pub fn btreemap_insert_blob_8_u64() -> u64 {
 }
 
 /// Benchmarks removing keys from a BTreeMap.
-#[update]
+#[query]
 pub fn btreemap_remove_blob_4_1024() -> u64 {
     remove_blob_helper::<4, 1024>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_remove_blob_8_1024() -> u64 {
     remove_blob_helper::<8, 1024>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_remove_blob_16_1024() -> u64 {
     remove_blob_helper::<16, 1024>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_remove_blob_32_1024() -> u64 {
     remove_blob_helper::<32, 1024>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_remove_blob_64_1024() -> u64 {
     remove_blob_helper::<64, 1024>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_remove_blob_128_1024() -> u64 {
     remove_blob_helper::<128, 1024>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_remove_blob_256_1024() -> u64 {
     remove_blob_helper::<256, 1024>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_remove_blob_512_1024() -> u64 {
     get_blob_helper::<512, 1024>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_remove_u64_u64() -> u64 {
     remove_helper::<u64, u64>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_remove_u64_blob_8() -> u64 {
     remove_helper::<u64, Blob<8>>()
 }
 
-#[update]
+#[query]
 pub fn btreemap_remove_blob_8_u64() -> u64 {
     remove_helper::<Blob<8>, u64>()
 }

--- a/benchmark-canisters/src/vec.rs
+++ b/benchmark-canisters/src/vec.rs
@@ -1,40 +1,40 @@
 use crate::{count_instructions, Random};
-use ic_cdk_macros::{query, update};
+use ic_cdk_macros::query;
 use ic_stable_structures::storable::Blob;
 use ic_stable_structures::{BoundedStorable, DefaultMemoryImpl, StableVec};
 use tiny_rng::{Rand, Rng};
 
-#[update]
+#[query]
 pub fn vec_insert_blob_4() -> u64 {
     vec_insert_blob::<4>()
 }
 
-#[update]
+#[query]
 pub fn vec_insert_blob_8() -> u64 {
     vec_insert_blob::<8>()
 }
 
-#[update]
+#[query]
 pub fn vec_insert_blob_16() -> u64 {
     vec_insert_blob::<16>()
 }
 
-#[update]
+#[query]
 pub fn vec_insert_blob_32() -> u64 {
     vec_insert_blob::<32>()
 }
 
-#[update]
+#[query]
 pub fn vec_insert_blob_64() -> u64 {
     vec_insert_blob::<64>()
 }
 
-#[update]
+#[query]
 pub fn vec_insert_blob_128() -> u64 {
     vec_insert_blob::<128>()
 }
 
-#[update]
+#[query]
 pub fn vec_insert_u64() -> u64 {
     vec_insert::<u64>()
 }


### PR DESCRIPTION
# Problem
Benchmarks are run within a canister to obtain the instruction count. However, benchmarks can run for up to 5B instructions in case of queries, and 50B in case of updates. We do have benchmarks that we haven't been able to run because they surpass these limits.

# Solution
Use `drun` instead of `dfx` to run the benchmarks. `drun` can be configured to have a practically infinite instruction count. As a result, a few benchmarks are now enabled by this commit, and all the benchmarks are now query calls to avoid side effects.

Closes EXC-1405