### PR TITLE
perf: remove redundant node load from BTreeMap::remove

### DIFF
--- a/benchmark-canisters/src/btreemap.rs
+++ b/benchmark-canisters/src/btreemap.rs
@@ -136,7 +136,7 @@ pub fn btreemap_remove_blob_256_1024() -> u64 {
 
 #[query]
 pub fn btreemap_remove_blob_512_1024() -> u64 {
-    get_blob_helper::<512, 1024>()
+    remove_blob_helper::<512, 1024>()
 }
 
 #[query]

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -760,8 +760,8 @@ where
                             // Merge child into left sibling if it exists.
 
                             assert!(left_sibling.at_minimum());
-                            let left_sibling_address = left_sibling.address();
-                            let left_sibling = self.merge(child, left_sibling, node.remove_entry(idx - 1));
+                            let left_sibling =
+                                self.merge(child, left_sibling, node.remove_entry(idx - 1));
                             // Removing child from parent.
                             node.remove_child(idx);
 
@@ -770,7 +770,7 @@ where
 
                                 if node.address() == self.root_addr {
                                     // Update the root.
-                                    self.root_addr = left_sibling_address;
+                                    self.root_addr = left_sibling.address();
                                     self.save();
                                 }
                             } else {
@@ -784,8 +784,8 @@ where
                             // Merge child into right sibling.
 
                             assert!(right_sibling.at_minimum());
-                            let right_sibling_address = right_sibling.address();
-                            let right_sibling = self.merge(child, right_sibling, node.remove_entry(idx));
+                            let right_sibling =
+                                self.merge(child, right_sibling, node.remove_entry(idx));
 
                             // Removing child from parent.
                             node.remove_child(idx);
@@ -795,7 +795,7 @@ where
 
                                 if node.address() == self.root_addr {
                                     // Update the root.
-                                    self.root_addr = right_sibling_address;
+                                    self.root_addr = right_sibling.address();
                                     self.save();
                                 }
                             } else {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -457,15 +457,14 @@ where
             return None;
         }
 
-        self.remove_helper(self.root_addr, key)
+        let root_node = self.load_node(self.root_addr);
+        self.remove_helper(root_node, key)
             .map(Cow::Owned)
             .map(V::from_bytes)
     }
 
     // A helper method for recursively removing a key from the B-tree.
-    fn remove_helper(&mut self, node_addr: Address, key: &K) -> Option<Vec<u8>> {
-        let mut node = self.load_node(node_addr);
-
+    fn remove_helper(&mut self, mut node: Node<K>, key: &K) -> Option<Vec<u8>> {
         if node.address() != self.root_addr {
             // We're guaranteed that whenever this method is called an entry can be
             // removed from the node without it needing to be merged into a sibling.
@@ -532,7 +531,7 @@ where
                             // Recursively delete the predecessor.
                             // TODO(EXC-1034): Do this in a single pass.
                             let predecessor = left_child.get_max(self.memory());
-                            self.remove_helper(node.child(idx), &predecessor.0)?;
+                            self.remove_helper(left_child, &predecessor.0)?;
 
                             // Replace the `key` with its predecessor.
                             let (_, old_value) = node.swap_entry(idx, predecessor);
@@ -567,7 +566,7 @@ where
                             // Recursively delete the successor.
                             // TODO(EXC-1034): Do this in a single pass.
                             let successor = right_child.get_min(self.memory());
-                            self.remove_helper(node.child(idx + 1), &successor.0)?;
+                            self.remove_helper(right_child, &successor.0)?;
 
                             // Replace the `key` with its successor.
                             let (_, old_value) = node.swap_entry(idx, successor);
@@ -622,7 +621,7 @@ where
                         new_child.save(self.memory());
 
                         // Recursively delete the key.
-                        self.remove_helper(new_child.address(), key)
+                        self.remove_helper(new_child, key)
                     }
                     Err(idx) => {
                         // Case 3: The node is an internal node and the key does NOT exist in it.
@@ -634,7 +633,7 @@ where
                         if child.can_remove_entry_without_merging() {
                             // The child has enough nodes. Recurse to delete the `key` from the
                             // `child`.
-                            return self.remove_helper(node.child(idx), key);
+                            return self.remove_helper(child, key);
                         }
 
                         // An entry can't be removed from the child without merging.
@@ -699,7 +698,7 @@ where
                                 left_sibling.save(self.memory());
                                 child.save(self.memory());
                                 node.save(self.memory());
-                                return self.remove_helper(child.address(), key);
+                                return self.remove_helper(child, key);
                             }
                         }
 
@@ -751,7 +750,7 @@ where
                                 right_sibling.save(self.memory());
                                 child.save(self.memory());
                                 node.save(self.memory());
-                                return self.remove_helper(child.address(), key);
+                                return self.remove_helper(child, key);
                             }
                         }
 
@@ -762,7 +761,7 @@ where
 
                             assert!(left_sibling.at_minimum());
                             let left_sibling_address = left_sibling.address();
-                            self.merge(child, left_sibling, node.remove_entry(idx - 1));
+                            let left_sibling = self.merge(child, left_sibling, node.remove_entry(idx - 1));
                             // Removing child from parent.
                             node.remove_child(idx);
 
@@ -778,7 +777,7 @@ where
                                 node.save(self.memory());
                             }
 
-                            return self.remove_helper(left_sibling_address, key);
+                            return self.remove_helper(left_sibling, key);
                         }
 
                         if let Some(right_sibling) = right_sibling {
@@ -786,7 +785,7 @@ where
 
                             assert!(right_sibling.at_minimum());
                             let right_sibling_address = right_sibling.address();
-                            self.merge(child, right_sibling, node.remove_entry(idx));
+                            let right_sibling = self.merge(child, right_sibling, node.remove_entry(idx));
 
                             // Removing child from parent.
                             node.remove_child(idx);
@@ -803,7 +802,7 @@ where
                                 node.save(self.memory());
                             }
 
-                            return self.remove_helper(right_sibling_address, key);
+                            return self.remove_helper(right_sibling, key);
                         }
 
                         unreachable!("At least one of the siblings must exist.");


### PR DESCRIPTION
A minor performance optimization where we avoid loading the same node twice when removing a key. Our benchmarks show a ~35% performance improvement in the `btreemap_remove_*` benchmarks.

```
btreemap_remove_blob_4_1024
                        time:   [1291.5 M Instructions 1291.5 M Instructions 1291.5 M Instructions]
                        change: [-35.542% -35.542% -35.542%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_8_1024
                        time:   [1482.7 M Instructions 1482.7 M Instructions 1482.7 M Instructions]
                        change: [-35.194% -35.194% -35.194%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_16_1024
                        time:   [1663.2 M Instructions 1663.2 M Instructions 1663.2 M Instructions]
                        change: [-35.169% -35.169% -35.169%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_32_1024
                        time:   [1713.5 M Instructions 1713.5 M Instructions 1713.5 M Instructions]
                        change: [-35.033% -35.033% -35.033%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_64_1024
                        time:   [1990.7 M Instructions 1990.7 M Instructions 1990.7 M Instructions]
                        change: [-35.271% -35.271% -35.271%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_128_1024
                        time:   [2269.5 M Instructions 2269.5 M Instructions 2269.5 M Instructions]
                        change: [-36.054% -36.054% -36.054%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_256_1024
                        time:   [2870.8 M Instructions 2870.8 M Instructions 2870.8 M Instructions]
                        change: [-36.575% -36.575% -36.575%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_512_1024
                        time:   [4045.3 M Instructions 4045.3 M Instructions 4045.3 M Instructions]
                        change: [-36.849% -36.849% -36.849%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_u64_u64 time:   [1134.2 M Instructions 1134.2 M Instructions 1134.2 M Instructions]
                        change: [-32.645% -32.645% -32.645%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_u64_blob_8
                        time:   [1063.9 M Instructions 1063.9 M Instructions 1063.9 M Instructions]
                        change: [-32.375% -32.375% -32.375%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_8_u64
                        time:   [1003.2 M Instructions 1003.2 M Instructions 1003.2 M Instructions]
                        change: [-35.086% -35.086% -35.086%] (p = 0.00 < 0.05)
                        Performance has improved.
```