### PR TITLE
fix: make `vec::InitError` public again

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -39,3 +39,12 @@ fn test_restricted_memory_rw() {
     mem.read(10, &mut buf[2..10]);
     assert_eq!(&buf[2..10], b"DEADBEEF");
 }
+
+#[test]
+#[ignore]
+fn vec_exposes_init_err() {
+    // Ensures that the `vec` module exposes `InitError` to avoid breaking
+    // clients that depend on it.
+    #[allow(unused_imports)]
+    use crate::vec::InitError;
+}

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,6 +1,7 @@
 //! This module implements a growable array in stable memory.
 
-use crate::base_vec::{BaseVec, InitError};
+use crate::base_vec::BaseVec;
+pub use crate::base_vec::InitError;
 use crate::storable::BoundedStorable;
 use crate::{GrowFailed, Memory};
 use std::fmt;


### PR DESCRIPTION
The refactoring of `vec` accidentally made `vec::InitError` private, which broke clients that upgraded to the latest stable structures release. See issue #98.

This commit makes `vec::InitError` public, and adds a test to ensure it always remains public.