### PR TITLE
chore: upgrade version to 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.5.5]
+## [0.5.5] - 2023-07-03
 
 ### Added
 - The `MinHeap` stable data structure (#91)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.5] - Unreleased
+## Unreleased
+
+## [0.5.5]
 
 ### Added
 - The `MinHeap` stable data structure (#91)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "criterion",
  "ic-cdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-stable-structures"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 description = "A collection of data structures for fearless canister upgrades."
 homepage = "https://docs.rs/ic-stable-structures"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.5.4"
+version = "0.5.5"
 
 [[package]]
 name = "ic0"


### PR DESCRIPTION
We've introduced a new min heap data structure in #91, and this version makes it accessible to our users.