### PR TITLE
perf: do not makes `Bytes` packed.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -45,7 +45,6 @@ impl AddAssign<Bytes> for Address {
     }
 }
 
-#[repr(C, packed)]
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct Bytes(u64);
 


### PR DESCRIPTION
This is a micro optimization where we no longer require `Bytes` to have a `packed` representation. This allows the Rust compiler to remove the overhead of this type completely during the compilation process. The net result is that performance improves by ~3% all around, and almost by %5 in some cases. Not bad for a one-line optimization.

```
btreemap_insert_blob_4_1024
                        time:   [902.82 M Instructions 902.82 M Instructions 902.82 M Instructions]
                        change: [-3.0126% -3.0126% -3.0126%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_8_1024
                        time:   [1040.8 M Instructions 1040.8 M Instructions 1040.8 M Instructions]
                        change: [-2.8112% -2.8112% -2.8112%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_16_1024
                        time:   [1136.5 M Instructions 1136.5 M Instructions 1136.5 M Instructions]
                        change: [-2.6323% -2.6323% -2.6323%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_32_1024
                        time:   [1180.3 M Instructions 1180.3 M Instructions 1180.3 M Instructions]
                        change: [-2.5855% -2.5855% -2.5855%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_64_1024
                        time:   [1420.0 M Instructions 1420.0 M Instructions 1420.0 M Instructions]
                        change: [-2.1716% -2.1716% -2.1716%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_128_1024
                        time:   [1679.8 M Instructions 1679.8 M Instructions 1679.8 M Instructions]
                        change: [-1.8489% -1.8489% -1.8489%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_256_1024
                        time:   [2196.8 M Instructions 2196.8 M Instructions 2196.8 M Instructions]
                        change: [-1.4272% -1.4272% -1.4272%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_512_1024
                        time:   [3257.9 M Instructions 3257.9 M Instructions 3257.9 M Instructions]
                        change: [-0.9633% -0.9633% -0.9633%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_u64_u64 time:   [756.97 M Instructions 756.97 M Instructions 756.97 M Instructions]
                        change: [-3.9940% -3.9940% -3.9940%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_u64_blob_8
                        time:   [729.82 M Instructions 729.82 M Instructions 729.82 M Instructions]
                        change: [-4.1532% -4.1532% -4.1532%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_insert_blob_8_u64
                        time:   [642.09 M Instructions 642.09 M Instructions 642.09 M Instructions]
                        change: [-4.4614% -4.4614% -4.4614%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_4_1024
                        time:   [396.58 M Instructions 396.58 M Instructions 396.58 M Instructions]
                        change: [-4.2928% -4.2928% -4.2928%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_8_1024
                        time:   [462.52 M Instructions 462.52 M Instructions 462.52 M Instructions]
                        change: [-3.5672% -3.5672% -3.5672%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_16_1024
                        time:   [545.06 M Instructions 545.06 M Instructions 545.06 M Instructions]
                        change: [-3.1284% -3.1284% -3.1284%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_32_1024
                        time:   [575.75 M Instructions 575.75 M Instructions 575.75 M Instructions]
                        change: [-3.0222% -3.0222% -3.0222%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_64_1024
                        time:   [799.59 M Instructions 799.59 M Instructions 799.59 M Instructions]
                        change: [-2.2283% -2.2283% -2.2283%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_128_1024
                        time:   [1021.2 M Instructions 1021.2 M Instructions 1021.2 M Instructions]
                        change: [-1.7451% -1.7451% -1.7451%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_u64_u64    time:   [393.51 M Instructions 393.51 M Instructions 393.51 M Instructions]
                        change: [-4.3975% -4.3975% -4.3975%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_u64_blob_8 time:   [389.66 M Instructions 389.66 M Instructions 389.66 M Instructions]
                        change: [-4.4480% -4.4480% -4.4480%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_8_u64 time:   [407.98 M Instructions 407.98 M Instructions 407.98 M Instructions]
                        change: [-4.0522% -4.0522% -4.0522%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_256_1024
                        time:   [1511.0 M Instructions 1511.0 M Instructions 1511.0 M Instructions]
                        change: [-1.1933% -1.1933% -1.1933%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_get_blob_512_1024
                        time:   [2476.6 M Instructions 2476.6 M Instructions 2476.6 M Instructions]
                        change: [-0.7319% -0.7319% -0.7319%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_blob_4_1024
                        time:   [984.03 M Instructions 984.03 M Instructions 984.03 M Instructions]
                        change: [-3.2584% -3.2584% -3.2584%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_8_1024
                        time:   [1261.0 M Instructions 1261.0 M Instructions 1261.0 M Instructions]
                        change: [-3.1125% -3.1125% -3.1125%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_16_1024
                        time:   [1504.9 M Instructions 1504.9 M Instructions 1504.9 M Instructions]
                        change: [-2.8981% -2.8981% -2.8981%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_32_1024
                        time:   [1579.8 M Instructions 1579.8 M Instructions 1579.8 M Instructions]
                        change: [-2.8446% -2.8446% -2.8446%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_64_1024
                        time:   [1874.1 M Instructions 1874.1 M Instructions 1874.1 M Instructions]
                        change: [-2.4584% -2.4584% -2.4584%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_128_1024
                        time:   [2196.8 M Instructions 2196.8 M Instructions 2196.8 M Instructions]
                        change: [-2.1279% -2.1279% -2.1279%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_256_1024
                        time:   [2806.5 M Instructions 2806.5 M Instructions 2806.5 M Instructions]
                        change: [-1.6459% -1.6459% -1.6459%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_512_1024
                        time:   [4102.6 M Instructions 4102.6 M Instructions 4102.6 M Instructions]
                        change: [-1.1478% -1.1478% -1.1478%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_u64_u64 time:   [1087.0 M Instructions 1087.0 M Instructions 1087.0 M Instructions]
                        change: [-4.1713% -4.1713% -4.1713%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_u64_blob_8
                        time:   [1045.4 M Instructions 1045.4 M Instructions 1045.4 M Instructions]
                        change: [-4.2803% -4.2803% -4.2803%] (p = 0.00 < 0.05)
                        Performance has improved.

btreemap_remove_blob_8_u64
                        time:   [858.01 M Instructions 858.01 M Instructions 858.01 M Instructions]
                        change: [-4.6366% -4.6366% -4.6366%] (p = 0.00 < 0.05)
                        Performance has improved.

```