### PR TITLE
chore: Ignore Jetbrains and VSCode config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 **/target
 **/.dfx
+
+# Various IDEs and Editors
+.vscode/
+.idea/
+**/*~


### PR DESCRIPTION
# Motivation

I use Jetbrains which displays its config files as git diff. This PR adds common editor ignore entries to `.gitignore`.