### PR TITLE
test: `Node::load` and `Node::save`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,7 @@ dependencies = [
  "maplit",
  "proptest",
  "tempfile",
+ "test-strategy",
 ]
 
 [[package]]
@@ -1256,6 +1257,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "structmeta"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,6 +1332,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-strategy"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = "1.4.0"
 maplit = "1.0.2"
 proptest = "1"
 tempfile = "3.3.0"
+test-strategy = "0.3.1"
 
 [[bench]]
 name = "benches"

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -7,6 +7,8 @@ use crate::{
 use std::borrow::{Borrow, Cow};
 use std::cell::{Ref, RefCell};
 
+#[cfg(test)]
+mod tests;
 mod v1;
 
 // The minimum degree to use in the btree.
@@ -341,7 +343,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
         assert_eq!(b.children.len(), 0);
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn entries<M: Memory>(&self, memory: &M) -> Vec<Entry<K>> {
         self.keys
             .iter()

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -7,6 +7,8 @@ use crate::{
 use std::borrow::{Borrow, Cow};
 use std::cell::{Ref, RefCell};
 
+mod v1;
+
 // The minimum degree to use in the btree.
 // This constant is taken from Rust's std implementation of BTreeMap.
 const B: usize = 6;
@@ -81,128 +83,14 @@ impl<K: Storable + Ord + Clone> Node<K> {
         max_key_size: u32,
         max_value_size: u32,
     ) -> Self {
-        // Load the header.
-        let header: NodeHeader = read_struct(address, memory);
-        assert_eq!(&header.magic, MAGIC, "Bad magic.");
-        assert_eq!(header.version, LAYOUT_VERSION, "Unsupported version.");
-
-        // Load the entries.
-        let mut keys = Vec::with_capacity(header.num_entries as usize);
-        let mut encoded_values = Vec::with_capacity(header.num_entries as usize);
-        let mut offset = NodeHeader::size();
-        let mut buf = Vec::with_capacity(max_key_size.max(max_value_size) as usize);
-        for _ in 0..header.num_entries {
-            // Read the key's size.
-            let key_size = read_u32(memory, address + offset);
-            offset += U32_SIZE;
-
-            // Read the key.
-            buf.resize(key_size as usize, 0);
-            memory.read((address + offset).get(), &mut buf);
-            offset += Bytes::from(max_key_size);
-            let key = K::from_bytes(Cow::Borrowed(&buf));
-            keys.push(key);
-
-            // Values are loaded lazily. Store a reference and skip loading it.
-            encoded_values.push(Value::ByRef(offset));
-            offset += U32_SIZE + Bytes::from(max_value_size);
-        }
-
-        // Load children if this is an internal node.
-        let mut children = vec![];
-        if header.node_type == INTERNAL_NODE_TYPE {
-            // The number of children is equal to the number of entries + 1.
-            for _ in 0..header.num_entries + 1 {
-                let child = Address::from(read_u64(memory, address + offset));
-                offset += Address::size();
-                children.push(child);
-            }
-
-            assert_eq!(children.len(), keys.len() + 1);
-        }
-
-        Self {
-            address,
-            keys,
-            encoded_values: RefCell::new(encoded_values),
-            children,
-            node_type: match header.node_type {
-                LEAF_NODE_TYPE => NodeType::Leaf,
-                INTERNAL_NODE_TYPE => NodeType::Internal,
-                other => unreachable!("Unknown node type {}", other),
-            },
-            max_key_size,
-            max_value_size,
-        }
+        // NOTE: new versions of `Node` will be introduced.
+        Self::load_v1(address, memory, max_key_size, max_value_size)
     }
 
     /// Saves the node to memory.
     pub fn save<M: Memory>(&self, memory: &M) {
-        match self.node_type {
-            NodeType::Leaf => {
-                assert!(self.children.is_empty());
-            }
-            NodeType::Internal => {
-                assert_eq!(self.children.len(), self.keys.len() + 1);
-            }
-        };
-
-        // We should never be saving an empty node.
-        assert!(!self.keys.is_empty() || !self.children.is_empty());
-
-        // Assert entries are sorted in strictly increasing order.
-        assert!(self.keys.windows(2).all(|e| e[0] < e[1]));
-
-        let header = NodeHeader {
-            magic: *MAGIC,
-            version: LAYOUT_VERSION,
-            node_type: match self.node_type {
-                NodeType::Leaf => LEAF_NODE_TYPE,
-                NodeType::Internal => INTERNAL_NODE_TYPE,
-            },
-            num_entries: self.keys.len() as u16,
-        };
-
-        write_struct(&header, self.address, memory);
-
-        let mut offset = NodeHeader::size();
-
-        // Load all the values. This is necessary so that we don't overwrite referenced
-        // values when writing the entries to the node.
-        for i in 0..self.keys.len() {
-            self.value(i, memory);
-        }
-
-        // Write the entries.
-        for (idx, key) in self.keys.iter().enumerate() {
-            // Write the size of the key.
-            let key_bytes = key.to_bytes();
-            write_u32(memory, self.address + offset, key_bytes.len() as u32);
-            offset += U32_SIZE;
-
-            // Write the key.
-            write(memory, (self.address + offset).get(), key_bytes.borrow());
-            offset += Bytes::from(self.max_key_size);
-
-            // Write the size of the value.
-            let value = self.value(idx, memory);
-            write_u32(memory, self.address + offset, value.len() as u32);
-            offset += U32_SIZE;
-
-            // Write the value.
-            write(memory, (self.address + offset).get(), &value);
-            offset += Bytes::from(self.max_value_size);
-        }
-
-        // Write the children
-        for child in self.children.iter() {
-            write(
-                memory,
-                (self.address + offset).get(),
-                &child.get().to_le_bytes(),
-            );
-            offset += Address::size();
-        }
+        // NOTE: new versions of `Node` will be introduced.
+        self.save_v1(memory)
     }
 
     /// Returns the address of the node.

--- a/src/btreemap/node/tests.rs
+++ b/src/btreemap/node/tests.rs
@@ -1,0 +1,39 @@
+use super::*;
+use crate::types::NULL;
+use proptest::collection::btree_map as pmap;
+use proptest::collection::vec as pvec;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use test_strategy::proptest;
+
+fn make_memory() -> Rc<RefCell<Vec<u8>>> {
+    Rc::new(RefCell::new(Vec::new()))
+}
+
+#[proptest]
+fn loading_and_reloading_entries(
+    #[strategy(1..100u32)] max_key_size: u32,
+    #[strategy(1..1_000u32)] max_value_size: u32,
+    #[strategy(
+        pmap(
+            pvec(0..u8::MAX, 0..#max_key_size as usize),
+            pvec(0..u8::MAX, 0..#max_value_size as usize),
+            1..CAPACITY
+        )
+    )]
+    entries: BTreeMap<Vec<u8>, Vec<u8>>,
+) {
+    let mem = make_memory();
+
+    // Create a new node and save it into memory.
+    let mut node = Node::new(NULL, NodeType::Leaf, max_key_size, max_value_size);
+    for entry in entries.clone().into_iter() {
+        node.push_entry(entry);
+    }
+    node.save(&mem);
+
+    // Reload the node and double check all the entries are correct.
+    let node = Node::load(NULL, &mem, max_key_size, max_value_size);
+    assert_eq!(node.entries(&mem), entries.into_iter().collect::<Vec<_>>());
+}

--- a/src/btreemap/node/v1.rs
+++ b/src/btreemap/node/v1.rs
@@ -1,0 +1,133 @@
+use super::*;
+
+impl<K: Storable + Ord + Clone> Node<K> {
+    /// Loads a node from memory at the given address.
+    pub(super) fn load_v1<M: Memory>(
+        address: Address,
+        memory: &M,
+        max_key_size: u32,
+        max_value_size: u32,
+    ) -> Self {
+        // Load the header.
+        let header: NodeHeader = read_struct(address, memory);
+        assert_eq!(&header.magic, MAGIC, "Bad magic.");
+        assert_eq!(header.version, LAYOUT_VERSION, "Unsupported version.");
+
+        // Load the entries.
+        let mut keys = Vec::with_capacity(header.num_entries as usize);
+        let mut encoded_values = Vec::with_capacity(header.num_entries as usize);
+        let mut offset = NodeHeader::size();
+        let mut buf = Vec::with_capacity(max_key_size.max(max_value_size) as usize);
+        for _ in 0..header.num_entries {
+            // Read the key's size.
+            let key_size = read_u32(memory, address + offset);
+            offset += U32_SIZE;
+
+            // Read the key.
+            buf.resize(key_size as usize, 0);
+            memory.read((address + offset).get(), &mut buf);
+            offset += Bytes::from(max_key_size);
+            let key = K::from_bytes(Cow::Borrowed(&buf));
+            keys.push(key);
+
+            // Values are loaded lazily. Store a reference and skip loading it.
+            encoded_values.push(Value::ByRef(offset));
+            offset += U32_SIZE + Bytes::from(max_value_size);
+        }
+
+        // Load children if this is an internal node.
+        let mut children = vec![];
+        if header.node_type == INTERNAL_NODE_TYPE {
+            // The number of children is equal to the number of entries + 1.
+            for _ in 0..header.num_entries + 1 {
+                let child = Address::from(read_u64(memory, address + offset));
+                offset += Address::size();
+                children.push(child);
+            }
+
+            assert_eq!(children.len(), keys.len() + 1);
+        }
+
+        Self {
+            address,
+            keys,
+            encoded_values: RefCell::new(encoded_values),
+            children,
+            node_type: match header.node_type {
+                LEAF_NODE_TYPE => NodeType::Leaf,
+                INTERNAL_NODE_TYPE => NodeType::Internal,
+                other => unreachable!("Unknown node type {}", other),
+            },
+            max_key_size,
+            max_value_size,
+        }
+    }
+
+    pub(super) fn save_v1<M: Memory>(&self, memory: &M) {
+        match self.node_type {
+            NodeType::Leaf => {
+                assert!(self.children.is_empty());
+            }
+            NodeType::Internal => {
+                assert_eq!(self.children.len(), self.keys.len() + 1);
+            }
+        };
+
+        // We should never be saving an empty node.
+        assert!(!self.keys.is_empty() || !self.children.is_empty());
+
+        // Assert entries are sorted in strictly increasing order.
+        assert!(self.keys.windows(2).all(|e| e[0] < e[1]));
+
+        let header = NodeHeader {
+            magic: *MAGIC,
+            version: LAYOUT_VERSION,
+            node_type: match self.node_type {
+                NodeType::Leaf => LEAF_NODE_TYPE,
+                NodeType::Internal => INTERNAL_NODE_TYPE,
+            },
+            num_entries: self.keys.len() as u16,
+        };
+
+        write_struct(&header, self.address, memory);
+
+        let mut offset = NodeHeader::size();
+
+        // Load all the values. This is necessary so that we don't overwrite referenced
+        // values when writing the entries to the node.
+        for i in 0..self.keys.len() {
+            self.value(i, memory);
+        }
+
+        // Write the entries.
+        for (idx, key) in self.keys.iter().enumerate() {
+            // Write the size of the key.
+            let key_bytes = key.to_bytes();
+            write_u32(memory, self.address + offset, key_bytes.len() as u32);
+            offset += U32_SIZE;
+
+            // Write the key.
+            write(memory, (self.address + offset).get(), key_bytes.borrow());
+            offset += Bytes::from(self.max_key_size);
+
+            // Write the size of the value.
+            let value = self.value(idx, memory);
+            write_u32(memory, self.address + offset, value.len() as u32);
+            offset += U32_SIZE;
+
+            // Write the value.
+            write(memory, (self.address + offset).get(), &value);
+            offset += Bytes::from(self.max_value_size);
+        }
+
+        // Write the children
+        for child in self.children.iter() {
+            write(
+                memory,
+                (self.address + offset).get(),
+                &child.get().to_le_bytes(),
+            );
+            offset += Address::size();
+        }
+    }
+}


### PR DESCRIPTION
A new version of `Node` will soon be introduced, and this commit paves the way for that by:

1. Moving the logic of `load` and `store` into a separate file (`v1.rs`)
2. Adding a proptest for `load` and `store` to ensure we don't introduce regressions