### PR TITLE
perf: lazy loading of BTreeMap values

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -143,7 +143,6 @@ fn execution_instructions(arguments: ExecutionArguments) -> u64 {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(output.status.success(), "{stdout}\n{stderr}");
-    println!("{stdout}\n{stderr}");
 
     // Convert result formatted as "(1_000_000 : nat64)" to u64.
     let result = stdout

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -143,6 +143,7 @@ fn execution_instructions(arguments: ExecutionArguments) -> u64 {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(output.status.success(), "{stdout}\n{stderr}");
+    println!("{stdout}\n{stderr}");
 
     // Convert result formatted as "(1_000_000 : nat64)" to u64.
     let result = stdout

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -233,7 +233,7 @@ where
             if let Ok(idx) = root.search(&key) {
                 // The key exists. Overwrite it and return the previous value.
                 let (_, previous_value) = root.swap_entry(idx, (key, value));
-                root.save(self.memory());
+                root.save();
                 return Some(V::from_bytes(Cow::Owned(previous_value)));
             }
 
@@ -279,7 +279,7 @@ where
                 // Overwrite it and return the previous value.
                 let (_, previous_value) = node.swap_entry(idx, (key, value));
 
-                node.save(self.memory());
+                node.save();
                 Some(previous_value)
             }
             Err(idx) => {
@@ -290,7 +290,7 @@ where
                         // The node is a non-full leaf.
                         // Insert the entry at the proper location.
                         node.insert_entry(idx, (key, value));
-                        node.save(self.memory());
+                        node.save();
 
                         // Update the length.
                         self.length += 1;
@@ -309,7 +309,7 @@ where
                             if let Ok(idx) = child.search(&key) {
                                 // The key exists. Overwrite it and return the previous value.
                                 let (_, previous_value) = child.swap_entry(idx, (key, value));
-                                child.save(self.memory());
+                                child.save();
                                 return Some(previous_value);
                             }
 
@@ -367,9 +367,9 @@ where
 
         node.insert_entry(full_child_idx, (median_key, median_value));
 
-        sibling.save(self.memory());
-        full_child.save(self.memory());
-        node.save(self.memory());
+        sibling.save();
+        full_child.save();
+        node.save();
     }
 
     /// Returns the value associated with the given key if it exists.
@@ -492,7 +492,7 @@ where
                             self.allocator.deallocate(node.address());
                             self.root_addr = NULL;
                         } else {
-                            node.save(self.memory());
+                            node.save();
                         }
 
                         self.save();
@@ -537,7 +537,7 @@ where
                             let (_, old_value) = node.swap_entry(idx, predecessor);
 
                             // Save the parent node.
-                            node.save(self.memory());
+                            node.save();
                             return Some(old_value);
                         }
 
@@ -572,7 +572,7 @@ where
                             let (_, old_value) = node.swap_entry(idx, successor);
 
                             // Save the parent node.
-                            node.save(self.memory());
+                            node.save();
                             return Some(old_value);
                         }
 
@@ -617,8 +617,8 @@ where
                             self.save();
                         }
 
-                        node.save(self.memory());
-                        new_child.save(self.memory());
+                        node.save();
+                        new_child.save();
 
                         // Recursively delete the key.
                         self.remove_helper(new_child, key)
@@ -695,9 +695,9 @@ where
                                     assert_eq!(child.node_type(), NodeType::Leaf);
                                 }
 
-                                left_sibling.save(self.memory());
-                                child.save(self.memory());
-                                node.save(self.memory());
+                                left_sibling.save();
+                                child.save();
+                                node.save();
                                 return self.remove_helper(child, key);
                             }
                         }
@@ -747,9 +747,9 @@ where
                                     }
                                 }
 
-                                right_sibling.save(self.memory());
-                                child.save(self.memory());
-                                node.save(self.memory());
+                                right_sibling.save();
+                                child.save();
+                                node.save();
                                 return self.remove_helper(child, key);
                             }
                         }
@@ -774,7 +774,7 @@ where
                                     self.save();
                                 }
                             } else {
-                                node.save(self.memory());
+                                node.save();
                             }
 
                             return self.remove_helper(left_sibling, key);
@@ -799,7 +799,7 @@ where
                                     self.save();
                                 }
                             } else {
-                                node.save(self.memory());
+                                node.save();
                             }
 
                             return self.remove_helper(right_sibling, key);
@@ -1032,7 +1032,7 @@ where
 
         lower.set_address(into_address);
 
-        lower.save(self.memory());
+        lower.save();
 
         self.allocator.deallocate(source_address);
         lower

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -94,7 +94,7 @@ impl<K, V, M> BTreeMap<K, V, M>
 where
     K: BoundedStorable + Ord + Clone,
     V: BoundedStorable,
-    M: Memory + Clone,
+    M: Memory,
 {
     /// Initializes a `BTreeMap`.
     ///

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1821,28 +1821,28 @@ mod test {
         let mem = make_memory();
         let mut btree = BTreeMap::new(mem.clone());
 
-        for j in (0..=1).rev() {
-            for i in (0..=5).rev() {
+        for j in (0..=10).rev() {
+            for i in (0..=255).rev() {
                 assert_eq!(btree.insert(vec![i, j], vec![i, j]), None);
             }
         }
 
-        for j in 0..=1 {
-            for i in 0..=5 {
+        for j in 0..=10 {
+            for i in 0..=255 {
                 assert_eq!(btree.get(&vec![i, j]), Some(vec![i, j]));
             }
         }
 
         let mut btree = BTreeMap::load(mem);
 
-        for j in (0..=1).rev() {
-            for i in (0..=5).rev() {
+        for j in (0..=10).rev() {
+            for i in (0..=255).rev() {
                 assert_eq!(btree.remove(&vec![i, j]), Some(vec![i, j]));
             }
         }
 
-        for j in 0..=1 {
-            for i in 0..=5 {
+        for j in 0..=10 {
+            for i in 0..=255 {
                 assert_eq!(btree.get(&vec![i, j]), None);
             }
         }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -682,7 +682,6 @@ where
                                     .swap_entry(idx - 1, (left_sibling_key, left_sibling_value));
 
                                 // Move the entry from the parent into the child.
-                                println!("moving entry from parent into child");
                                 child.insert_entry(0, (parent_key, parent_value));
 
                                 // Move the last child from left sibling into child.
@@ -699,7 +698,6 @@ where
                                 left_sibling.save(self.memory());
                                 child.save(self.memory());
                                 node.save(self.memory());
-                                println!("REMOVE HELPER");
                                 return self.remove_helper(child, key);
                             }
                         }
@@ -1011,7 +1009,6 @@ where
     //   [1, 2, 3, 4, 5, 6, 7] (stored in the `into` node)
     //   `source` is deallocated.
     fn merge(&mut self, source: Node<K, M>, into: Node<K, M>, median: Entry<K>) -> Node<K, M> {
-        println!("merging");
         assert_eq!(source.node_type(), into.node_type());
         assert!(source.entries_len() > 0);
         assert!(into.entries_len() > 0);
@@ -1826,14 +1823,13 @@ mod test {
 
         for j in (0..=1).rev() {
             for i in (0..=5).rev() {
-                println!("INSERT");
                 assert_eq!(btree.insert(vec![i, j], vec![i, j]), None);
             }
         }
 
         for j in 0..=1 {
             for i in 0..=5 {
-//                assert_eq!(btree.get(&vec![i, j]), Some(vec![i, j]));
+                assert_eq!(btree.get(&vec![i, j]), Some(vec![i, j]));
             }
         }
 
@@ -1841,7 +1837,6 @@ mod test {
 
         for j in (0..=1).rev() {
             for i in (0..=5).rev() {
-                println!("REMOVE");
                 assert_eq!(btree.remove(&vec![i, j]), Some(vec![i, j]));
             }
         }

--- a/src/btreemap/iter.rs
+++ b/src/btreemap/iter.rs
@@ -40,7 +40,7 @@ impl<'a, K, V, M> Iter<'a, K, V, M>
 where
     K: BoundedStorable + Ord + Clone,
     V: BoundedStorable,
-    M: Memory + Clone,
+    M: Memory,
 {
     pub(crate) fn new(map: &'a BTreeMap<K, V, M>) -> Self {
         Self {
@@ -77,7 +77,7 @@ impl<K, V, M> Iterator for Iter<'_, K, V, M>
 where
     K: BoundedStorable + Ord + Clone,
     V: BoundedStorable,
-    M: Memory + Clone,
+    M: Memory,
 {
     type Item = (K, V);
 

--- a/src/btreemap/iter.rs
+++ b/src/btreemap/iter.rs
@@ -7,9 +7,9 @@ use std::borrow::Cow;
 use std::ops::{Bound, RangeBounds};
 
 /// An indicator of the current position in the map.
-pub(crate) enum Cursor<K: BoundedStorable + Ord + Clone> {
+pub(crate) enum Cursor<K: BoundedStorable + Ord + Clone, M: Memory + Clone> {
     Address(Address),
-    Node { node: Node<K>, next: Index },
+    Node { node: Node<K, M>, next: Index },
 }
 
 /// An index into a node's child or entry.
@@ -24,13 +24,13 @@ pub struct Iter<'a, K, V, M>
 where
     K: BoundedStorable + Ord + Clone,
     V: BoundedStorable,
-    M: Memory,
+    M: Memory + Clone,
 {
     // A reference to the map being iterated on.
     map: &'a BTreeMap<K, V, M>,
 
     // A stack of cursors indicating the current position in the tree.
-    cursors: Vec<Cursor<K>>,
+    cursors: Vec<Cursor<K, M>>,
 
     // The range of keys we want to traverse.
     range: (Bound<K>, Bound<K>),
@@ -40,7 +40,7 @@ impl<'a, K, V, M> Iter<'a, K, V, M>
 where
     K: BoundedStorable + Ord + Clone,
     V: BoundedStorable,
-    M: Memory,
+    M: Memory + Clone,
 {
     pub(crate) fn new(map: &'a BTreeMap<K, V, M>) -> Self {
         Self {
@@ -63,7 +63,7 @@ where
     pub(crate) fn new_in_range(
         map: &'a BTreeMap<K, V, M>,
         range: (Bound<K>, Bound<K>),
-        cursors: Vec<Cursor<K>>,
+        cursors: Vec<Cursor<K, M>>,
     ) -> Self {
         Self {
             map,
@@ -77,7 +77,7 @@ impl<K, V, M> Iterator for Iter<'_, K, V, M>
 where
     K: BoundedStorable + Ord + Clone,
     V: BoundedStorable,
-    M: Memory,
+    M: Memory + Clone,
 {
     type Item = (K, V);
 

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -149,7 +149,6 @@ impl<K: Storable + Ord + Clone, M: Memory + Clone> Node<K, M> {
     /// Saves the node to memory.
     // TODO: don't pass memory
     pub fn save(&self, memory: &M) {
-        println!("saving");
         match self.node_type {
             NodeType::Leaf => {
                 assert!(self.children.is_empty());
@@ -179,8 +178,6 @@ impl<K: Storable + Ord + Clone, M: Memory + Clone> Node<K, M> {
 
         let mut offset = NodeHeader::size();
 
-        println!("values: {:?}", self.encoded_values);
-
         // Load the values.
         let encoded_values: Vec<_> = (0..self.keys.len()).map(|i| Value::Loaded(self.value(i))).collect();
 
@@ -207,12 +204,6 @@ impl<K: Storable + Ord + Clone, M: Memory + Clone> Node<K, M> {
             let value = self.value(idx);
             write_u32(memory, self.address + offset, value.len() as u32);
             offset += U32_SIZE;
-            println!(
-                "writing key {:?} and value: {:?}, value idx: {}",
-                key.to_bytes().to_vec(),
-                value,
-                (self.address + offset).get()
-            );
             write(memory, (self.address + offset).get(), &value);
             offset += Bytes::from(self.max_value_size);
         }
@@ -367,7 +358,6 @@ impl<K: Storable + Ord + Clone, M: Memory + Clone> Node<K, M> {
 
     /// Inserts a new entry at the specified index.
     pub fn insert_entry(&mut self, idx: usize, (key, encoded_value): Entry<K>) {
-        println!("inserting {:?} at idx {:?}", key.to_bytes(), idx);
         self.keys.insert(idx, key);
         self.encoded_values
             .borrow_mut()
@@ -409,7 +399,6 @@ impl<K: Storable + Ord + Clone, M: Memory + Clone> Node<K, M> {
 
     /// Moves entries from the `other` node to the back of this node.
     pub fn append_entries_from(&mut self, other: &mut Node<K, M>) {
-        println!("appending entries");
         self.keys.append(&mut other.keys);
         self.encoded_values
             .borrow_mut()
@@ -482,7 +471,6 @@ impl<K: Storable + Ord + Clone, M: Memory + Clone> Node<K, M> {
 
     /// Moves elements from own node to a sibling node and returns the median element.
     pub fn split(&mut self, sibling: &mut Node<K, M>) -> Entry<K> {
-        println!("splitting");
         debug_assert!(self.is_full());
 
         // Move the entries and children above the median into the new sibling.

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -27,8 +27,7 @@ pub enum NodeType {
 
 pub type Entry<K> = (K, Vec<u8>);
 
-#[derive(Debug, PartialEq, Eq)] // TODO: these equals are wrong. Do we need partialeq and eq on the
-                                // node?
+#[derive(Debug)]
 enum Value {
     Ref(Address, u32),
     Loaded(Vec<u8>),
@@ -47,7 +46,7 @@ enum Value {
 ///     - value (`max_value_size` bytes)
 ///
 /// Each node can contain up to `CAPACITY + 1` children, each child is 8 bytes.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct Node<K: Storable + Ord + Clone, M: Memory + Clone> {
     address: Address,
     keys: Vec<K>,


### PR DESCRIPTION
Prior to this commit, all of the values in a BTreeMap's node were loaded every time the node is loaded. This is wasteful, as most values are untouched. This commit loads these values lazily, only loading those that are necessary upon access.

The improvement in performance is roughly 25% for `insert`, 50% for `get`, and 15% for `remove`.

Benchmarks compared to current `main` branch:

```
btreemap_insert_blob_4_1024
                        time:   [932.06 M Instructions 932.06 M Instructions 932.06 M Instructions]
                        change: [-34.049% -34.049% -34.049%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_8_1024
                        time:   [1071.5 M Instructions 1071.5 M Instructions 1071.5 M Instructions]
                        change: [-33.827% -33.827% -33.827%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_16_1024
                        time:   [1167.8 M Instructions 1167.8 M Instructions 1167.8 M Instructions]
                        change: [-31.288% -31.288% -31.288%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_32_1024
                        time:   [1212.1 M Instructions 1212.1 M Instructions 1212.1 M Instructions]
                        change: [-30.442% -30.442% -30.442%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_64_1024
                        time:   [1452.6 M Instructions 1452.6 M Instructions 1452.6 M Instructions]
                        change: [-28.669% -28.669% -28.669%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_128_1024
                        time:   [1712.5 M Instructions 1712.5 M Instructions 1712.5 M Instructions]
                        change: [-26.306% -26.306% -26.306%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_256_1024
                        time:   [2229.8 M Instructions 2229.8 M Instructions 2229.8 M Instructions]
                        change: [-22.774% -22.774% -22.774%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_512_1024
                        time:   [3293.6 M Instructions 3293.6 M Instructions 3293.6 M Instructions]
                        change: [-17.990% -17.990% -17.990%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_u64_u64 time:   [793.09 M Instructions 793.09 M Instructions 793.09 M Instructions]
                        change: [-16.062% -16.062% -16.062%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_u64_blob_8
                        time:   [764.01 M Instructions 764.01 M Instructions 764.01 M Instructions]
                        change: [-13.099% -13.099% -13.099%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_8_u64
                        time:   [671.58 M Instructions 671.58 M Instructions 671.58 M Instructions]
                        change: [-22.975% -22.975% -22.975%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_4_1024
                        time:   [421.40 M Instructions 421.40 M Instructions 421.40 M Instructions]
                        change: [-68.098% -68.098% -68.098%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_8_1024
                        time:   [486.29 M Instructions 486.29 M Instructions 486.29 M Instructions]
                        change: [-63.025% -63.025% -63.025%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_16_1024
                        time:   [569.50 M Instructions 569.50 M Instructions 569.50 M Instructions]
                        change: [-59.026% -59.026% -59.026%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_32_1024
                        time:   [600.68 M Instructions 600.68 M Instructions 600.68 M Instructions]
                        change: [-59.059% -59.059% -59.059%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_64_1024
                        time:   [824.92 M Instructions 824.92 M Instructions 824.92 M Instructions]
                        change: [-52.001% -52.001% -52.001%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_128_1024
                        time:   [1046.4 M Instructions 1046.4 M Instructions 1046.4 M Instructions]
                        change: [-46.366% -46.366% -46.366%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_u64_u64    time:   [418.74 M Instructions 418.74 M Instructions 418.74 M Instructions]
                        change: [-45.181% -45.181% -45.181%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_u64_blob_8 time:   [414.95 M Instructions 414.95 M Instructions 414.95 M Instructions]
                        change: [-40.735% -40.735% -40.735%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_8_u64 time:   [431.92 M Instructions 431.92 M Instructions 431.92 M Instructions]
                        change: [-42.806% -42.806% -42.806%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_256_1024
                        time:   [1536.4 M Instructions 1536.4 M Instructions 1536.4 M Instructions]
                        change: [-37.469% -37.469% -37.469%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_512_1024
                        time:   [2502.0 M Instructions 2502.0 M Instructions 2502.0 M Instructions]
                        change: [-27.221% -27.221% -27.221%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_4_1024
                        time:   [1012.6 M Instructions 1012.6 M Instructions 1012.6 M Instructions]
                        change: [-32.568% -32.568% -32.568%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_8_1024
                        time:   [1294.4 M Instructions 1294.4 M Instructions 1294.4 M Instructions]
                        change: [-25.146% -25.146% -25.146%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_16_1024
                        time:   [1540.5 M Instructions 1540.5 M Instructions 1540.5 M Instructions]
                        change: [-20.442% -20.442% -20.442%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_32_1024
                        time:   [1617.2 M Instructions 1617.2 M Instructions 1617.2 M Instructions]
                        change: [-19.033% -19.033% -19.033%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_64_1024
                        time:   [1914.7 M Instructions 1914.7 M Instructions 1914.7 M Instructions]
                        change: [-16.063% -16.063% -16.063%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_128_1024
                        time:   [2235.5 M Instructions 2235.5 M Instructions 2235.5 M Instructions]
                        change: [-13.275% -13.275% -13.275%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_256_1024
                        time:   [2842.6 M Instructions 2842.6 M Instructions 2842.6 M Instructions]
                        change: [-11.722% -11.722% -11.722%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_512_1024
                        time:   [4136.0 M Instructions 4136.0 M Instructions 4136.0 M Instructions]
                        change: [-7.2807% -7.2807% -7.2807%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_u64_u64 time:   [1125.0 M Instructions 1125.0 M Instructions 1125.0 M Instructions]
                        change: [-2.2258% -2.2258% -2.2258%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_u64_blob_8
                        time:   [1080.4 M Instructions 1080.4 M Instructions 1080.4 M Instructions]
                        change: [+0.2331% +0.2331% +0.2331%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_blob_8_u64
                        time:   [890.69 M Instructions 890.69 M Instructions 890.69 M Instructions]
                        change: [-12.373% -12.373% -12.373%] (p = 0.00 < 0.05)
                        Performance has improved.
```