### PR TITLE
feat: stable min heap data structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install DFX
         run: |
           wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-          DFX_VERSION=${DFX_VERSION:=0.14.0} bash install-dfx.sh < <(yes Y)
+          DFX_VERSION=${DFX_VERSION:=0.14.1} bash install-dfx.sh < <(yes Y)
           rm install-dfx.sh
           dfx cache install
           echo "$HOME/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install DFX
         run: |
           wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-          DFX_VERSION=${DFX_VERSION:=0.11.2} bash install-dfx.sh < <(yes Y)
+          DFX_VERSION=${DFX_VERSION:=0.14.0} bash install-dfx.sh < <(yes Y)
           rm install-dfx.sh
           dfx cache install
           echo "$HOME/bin" >> $GITHUB_PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.5] - Unreleased
+
+### Added
+- The `MinHeap` stable data structure (#91)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For more information about the philosophy behind the library, see [Roman's tutor
 - [Vec]: A growable array
 - [Log]: An append-only list of variable-size entries
 - [Cell]: A serializable value
+- [MinHeap]: A priority queue.
 
 ## How it Works
 
@@ -94,7 +95,7 @@ Dependencies:
 [dependencies]
 ic-cdk = "0.6.8"
 ic-cdk-macros = "0.6.8"
-ic-stable-structures = "0.5.4"
+ic-stable-structures = "0.5.5"
 ```
 
 Code:

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -900,6 +900,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "task_timer"
+version = "0.2.0"
+dependencies = [
+ "candid",
+ "ic-cdk",
+ "ic-cdk-macros",
+ "ic-stable-structures",
+ "ic0",
+]
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,4 +4,5 @@ members = [
     "src/vecs_and_strings",
     "src/custom_types_example",
     "src/quick_start",
+    "src/task_timer",
 ]

--- a/examples/dfx.json
+++ b/examples/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.14.0",
+  "dfx": "0.14.1",
   "canisters": {
     "quick_start": {
       "candid": "src/quick_start/candid.did",

--- a/examples/dfx.json
+++ b/examples/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.11.2",
+  "dfx": "0.14.0",
   "canisters": {
     "quick_start": {
       "candid": "src/quick_start/candid.did",
@@ -19,6 +19,11 @@
     "custom_types_example": {
       "candid": "src/custom_types_example/candid.did",
       "package": "custom_types_example",
+      "type": "rust"
+    },
+    "task_timer": {
+      "candid": "src/task_timer/candid.did",
+      "package": "task_timer",
       "type": "rust"
     }
   },

--- a/examples/src/task_timer/Cargo.toml
+++ b/examples/src/task_timer/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "task_timer"
+version = "0.2.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = "0.8.4"
+ic0 = "0.18"
+ic-cdk = "0.6.10"
+ic-cdk-macros = "0.6.10"
+ic-stable-structures = { path = "../../../" }

--- a/examples/src/task_timer/candid.did
+++ b/examples/src/task_timer/candid.did
@@ -1,0 +1,3 @@
+service : () -> {
+    schedule_task : (after_sec : nat64) -> ();
+}

--- a/examples/src/task_timer/src/lib.rs
+++ b/examples/src/task_timer/src/lib.rs
@@ -1,0 +1,62 @@
+//! An example showcasing how to use a MinHeap for scheduled tasks.
+use ic_cdk_macros::{post_upgrade, update};
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::{DefaultMemoryImpl, StableMinHeap};
+use std::cell::RefCell;
+
+type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+thread_local! {
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+
+    static TASKS: RefCell<StableMinHeap<u64, Memory>> =
+        MEMORY_MANAGER.with(|mm|
+            RefCell::new(
+                StableMinHeap::init(mm.borrow().get(MemoryId::new(1)))
+                .expect("failed to initialize the tasks"))
+        );
+}
+
+#[post_upgrade]
+fn post_upgrade() {
+    reschedule();
+}
+
+#[update]
+fn schedule_task(after_sec: u64) {
+    let task_time = ic_cdk::api::time() + after_sec * 1_000_000_000;
+    TASKS.with(|t| {
+        t.borrow_mut()
+            .push(&task_time)
+            .expect("failed to schedule a task")
+    });
+    reschedule();
+}
+
+#[export_name = "canister_global_timer"]
+fn timer() {
+    let now = ic_cdk::api::time();
+    while let Some(task_time) = TASKS.with(|t| t.borrow().peek()) {
+        if task_time > now {
+            reschedule();
+            return;
+        }
+        let _ = TASKS.with(|t| t.borrow_mut().pop());
+
+        execute_task(task_time, now);
+        reschedule();
+    }
+}
+
+fn execute_task(scheduled_at: u64, now: u64) {
+    ic_cdk::println!("executing task scheculed at {scheduled_at}, current time is {now}");
+}
+
+fn reschedule() {
+    if let Some(task_time) = TASKS.with(|t| t.borrow().peek()) {
+        unsafe {
+            ic0::global_timer_set(task_time as i64);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,8 @@ impl Display for GrowFailed {
         write!(
             f,
             "Failed to grow memory: current size={}, delta={}",
-            self.current_size, self.delta
+            self.current_size,
+            self.delta
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod ic0_memory; // Memory API for canisters.
 pub mod log;
 pub use log::{Log as StableLog, Log};
 pub mod memory_manager;
+pub mod min_heap;
 pub mod reader;
 pub mod storable;
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod storable;
 mod tests;
 mod types;
 pub mod vec;
-pub use min_heap::MinHeap as StableMinHeap;
+pub use min_heap::{MinHeap, MinHeap as StableMinHeap};
 pub use vec::{Vec as StableVec, Vec};
 pub mod vec_mem;
 pub mod writer;
@@ -97,8 +97,7 @@ impl Display for GrowFailed {
         write!(
             f,
             "Failed to grow memory: current size={}, delta={}",
-            self.current_size,
-            self.delta
+            self.current_size, self.delta
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod storable;
 mod tests;
 mod types;
 pub mod vec;
+pub use min_heap::MinHeap as StableMinHeap;
 pub use vec::{Vec as StableVec, Vec};
 pub mod vec_mem;
 pub mod writer;
@@ -96,8 +97,7 @@ impl Display for GrowFailed {
         write!(
             f,
             "Failed to grow memory: current size={}, delta={}",
-            self.current_size,
-            self.delta
+            self.current_size, self.delta
         )
     }
 }

--- a/src/min_heap.rs
+++ b/src/min_heap.rs
@@ -136,7 +136,7 @@ where
             }
 
             if n <= r {
-                // Only the left child is withing the array bounds.
+                // Only the left child is within the array bounds.
 
                 let left = self.0.get(l).unwrap();
                 if is_less(&left, item) {
@@ -145,7 +145,7 @@ where
                     continue;
                 }
             } else {
-                // Both children are withing the array bounds.
+                // Both children are within the array bounds.
 
                 let left = self.0.get(l).unwrap();
                 let right = self.0.get(r).unwrap();

--- a/src/min_heap.rs
+++ b/src/min_heap.rs
@@ -1,0 +1,140 @@
+use crate::base_vec::{BaseVec, InitError};
+use crate::storable::BoundedStorable;
+use crate::{GrowFailed, Memory};
+
+const MAGIC: [u8; 3] = *b"SHP"; // Short for "stable heap".
+
+/// An implementation of a binary heap.
+///
+/// Contrary to [std::collections::BinaryHeap], this heap is a min-heap (smallest items come first).
+/// Motivation: max heaps are helpful for sorting, but most daily programming tasks require min
+/// heaps.
+pub struct MinHeap<T: BoundedStorable + PartialOrd, M: Memory>(BaseVec<T, M>);
+
+impl<T, M> MinHeap<T, M>
+where
+    T: BoundedStorable + PartialOrd,
+    M: Memory,
+{
+    /// Creates a new empty heap in the specified memory,
+    /// overwriting any data structures the memory might have
+    /// contained.
+    ///
+    /// Complexity: O(1)
+    pub fn new(memory: M) -> Result<Self, GrowFailed> {
+        BaseVec::<T, M>::new(memory, MAGIC).map(Self)
+    }
+
+    /// Initializes a heap in the specified memory.
+    ///
+    /// Complexity: O(1)
+    ///
+    /// PRECONDITION: the memory is either empty or contains a valid
+    /// stable heap.
+    pub fn init(memory: M) -> Result<Self, InitError> {
+        BaseVec::<T, M>::init(memory, MAGIC).map(Self)
+    }
+
+    pub fn len(&self) -> u64 {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Pushes an item onto the min heap.
+    pub fn push(&mut self, item: &T) -> Result<(), GrowFailed> {
+        self.0.push(item)?;
+        debug_assert!(!self.is_empty());
+        self.bubble_up(self.0.len().saturating_sub(1), item);
+        debug_assert_eq!(Ok(()), self.check_invariant());
+        Ok(())
+    }
+
+    /// Removes the smallest item from the heap and returns it.
+    /// Returns `None` if the heap is empty.
+    pub fn pop(&mut self) -> Option<T> {
+        let n = self.len();
+        match n {
+            0 => None,
+            1 => self.0.pop(),
+            _more => {
+                let smallest = self.0.get(0).unwrap();
+                let last = self.0.pop().unwrap();
+                self.0.set(0, &last);
+                self.bubble_down(0, n, &last);
+                debug_assert_eq!(Ok(()), self.check_invariant());
+                Some(smallest)
+            }
+        }
+    }
+
+    /// Returns the smallest item in the heap.
+    /// Returns `None` if the heap is empty.
+    pub fn peek(&self) -> Option<T> {
+        self.0.get(0)
+    }
+
+    /// Returns an iterator visiting all values in the underlying vector, in arbitrary order.
+    pub fn iter(&self) -> impl Iterator<Item = T> + '_ {
+        self.0.iter()
+    }
+
+    #[cfg(debug_assertions)]
+    fn check_invariant(&self) -> Result<(), String> {
+        let n = self.len();
+        for i in (1..n).rev() {
+            let p = (i - 1) / 2;
+            let item = self.0.get(i).unwrap();
+            let parent = self.0.get(p).unwrap();
+            if parent.partial_cmp(&item) == Some(std::cmp::Ordering::Greater) {
+                return Err(format!(
+                    "Binary heap invariant violated in indices {i} and {p}"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn bubble_up(&mut self, mut i: u64, item: &T) {
+        // LOOP INVARIANT: self.0.get(i) == item
+        while i > 0 {
+            let p = (i - 1) / 2;
+            let parent = self.0.get(i).unwrap();
+            if item.partial_cmp(&parent) == Some(std::cmp::Ordering::Less) {
+                self.0.set(i, &parent);
+                self.0.set(p, item);
+            }
+            i = p;
+        }
+    }
+
+    fn bubble_down(&mut self, mut i: u64, n: u64, item: &T) {
+        // LOOP INVARIANT: self.0.get(i) == item
+        loop {
+            let l = i * 2 + 1;
+            if n <= l {
+                return;
+            }
+            let child = self.0.get(l).unwrap();
+            if child.partial_cmp(item) == Some(std::cmp::Ordering::Less) {
+                self.0.set(i, &child);
+                self.0.set(l, item);
+                i = l;
+                continue;
+            }
+
+            let r = l + 1;
+            if n <= r {
+                return;
+            }
+            let child = self.0.get(r).unwrap();
+            if child.partial_cmp(item) == Some(std::cmp::Ordering::Less) {
+                self.0.set(i, &child);
+                self.0.set(r, item);
+                i = r;
+            }
+        }
+    }
+}

--- a/src/min_heap.rs
+++ b/src/min_heap.rs
@@ -8,11 +8,10 @@ mod tests;
 
 const MAGIC: [u8; 3] = *b"SMH"; // Short for "stable min heap".
 
-/// An implementation of a binary heap.
-///
-/// Contrary to [std::collections::BinaryHeap], this heap is a min-heap (smallest items come first).
-/// Motivation: max heaps are helpful for sorting, but most daily programming tasks require min
-/// heaps.
+/// An implementation of the [binary min heap](https://en.wikipedia.org/wiki/Binary_heap).
+// NB. Contrary to [std::collections::BinaryHeap], this heap is a min-heap (smallest items come first).
+// Motivation: max heaps are helpful for sorting, but most daily programming tasks require min
+// heaps.
 pub struct MinHeap<T: BoundedStorable + PartialOrd, M: Memory>(BaseVec<T, M>);
 
 // Note: Heap Invariant

--- a/src/min_heap.rs
+++ b/src/min_heap.rs
@@ -1,8 +1,12 @@
 use crate::base_vec::{BaseVec, InitError};
 use crate::storable::BoundedStorable;
 use crate::{GrowFailed, Memory};
+use std::fmt;
 
-const MAGIC: [u8; 3] = *b"SHP"; // Short for "stable heap".
+#[cfg(test)]
+mod tests;
+
+const MAGIC: [u8; 3] = *b"SMH"; // Short for "stable min heap".
 
 /// An implementation of a binary heap.
 ///
@@ -10,6 +14,12 @@ const MAGIC: [u8; 3] = *b"SHP"; // Short for "stable heap".
 /// Motivation: max heaps are helpful for sorting, but most daily programming tasks require min
 /// heaps.
 pub struct MinHeap<T: BoundedStorable + PartialOrd, M: Memory>(BaseVec<T, M>);
+
+// Note: Heap Invariant
+// ~~~~~~~~~~~~~~~~~~~~
+//
+// HeapInvariant(heap, i, j) :=
+//   ∀ k: i ≤ k ≤ j: LET p = (k - 1)/2 IN (p ≤ i) => heap[p] ≤ heap[k]
 
 impl<T, M> MinHeap<T, M>
 where
@@ -46,8 +56,7 @@ where
     /// Pushes an item onto the min heap.
     pub fn push(&mut self, item: &T) -> Result<(), GrowFailed> {
         self.0.push(item)?;
-        debug_assert!(!self.is_empty());
-        self.bubble_up(self.0.len().saturating_sub(1), item);
+        self.bubble_up(self.0.len() - 1, item);
         debug_assert_eq!(Ok(()), self.check_invariant());
         Ok(())
     }
@@ -63,7 +72,7 @@ where
                 let smallest = self.0.get(0).unwrap();
                 let last = self.0.pop().unwrap();
                 self.0.set(0, &last);
-                self.bubble_down(0, n, &last);
+                self.bubble_down(0, n - 1, &last);
                 debug_assert_eq!(Ok(()), self.check_invariant());
                 Some(smallest)
             }
@@ -81,14 +90,19 @@ where
         self.0.iter()
     }
 
-    #[cfg(debug_assertions)]
+    pub fn into_memory(self) -> M {
+        self.0.into_memory()
+    }
+
+    #[allow(dead_code)]
+    /// Checks the HeapInvariant(self, 0, self.len() - 1)
     fn check_invariant(&self) -> Result<(), String> {
         let n = self.len();
-        for i in (1..n).rev() {
+        for i in 1..n {
             let p = (i - 1) / 2;
             let item = self.0.get(i).unwrap();
             let parent = self.0.get(p).unwrap();
-            if parent.partial_cmp(&item) == Some(std::cmp::Ordering::Greater) {
+            if is_less(&item, &parent) {
                 return Err(format!(
                     "Binary heap invariant violated in indices {i} and {p}"
                 ));
@@ -99,10 +113,11 @@ where
 
     fn bubble_up(&mut self, mut i: u64, item: &T) {
         // LOOP INVARIANT: self.0.get(i) == item
+        //                 ∧ HeapInvariant(self, i, self.len() - 1)
         while i > 0 {
             let p = (i - 1) / 2;
-            let parent = self.0.get(i).unwrap();
-            if item.partial_cmp(&parent) == Some(std::cmp::Ordering::Less) {
+            let parent = self.0.get(p).unwrap();
+            if is_less(item, &parent) {
                 self.0.set(i, &parent);
                 self.0.set(p, item);
             }
@@ -111,30 +126,65 @@ where
     }
 
     fn bubble_down(&mut self, mut i: u64, n: u64, item: &T) {
-        // LOOP INVARIANT: self.0.get(i) == item
+        // LOOP INVARIANT: ∧ self.0.get(i) == item
+        //                 ∧ HeapInvariant(self, 0, i)
         loop {
             let l = i * 2 + 1;
+            let r = l + 1;
+
             if n <= l {
                 return;
             }
-            let child = self.0.get(l).unwrap();
-            if child.partial_cmp(item) == Some(std::cmp::Ordering::Less) {
-                self.0.set(i, &child);
-                self.0.set(l, item);
-                i = l;
-                continue;
-            }
 
-            let r = l + 1;
             if n <= r {
-                return;
+                // Only the left child is withing the array bounds.
+
+                let child = self.0.get(l).unwrap();
+                if is_less(&child, item) {
+                    self.0.set(i, &child);
+                    self.0.set(l, item);
+                    i = l;
+                    continue;
+                }
+            } else {
+                // Both children are withing the array bounds.
+
+                let left = self.0.get(l).unwrap();
+                let right = self.0.get(r).unwrap();
+
+                if is_less(&left, item) {
+                    if is_less(&right, &left) {
+                        self.0.set(i, &right);
+                        self.0.set(r, item);
+                        i = r;
+                    } else {
+                        self.0.set(i, &left);
+                        self.0.set(l, item);
+                        i = l;
+                    }
+                    continue;
+                } else if is_less(&right, item) {
+                    self.0.set(i, &right);
+                    self.0.set(r, item);
+                    i = r;
+                    continue;
+                }
             }
-            let child = self.0.get(r).unwrap();
-            if child.partial_cmp(item) == Some(std::cmp::Ordering::Less) {
-                self.0.set(i, &child);
-                self.0.set(r, item);
-                i = r;
-            }
+            return;
         }
+    }
+}
+
+fn is_less<T: PartialOrd>(x: &T, y: &T) -> bool {
+    x.partial_cmp(y) == Some(std::cmp::Ordering::Less)
+}
+
+impl<T, M> fmt::Debug for MinHeap<T, M>
+where
+    T: BoundedStorable + PartialOrd + fmt::Debug,
+    M: Memory,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(fmt)
     }
 }

--- a/src/min_heap.rs
+++ b/src/min_heap.rs
@@ -170,8 +170,8 @@ where
     }
 
     fn swap(&mut self, i: u64, x: &T, j: u64, y: &T) {
-        self.0.set(i, &y);
-        self.0.set(j, &x);
+        self.0.set(i, y);
+        self.0.set(j, x);
     }
 }
 

--- a/src/min_heap.rs
+++ b/src/min_heap.rs
@@ -118,8 +118,7 @@ where
             let p = (i - 1) / 2;
             let parent = self.0.get(p).unwrap();
             if is_less(item, &parent) {
-                self.0.set(i, &parent);
-                self.0.set(p, item);
+                self.swap(i, item, p, &parent);
             }
             i = p;
         }
@@ -139,10 +138,9 @@ where
             if n <= r {
                 // Only the left child is withing the array bounds.
 
-                let child = self.0.get(l).unwrap();
-                if is_less(&child, item) {
-                    self.0.set(i, &child);
-                    self.0.set(l, item);
+                let left = self.0.get(l).unwrap();
+                if is_less(&left, item) {
+                    self.swap(i, item, l, &left);
                     i = l;
                     continue;
                 }
@@ -154,24 +152,26 @@ where
 
                 if is_less(&left, item) {
                     if is_less(&right, &left) {
-                        self.0.set(i, &right);
-                        self.0.set(r, item);
+                        self.swap(i, item, r, &right);
                         i = r;
                     } else {
-                        self.0.set(i, &left);
-                        self.0.set(l, item);
+                        self.swap(i, item, l, &left);
                         i = l;
                     }
                     continue;
                 } else if is_less(&right, item) {
-                    self.0.set(i, &right);
-                    self.0.set(r, item);
+                    self.swap(i, item, r, &right);
                     i = r;
                     continue;
                 }
             }
             return;
         }
+    }
+
+    fn swap(&mut self, i: u64, x: &T, j: u64, y: &T) {
+        self.0.set(i, &y);
+        self.0.set(j, &x);
     }
 }
 

--- a/src/min_heap/tests.rs
+++ b/src/min_heap/tests.rs
@@ -1,0 +1,130 @@
+use super::{InitError, MinHeap as StableMinHeap};
+use crate::vec_mem::VectorMemory as M;
+use crate::{GrowFailed, Memory};
+use proptest::collection::vec as pvec;
+use proptest::prelude::*;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::fmt::Debug;
+
+#[derive(Debug, PartialEq, Clone)]
+enum Operation<T> {
+    Push(T),
+    Pop,
+}
+
+fn arb_op<T: Clone + Debug>(s: impl Strategy<Value = T>) -> impl Strategy<Value = Operation<T>> {
+    prop_oneof![
+        3 => s.prop_map(Operation::Push),
+        1 => Just(Operation::Pop),
+    ]
+}
+
+proptest! {
+    #[test]
+    fn push_pop_model_u64(ops in pvec(arb_op(any::<u64>()), 40)) {
+        let mut h = BinaryHeap::new();
+        let mut sh = StableMinHeap::<u64, M>::new(M::default()).unwrap();
+
+        for op in ops {
+            match op {
+                Operation::Push(x) => {
+                    sh.push(&x).unwrap();
+                    h.push(Reverse(x));
+                }
+                Operation::Pop => {
+                    prop_assert_eq!(sh.pop(), h.pop().map(|Reverse(x)| x));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn pop_sorted(mut items in pvec(any::<u64>(), 0..50)) {
+        let mut sh = StableMinHeap::<u64, M>::new(M::default()).unwrap();
+        for x in &items {
+            sh.push(x).unwrap();
+        }
+        items.sort();
+        for x in items {
+            prop_assert_eq!(Some(x), sh.pop());
+        }
+    }
+}
+
+#[test]
+fn test_simple_case() {
+    let mut h = StableMinHeap::<u64, M>::new(M::default()).unwrap();
+    assert_eq!(h.pop(), None);
+    h.push(&0).unwrap();
+    h.push(&3).unwrap();
+    h.push(&0).unwrap();
+    h.push(&1).unwrap();
+    assert_eq!(h.pop(), Some(0));
+    assert_eq!(h.pop(), Some(0));
+    assert_eq!(h.pop(), Some(1));
+    assert_eq!(h.pop(), Some(3));
+    assert_eq!(h.len(), 0);
+    assert!(h.is_empty());
+}
+
+#[test]
+fn test_init_type_compatibility() {
+    let h = StableMinHeap::<u64, M>::new(M::default()).unwrap();
+
+    assert_eq!(
+        StableMinHeap::<u32, M>::init(h.into_memory()).unwrap_err(),
+        InitError::IncompatibleElementType
+    );
+}
+
+#[test]
+fn test_init_failures() {
+    struct EmptyMem;
+    impl Memory for EmptyMem {
+        fn size(&self) -> u64 {
+            0
+        }
+        fn grow(&self, _: u64) -> i64 {
+            -1
+        }
+        fn read(&self, _: u64, _: &mut [u8]) {
+            panic!("out of bounds")
+        }
+        fn write(&self, _: u64, _: &[u8]) {
+            panic!("out of bounds")
+        }
+    }
+
+    assert_eq!(
+        StableMinHeap::<u64, EmptyMem>::new(EmptyMem).unwrap_err(),
+        GrowFailed {
+            current_size: 0,
+            delta: 1
+        }
+    );
+
+    assert_eq!(
+        StableMinHeap::<u64, EmptyMem>::init(EmptyMem).unwrap_err(),
+        InitError::OutOfMemory,
+    );
+
+    let mem = M::default();
+    mem.grow(1);
+    mem.write(0, b"SVC\x01\x08\x00\x00\x00\x00\x00\x00\x00\x01");
+    assert_eq!(
+        StableMinHeap::<u64, M>::init(mem).unwrap_err(),
+        InitError::BadMagic {
+            actual: *b"SVC",
+            expected: *b"SMH"
+        },
+    );
+
+    let mem = M::default();
+    mem.grow(1);
+    mem.write(0, b"SMH\x0f\x08\x00\x00\x00\x00\x00\x00\x00\x01");
+    assert_eq!(
+        StableMinHeap::<u64, M>::init(mem).unwrap_err(),
+        InitError::IncompatibleVersion(15),
+    );
+}


### PR DESCRIPTION
This change introduces the `MinHeap` stable structure analogous to `std::collections::BinaryHeap`.
Contrary to `BinaryHeap`, `MinHeap` prioritizes smaller items, which I found much more useful in practice than prioritizing larger items.