### PR TITLE
chore: bump version to 0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "criterion",
  "ic-cdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-stable-structures"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 description = "A collection of data structures for fearless canister upgrades."
 homepage = "https://docs.rs/ic-stable-structures"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Dependencies:
 [dependencies]
 ic-cdk = "0.6.8"
 ic-cdk-macros = "0.6.8"
-ic-stable-structures = "0.5.5"
+ic-stable-structures = "0.5.6"
 ```
 
 Code:

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.5.5"
+version = "0.5.6"
 
 [[package]]
 name = "ic0"


### PR DESCRIPTION
Bumping the version is needed to roll out the fix in #100.