### PR TITLE
feat: BTreeMap V2 (beta)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install DFX
         run: |
           wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-          DFX_VERSION=${DFX_VERSION:=0.14.1} bash install-dfx.sh < <(yes Y)
+          DFX_VERSION=${DFX_VERSION:=0.14.3} bash install-dfx.sh < <(yes Y)
           rm install-dfx.sh
           dfx cache install
           echo "$HOME/bin" >> $GITHUB_PATH

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -177,40 +177,73 @@ pub fn criterion_benchmark(c: &mut Criterion<Instructions>) {
 
     // BTree benchmarks
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_4_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_4_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_8_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_8_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_16_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_16_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_32_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_32_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_64_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_64_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_128_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_128_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_256_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_256_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_512_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_512_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_u64_u64");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_u64_u64_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_u64_blob_8");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_u64_blob_8_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_8_u64");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_insert_blob_8_u64_v2");
 
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_4_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_4_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_8_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_8_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_16_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_16_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_32_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_32_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_64_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_64_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_128_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_128_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_u64_u64");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_u64_u64_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_u64_blob_8");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_u64_blob_8_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_8_u64");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_8_u64_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_256_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_256_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_512_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_get_blob_512_1024_v2");
 
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_4_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_4_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_8_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_8_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_16_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_16_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_32_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_32_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_64_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_64_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_128_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_128_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_256_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_256_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_512_1024");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_512_1024_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_u64_u64");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_u64_u64_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_u64_blob_8");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_u64_blob_8_v2");
     bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_8_u64");
+    bench_function(c, *BENCHMARK_CANISTER, "btreemap_remove_blob_8_u64_v2");
 
     // Vec benchmarks
     bench_function(c, *BENCHMARK_CANISTER, "vec_insert_blob_4");

--- a/benches/run-benchmark.sh
+++ b/benches/run-benchmark.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 BENCH_NAME=$1
-FILE=mktemp
+FILE=$(mktemp)
 
 if ! type "drun" > /dev/null; then
   echo "drun is not installed. Please add drun to your path from commit d35535c96184be039aaa31f68b48bbe45909494e."

--- a/benchmark-canisters/dfx.json
+++ b/benchmark-canisters/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.12.1",
+  "dfx": "0.14.3",
   "canisters": {
     "benchmarks": {
       "candid": "candid.did",

--- a/benchmark-canisters/src/btreemap.rs
+++ b/benchmark-canisters/src/btreemap.rs
@@ -9,8 +9,18 @@ pub fn btreemap_insert_blob_4_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_insert_blob_4_1024_v2() -> u64 {
+    insert_blob_helper_v2::<4, 1024>()
+}
+
+#[query]
 pub fn btreemap_insert_blob_8_1024() -> u64 {
     insert_blob_helper::<8, 1024>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_8_1024_v2() -> u64 {
+    insert_blob_helper_v2::<8, 1024>()
 }
 
 #[query]
@@ -19,8 +29,18 @@ pub fn btreemap_insert_blob_16_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_insert_blob_16_1024_v2() -> u64 {
+    insert_blob_helper_v2::<16, 1024>()
+}
+
+#[query]
 pub fn btreemap_insert_blob_32_1024() -> u64 {
     insert_blob_helper::<32, 1024>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_32_1024_v2() -> u64 {
+    insert_blob_helper_v2::<32, 1024>()
 }
 
 #[query]
@@ -29,8 +49,18 @@ pub fn btreemap_insert_blob_64_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_insert_blob_64_1024_v2() -> u64 {
+    insert_blob_helper_v2::<64, 1024>()
+}
+
+#[query]
 pub fn btreemap_insert_blob_128_1024() -> u64 {
     insert_blob_helper::<128, 1024>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_128_1024_v2() -> u64 {
+    insert_blob_helper_v2::<128, 1024>()
 }
 
 #[query]
@@ -39,8 +69,18 @@ pub fn btreemap_insert_blob_256_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_insert_blob_256_1024_v2() -> u64 {
+    insert_blob_helper_v2::<256, 1024>()
+}
+
+#[query]
 pub fn btreemap_insert_blob_512_1024() -> u64 {
     insert_blob_helper::<512, 1024>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_512_1024_v2() -> u64 {
+    insert_blob_helper_v2::<512, 1024>()
 }
 
 #[query]
@@ -49,8 +89,18 @@ pub fn btreemap_insert_blob_1024_4() -> u64 {
 }
 
 #[query]
+pub fn btreemap_insert_blob_1024_4_v2() -> u64 {
+    insert_blob_helper_v2::<1024, 4>()
+}
+
+#[query]
 pub fn btreemap_insert_blob_1024_8() -> u64 {
     insert_blob_helper::<1024, 8>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_1024_8_v2() -> u64 {
+    insert_blob_helper_v2::<1024, 8>()
 }
 
 #[query]
@@ -59,8 +109,18 @@ pub fn btreemap_insert_blob_1024_16() -> u64 {
 }
 
 #[query]
+pub fn btreemap_insert_blob_1024_16_v2() -> u64 {
+    insert_blob_helper_v2::<1024, 16>()
+}
+
+#[query]
 pub fn btreemap_insert_blob_1024_32() -> u64 {
     insert_blob_helper::<1024, 32>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_1024_32_v2() -> u64 {
+    insert_blob_helper_v2::<1024, 32>()
 }
 
 #[query]
@@ -69,8 +129,18 @@ pub fn btreemap_insert_blob_1024_64() -> u64 {
 }
 
 #[query]
+pub fn btreemap_insert_blob_1024_64_v2() -> u64 {
+    insert_blob_helper_v2::<1024, 64>()
+}
+
+#[query]
 pub fn btreemap_insert_blob_1024_128() -> u64 {
     insert_blob_helper::<1024, 128>()
+}
+
+#[query]
+pub fn btreemap_insert_blob_1024_128_v2() -> u64 {
+    insert_blob_helper_v2::<1024, 128>()
 }
 
 #[query]
@@ -79,23 +149,54 @@ pub fn btreemap_insert_blob_1024_256() -> u64 {
 }
 
 #[query]
+pub fn btreemap_insert_blob_1024_256_v2() -> u64 {
+    insert_blob_helper_v2::<1024, 256>()
+}
+
+#[query]
 pub fn btreemap_insert_blob_1024_512() -> u64 {
     insert_blob_helper::<1024, 512>()
 }
 
 #[query]
+pub fn btreemap_insert_blob_1024_512_v2() -> u64 {
+    insert_blob_helper_v2::<1024, 512>()
+}
+
+#[query]
 pub fn btreemap_insert_u64_u64() -> u64 {
-    insert_helper::<u64, u64>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    insert_helper::<u64, u64>(btree)
+}
+
+#[query]
+pub fn btreemap_insert_u64_u64_v2() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    insert_helper::<u64, u64>(btree)
 }
 
 #[query]
 pub fn btreemap_insert_u64_blob_8() -> u64 {
-    insert_helper::<u64, Blob<8>>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    insert_helper::<u64, Blob<8>>(btree)
+}
+
+#[query]
+pub fn btreemap_insert_u64_blob_8_v2() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    insert_helper::<u64, Blob<8>>(btree)
 }
 
 #[query]
 pub fn btreemap_insert_blob_8_u64() -> u64 {
-    insert_helper::<Blob<8>, u64>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    insert_helper::<Blob<8>, u64>(btree)
+}
+
+#[query]
+pub fn btreemap_insert_blob_8_u64_v2() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    insert_helper::<Blob<8>, u64>(btree)
 }
 
 /// Benchmarks removing keys from a BTreeMap.
@@ -105,7 +206,17 @@ pub fn btreemap_remove_blob_4_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_remove_blob_4_1024_v2() -> u64 {
+    remove_blob_helper::<4, 1024>()
+}
+
+#[query]
 pub fn btreemap_remove_blob_8_1024() -> u64 {
+    remove_blob_helper::<8, 1024>()
+}
+
+#[query]
+pub fn btreemap_remove_blob_8_1024_v2() -> u64 {
     remove_blob_helper::<8, 1024>()
 }
 
@@ -115,8 +226,18 @@ pub fn btreemap_remove_blob_16_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_remove_blob_16_1024_v2() -> u64 {
+    remove_blob_helper_v2::<16, 1024>()
+}
+
+#[query]
 pub fn btreemap_remove_blob_32_1024() -> u64 {
     remove_blob_helper::<32, 1024>()
+}
+
+#[query]
+pub fn btreemap_remove_blob_32_1024_v2() -> u64 {
+    remove_blob_helper_v2::<32, 1024>()
 }
 
 #[query]
@@ -125,8 +246,18 @@ pub fn btreemap_remove_blob_64_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_remove_blob_64_1024_v2() -> u64 {
+    remove_blob_helper_v2::<64, 1024>()
+}
+
+#[query]
 pub fn btreemap_remove_blob_128_1024() -> u64 {
     remove_blob_helper::<128, 1024>()
+}
+
+#[query]
+pub fn btreemap_remove_blob_128_1024_v2() -> u64 {
+    remove_blob_helper_v2::<128, 1024>()
 }
 
 #[query]
@@ -135,23 +266,51 @@ pub fn btreemap_remove_blob_256_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_remove_blob_256_1024_v2() -> u64 {
+    remove_blob_helper_v2::<256, 1024>()
+}
+
+#[query]
 pub fn btreemap_remove_blob_512_1024() -> u64 {
     remove_blob_helper::<512, 1024>()
 }
 
 #[query]
+pub fn btreemap_remove_blob_512_1024_v2() -> u64 {
+    remove_blob_helper_v2::<512, 1024>()
+}
+
+#[query]
 pub fn btreemap_remove_u64_u64() -> u64 {
-    remove_helper::<u64, u64>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    remove_helper::<u64, u64>(btree)
+}
+#[query]
+pub fn btreemap_remove_u64_u64_v2() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    remove_helper::<u64, u64>(btree)
 }
 
 #[query]
 pub fn btreemap_remove_u64_blob_8() -> u64 {
-    remove_helper::<u64, Blob<8>>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    remove_helper::<u64, Blob<8>>(btree)
+}
+#[query]
+pub fn btreemap_remove_u64_blob_8_v2() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    remove_helper::<u64, Blob<8>>(btree)
 }
 
 #[query]
 pub fn btreemap_remove_blob_8_u64() -> u64 {
-    remove_helper::<Blob<8>, u64>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    remove_helper::<Blob<8>, u64>(btree)
+}
+#[query]
+pub fn btreemap_remove_blob_8_u64_v2() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    remove_helper::<Blob<8>, u64>(btree)
 }
 
 /// Benchmarks getting keys from a BTreeMap.
@@ -161,8 +320,18 @@ pub fn btreemap_get_blob_4_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_get_blob_4_1024_v2() -> u64 {
+    get_blob_helper_v2::<4, 1024>()
+}
+
+#[query]
 pub fn btreemap_get_blob_8_1024() -> u64 {
     get_blob_helper::<8, 1024>()
+}
+
+#[query]
+pub fn btreemap_get_blob_8_1024_v2() -> u64 {
+    get_blob_helper_v2::<8, 1024>()
 }
 
 #[query]
@@ -171,8 +340,18 @@ pub fn btreemap_get_blob_16_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_get_blob_16_1024_v2() -> u64 {
+    get_blob_helper_v2::<16, 1024>()
+}
+
+#[query]
 pub fn btreemap_get_blob_32_1024() -> u64 {
     get_blob_helper::<32, 1024>()
+}
+
+#[query]
+pub fn btreemap_get_blob_32_1024_v2() -> u64 {
+    get_blob_helper_v2::<32, 1024>()
 }
 
 #[query]
@@ -181,8 +360,18 @@ pub fn btreemap_get_blob_64_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_get_blob_64_1024_v2() -> u64 {
+    get_blob_helper_v2::<64, 1024>()
+}
+
+#[query]
 pub fn btreemap_get_blob_128_1024() -> u64 {
     get_blob_helper::<128, 1024>()
+}
+
+#[query]
+pub fn btreemap_get_blob_128_1024_v2() -> u64 {
+    get_blob_helper_v2::<128, 1024>()
 }
 
 #[query]
@@ -191,33 +380,71 @@ pub fn btreemap_get_blob_256_1024() -> u64 {
 }
 
 #[query]
+pub fn btreemap_get_blob_256_1024_v2() -> u64 {
+    get_blob_helper_v2::<256, 1024>()
+}
+
+#[query]
 pub fn btreemap_get_blob_512_1024() -> u64 {
     get_blob_helper::<512, 1024>()
 }
 
 #[query]
+pub fn btreemap_get_blob_512_1024_v2() -> u64 {
+    get_blob_helper_v2::<512, 1024>()
+}
+
+#[query]
 pub fn btreemap_get_u64_u64() -> u64 {
-    get_helper::<u64, u64>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    get_helper::<u64, u64>(btree)
+}
+
+#[query]
+pub fn btreemap_get_u64_u64_v2() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    get_helper::<u64, u64>(btree)
 }
 
 #[query]
 pub fn btreemap_get_u64_blob_8() -> u64 {
-    get_helper::<u64, Blob<8>>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    get_helper::<u64, Blob<8>>(btree)
+}
+
+#[query]
+pub fn btreemap_get_u64_blob_8_v2() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    get_helper::<u64, Blob<8>>(btree)
 }
 
 #[query]
 pub fn btreemap_get_blob_8_u64() -> u64 {
-    get_helper::<Blob<8>, u64>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    get_helper::<Blob<8>, u64>(btree)
+}
+
+#[query]
+pub fn btreemap_get_blob_8_u64_v2() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    get_helper::<Blob<8>, u64>(btree)
 }
 
 // Profiles inserting a large number of random blobs into a btreemap.
 fn insert_blob_helper<const K: usize, const V: usize>() -> u64 {
-    insert_helper::<Blob<K>, Blob<V>>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    insert_helper::<Blob<K>, Blob<V>>(btree)
+}
+
+fn insert_blob_helper_v2<const K: usize, const V: usize>() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    insert_helper::<Blob<K>, Blob<V>>(btree)
 }
 
 // Profiles inserting a large number of random blobs into a btreemap.
-fn insert_helper<K: Clone + Ord + Storable + Random, V: Storable + Random>() -> u64 {
-    let mut btree: BTreeMap<K, V, _> = BTreeMap::new(DefaultMemoryImpl::default());
+fn insert_helper<K: Clone + Ord + Storable + Random, V: Storable + Random>(
+    mut btree: BTreeMap<K, V, DefaultMemoryImpl>,
+) -> u64 {
     let num_keys = 10_000;
     let mut rng = Rng::from_seed(0);
     let mut random_keys = Vec::with_capacity(num_keys);
@@ -238,11 +465,18 @@ fn insert_helper<K: Clone + Ord + Storable + Random, V: Storable + Random>() -> 
 
 // Profiles getting a large number of random blobs from a btreemap.
 fn get_blob_helper<const K: usize, const V: usize>() -> u64 {
-    get_helper::<Blob<K>, Blob<V>>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    get_helper::<Blob<K>, Blob<V>>(btree)
 }
 
-fn get_helper<K: Clone + Ord + Storable + Random, V: Storable + Random>() -> u64 {
-    let mut btree: BTreeMap<K, V, _> = BTreeMap::new(DefaultMemoryImpl::default());
+fn get_blob_helper_v2<const K: usize, const V: usize>() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    get_helper::<Blob<K>, Blob<V>>(btree)
+}
+
+fn get_helper<K: Clone + Ord + Storable + Random, V: Storable + Random>(
+    mut btree: BTreeMap<K, V, DefaultMemoryImpl>,
+) -> u64 {
     let num_keys = 10_000;
     let mut rng = Rng::from_seed(0);
     let mut random_keys = Vec::with_capacity(num_keys);
@@ -268,11 +502,18 @@ fn get_helper<K: Clone + Ord + Storable + Random, V: Storable + Random>() -> u64
 
 // Inserts a large number of random blobs into a btreemap, then profiles removing them.
 fn remove_blob_helper<const K: usize, const V: usize>() -> u64 {
-    remove_helper::<Blob<K>, Blob<V>>()
+    let btree = BTreeMap::new(DefaultMemoryImpl::default());
+    remove_helper::<Blob<K>, Blob<V>>(btree)
 }
 
-fn remove_helper<K: Clone + Ord + Storable + Random, V: Storable + Random>() -> u64 {
-    let mut btree: BTreeMap<K, V, _> = BTreeMap::new(DefaultMemoryImpl::default());
+fn remove_blob_helper_v2<const K: usize, const V: usize>() -> u64 {
+    let btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+    remove_helper::<Blob<K>, Blob<V>>(btree)
+}
+
+fn remove_helper<K: Clone + Ord + Storable + Random, V: Storable + Random>(
+    mut btree: BTreeMap<K, V, DefaultMemoryImpl>,
+) -> u64 {
     let num_keys = 10_000;
     let mut rng = Rng::from_seed(0);
     let mut random_keys = Vec::with_capacity(num_keys);

--- a/examples/dfx.json
+++ b/examples/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.14.1",
+  "dfx": "0.14.3",
   "canisters": {
     "quick_start": {
       "candid": "src/quick_start/candid.did",

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1307,10 +1307,10 @@ mod test {
             let median_index = right_child.entries_len() / 2;
             assert_eq!(right_child.key(median_index), &b(&[12]));
 
-            // Overwrite the median key.
+            // Overwrite the value of the median key.
             assert_eq!(btree.insert(b(&[12]), b(&[1, 2, 3])), Some(b(&[])));
 
-            // The key is overwritten successfully.
+            // The value is overwritten successfully.
             assert_eq!(btree.get(&b(&[12])), Some(b(&[1, 2, 3])));
 
             // The child has not been split and is still full.
@@ -1384,10 +1384,10 @@ mod test {
     fn insert_same_key_multiple() {
         btree_test(|mut btree| {
             assert_eq!(btree.insert(b(&[1]), b(&[2])), None);
-
             for i in 2..10 {
                 assert_eq!(btree.insert(b(&[1]), b(&[i + 1])), Some(b(&[i])));
             }
+            assert_eq!(btree.get(&b(&[1])), Some(b(&[10])));
         });
     }
 
@@ -2053,7 +2053,7 @@ mod test {
             //               /   \
             // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-            // Test a prefix that's larger than the value in the internal node.
+            // Test a prefix that's larger than the key in the internal node.
             assert_eq!(
                 btree.range(b(&[7])..b(&[8])).collect::<Vec<_>>(),
                 vec![(b(&[7]), b(&[]))]
@@ -2087,7 +2087,7 @@ mod test {
             assert_eq!(root.entries(btree.memory()), vec![(b(&[1, 2]), vec![])]);
             assert_eq!(root.children_len(), 2);
 
-            // Tests a prefix that's smaller than the value in the internal node.
+            // Tests a prefix that's smaller than the key in the internal node.
             assert_eq!(
                 btree.range(b(&[0])..b(&[1])).collect::<Vec<_>>(),
                 vec![
@@ -2109,7 +2109,7 @@ mod test {
                 ]
             );
 
-            // Tests a prefix that's larger than the value in the internal node.
+            // Tests a prefix that's larger than the key in the internal node.
             assert_eq!(
                 btree.range(b(&[2])..b(&[3])).collect::<Vec<_>>(),
                 vec![
@@ -2201,6 +2201,22 @@ mod test {
             assert_eq!(
                 btree.range(b(&[1, 5])..b(&[1, 6])).collect::<Vec<_>>(),
                 vec![]
+            );
+
+            // Tests a prefix beginning in the middle of the tree and crossing several nodes.
+            assert_eq!(
+                btree.range(b(&[1, 5])..=b(&[2, 6])).collect::<Vec<_>>(),
+                vec![
+                    (b(&[1, 6]), b(&[])),
+                    (b(&[1, 8]), b(&[])),
+                    (b(&[1, 10]), b(&[])),
+                    (b(&[2, 1]), b(&[])),
+                    (b(&[2, 2]), b(&[])),
+                    (b(&[2, 3]), b(&[])),
+                    (b(&[2, 4]), b(&[])),
+                    (b(&[2, 5]), b(&[])),
+                    (b(&[2, 6]), b(&[])),
+                ]
             );
 
             // Tests a prefix that crosses several nodes.
@@ -2311,13 +2327,13 @@ mod test {
                 ]
             );
 
-            // Tests a offset that has a value somewhere in the range of values of an internal node.
+            // Tests an offset that has a keys somewhere in the range of keys of an internal node.
             assert_eq!(
                 btree.range(b(&[1, 3])..b(&[2])).collect::<Vec<_>>(),
                 vec![(b(&[1, 3]), b(&[])), (b(&[1, 4]), b(&[])),]
             );
 
-            // Tests a offset that's larger than the value in the internal node.
+            // Tests an offset that's larger than the key in the internal node.
             assert_eq!(btree.range(b(&[2, 5])..).collect::<Vec<_>>(), vec![]);
         });
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -113,6 +113,28 @@ where
         }
     }
 
+    /// Initializes a v2 `BTreeMap`.
+    ///
+    /// This is currently exposed only for beta-testing purposes and will be removed in favor of
+    /// using BTreeMap::init directly once V2 is tested well enough.
+    pub fn init_v2(memory: M) -> Self {
+        if memory.size() == 0 {
+            // Memory is empty. Create a new map.
+            return BTreeMap::new(memory);
+        }
+
+        // Check if the magic in the memory corresponds to a BTreeMap.
+        let mut dst = vec![0; 3];
+        memory.read(0, &mut dst);
+        if dst != MAGIC {
+            // No BTreeMap found. Create a new instance.
+            BTreeMap::new_v2(memory)
+        } else {
+            // The memory already contains a BTreeMap. Load it.
+            BTreeMap::load(memory)
+        }
+    }
+
     /// Creates a new instance a `BTreeMap`.
     ///
     /// The given `memory` is assumed to be exclusively reserved for this data

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -147,7 +147,7 @@ where
         btree
     }
 
-    /// Create a V2 of the BTree.
+    /// Create a v2 instance of the BTree.
     /// This is currently exposed only for beta-testing purposes and will be removed in favor of
     /// using BTreeMap::new directly once V2 is tested well enough.
     pub fn new_v2(memory: M) -> Self {
@@ -227,7 +227,8 @@ where
                 }
             }
             LAYOUT_VERSION_2 => {
-                // FIXME: deal with derived page size.
+                // TODO: Handle derived page sizes.
+
                 // Deserialize the fields
                 BTreeHeader {
                     version: Version::V2(PageSize::Value(u32::from_le_bytes(

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1221,7 +1221,7 @@ mod test {
     }
 
     // A test runner that runs the test using both V1 and V2 btrees.
-    fn btree_test<K, V, R, F>(f: F)
+    pub fn btree_test<K, V, R, F>(f: F)
     where
         K: Storable + Ord + Clone,
         V: Storable,

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1177,7 +1177,10 @@ impl std::fmt::Display for InsertError {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::storable::Blob;
+    use crate::{
+        storable::{Blob, Bound as StorableBound},
+        VectorMemory,
+    };
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -1194,585 +1197,588 @@ mod test {
         Blob::<10>::try_from(x).unwrap()
     }
 
+    // A test runner that runs the test using both V1 and V2 btrees.
+    fn btree_test<K, V, R, F>(f: F)
+    where
+        K: Storable + Ord + Clone,
+        V: Storable,
+        F: Fn(BTreeMap<K, V, VectorMemory>) -> R,
+    {
+        // Run the test with the V1 btree.
+        let mem = make_memory();
+        let btree = BTreeMap::new(mem);
+        f(btree);
+
+        // Run the test with the V2 btree.
+        let mem = make_memory();
+        let btree = BTreeMap::new_v2(mem);
+        f(btree);
+    }
+
     #[test]
     fn init_preserves_data() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::init(mem.clone());
-        assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
-        assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
+        btree_test(|mut btree| {
+            assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
+            assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
 
-        // Reload the btree
-        let btree = BTreeMap::init(mem);
+            // Reload the btree
+            let btree = BTreeMap::init(btree.into_memory());
 
-        // Data still exists.
-        assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
+            // Data still exists.
+            assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
+        });
     }
 
     #[test]
     fn insert_get() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
-
-        assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
-        assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
+        btree_test(|mut btree| {
+            assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
+            assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
+        });
     }
 
     #[test]
     fn insert_overwrites_previous_value() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
-
-        assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
-        assert_eq!(
-            btree.insert(b(&[1, 2, 3]), b(&[7, 8, 9])),
-            Some(b(&[4, 5, 6]))
-        );
-        assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[7, 8, 9])));
+        btree_test(|mut btree| {
+            assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
+            assert_eq!(
+                btree.insert(b(&[1, 2, 3]), b(&[7, 8, 9])),
+                Some(b(&[4, 5, 6]))
+            );
+            assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[7, 8, 9])));
+        });
     }
 
     #[test]
     fn insert_get_multiple() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
-
-        assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
-        assert_eq!(btree.insert(b(&[4, 5]), b(&[7, 8, 9, 10])), None);
-        assert_eq!(btree.insert(b(&[]), b(&[11])), None);
-        assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
-        assert_eq!(btree.get(&b(&[4, 5])), Some(b(&[7, 8, 9, 10])));
-        assert_eq!(btree.get(&b(&[])), Some(b(&[11])));
+        btree_test(|mut btree| {
+            assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
+            assert_eq!(btree.insert(b(&[4, 5]), b(&[7, 8, 9, 10])), None);
+            assert_eq!(btree.insert(b(&[]), b(&[11])), None);
+            assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
+            assert_eq!(btree.get(&b(&[4, 5])), Some(b(&[7, 8, 9, 10])));
+            assert_eq!(btree.get(&b(&[])), Some(b(&[11])));
+        });
     }
 
     #[test]
     fn insert_overwrite_median_key_in_full_child_node() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            for i in 1..=17 {
+                assert_eq!(btree.insert(b(&[i]), b(&[])), None);
+            }
 
-        for i in 1..=17 {
-            assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-        }
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
 
-        // The result should look like this:
-        //                [6]
-        //               /   \
-        // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(6)]);
+            assert_eq!(root.children_len(), 2);
 
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(root.entries(btree.memory()), vec![e(6)]);
-        assert_eq!(root.children_len(), 2);
+            // The right child should now be full, with the median key being "12"
+            let right_child = btree.load_node(root.child(1));
+            assert!(right_child.is_full());
+            let median_index = right_child.entries_len() / 2;
+            assert_eq!(right_child.key(median_index), &b(&[12]));
 
-        // The right child should now be full, with the median key being "12"
-        let right_child = btree.load_node(root.child(1));
-        assert!(right_child.is_full());
-        let median_index = right_child.entries_len() / 2;
-        assert_eq!(right_child.key(median_index), &b(&[12]));
+            // Overwrite the median key.
+            assert_eq!(btree.insert(b(&[12]), b(&[1, 2, 3])), Some(b(&[])));
 
-        // Overwrite the median key.
-        assert_eq!(btree.insert(b(&[12]), b(&[1, 2, 3])), Some(b(&[])));
+            // The key is overwritten successfully.
+            assert_eq!(btree.get(&b(&[12])), Some(b(&[1, 2, 3])));
 
-        // The key is overwritten successfully.
-        assert_eq!(btree.get(&b(&[12])), Some(b(&[1, 2, 3])));
-
-        // The child has not been split and is still full.
-        let right_child = btree.load_node(root.child(1));
-        assert_eq!(right_child.node_type(), NodeType::Leaf);
-        assert!(right_child.is_full());
+            // The child has not been split and is still full.
+            let right_child = btree.load_node(root.child(1));
+            assert_eq!(right_child.node_type(), NodeType::Leaf);
+            assert!(right_child.is_full());
+        });
     }
 
     #[test]
     fn insert_overwrite_key_in_full_root_node() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(b(&[i]), b(&[])), None);
+            }
 
-        for i in 1..=11 {
-            assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-        }
+            // We now have a root that is full and looks like this:
+            //
+            // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+            let root = btree.load_node(btree.root_addr);
+            assert!(root.is_full());
 
-        // We now have a root that is full and looks like this:
-        //
-        // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-        let root = btree.load_node(btree.root_addr);
-        assert!(root.is_full());
+            // Overwrite an element in the root. It should NOT cause the node to be split.
+            assert_eq!(btree.insert(b(&[6]), b(&[4, 5, 6])), Some(b(&[])));
 
-        // Overwrite an element in the root. It should NOT cause the node to be split.
-        assert_eq!(btree.insert(b(&[6]), b(&[4, 5, 6])), Some(b(&[])));
-
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Leaf);
-        assert_eq!(btree.get(&b(&[6])), Some(b(&[4, 5, 6])));
-        assert_eq!(root.entries_len(), 11);
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Leaf);
+            assert_eq!(btree.get(&b(&[6])), Some(b(&[4, 5, 6])));
+            assert_eq!(root.entries_len(), 11);
+        });
     }
 
     #[test]
     fn allocations() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
-
-        // Insert entries until the root node is full.
-        let mut i = 0;
-        loop {
-            assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-            let root = btree.load_node(btree.root_addr);
-            if root.is_full() {
-                break;
+        btree_test(|mut btree| {
+            // Insert entries until the root node is full.
+            let mut i = 0;
+            loop {
+                assert_eq!(btree.insert(b(&[i]), b(&[])), None);
+                let root = btree.load_node(btree.root_addr);
+                if root.is_full() {
+                    break;
+                }
+                i += 1;
             }
-            i += 1;
-        }
 
-        // Only need a single allocation to store up to `CAPACITY` elements.
-        assert_eq!(btree.allocator.num_allocated_chunks(), 1);
+            // Only need a single allocation to store up to `CAPACITY` elements.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 1);
 
-        assert_eq!(btree.insert(b(&[255]), b(&[])), None);
+            assert_eq!(btree.insert(b(&[255]), b(&[])), None);
 
-        // The node had to be split into three nodes.
-        assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+            // The node had to be split into three nodes.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+        });
     }
 
     #[test]
     fn allocations_2() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
-        assert_eq!(btree.allocator.num_allocated_chunks(), 0);
+        btree_test(|mut btree| {
+            assert_eq!(btree.allocator.num_allocated_chunks(), 0);
 
-        assert_eq!(btree.insert(b(&[]), b(&[])), None);
-        assert_eq!(btree.allocator.num_allocated_chunks(), 1);
+            assert_eq!(btree.insert(b(&[]), b(&[])), None);
+            assert_eq!(btree.allocator.num_allocated_chunks(), 1);
 
-        assert_eq!(btree.remove(&b(&[])), Some(b(&[])));
-        assert_eq!(btree.allocator.num_allocated_chunks(), 0);
+            assert_eq!(btree.remove(&b(&[])), Some(b(&[])));
+            assert_eq!(btree.allocator.num_allocated_chunks(), 0);
+        });
     }
 
     #[test]
     fn insert_same_key_multiple() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            assert_eq!(btree.insert(b(&[1]), b(&[2])), None);
 
-        assert_eq!(btree.insert(b(&[1]), b(&[2])), None);
-
-        for i in 2..10 {
-            assert_eq!(btree.insert(b(&[1]), b(&[i + 1])), Some(b(&[i])));
-        }
+            for i in 2..10 {
+                assert_eq!(btree.insert(b(&[1]), b(&[i + 1])), Some(b(&[i])));
+            }
+        });
     }
 
     #[test]
     fn insert_split_node() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(b(&[i]), b(&[])), None);
+            }
 
-        for i in 1..=11 {
-            assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-        }
+            // Should now split a node.
+            assert_eq!(btree.insert(b(&[12]), b(&[])), None);
 
-        // Should now split a node.
-        assert_eq!(btree.insert(b(&[12]), b(&[])), None);
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-        // The result should look like this:
-        //                [6]
-        //               /   \
-        // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
-
-        for i in 1..=12 {
-            assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
-        }
+            for i in 1..=12 {
+                assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
+            }
+        });
     }
 
     #[test]
     fn insert_split_multiple_nodes() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(b(&[i]), b(&[])), None);
+            }
+            // Should now split a node.
+            assert_eq!(btree.insert(b(&[12]), b(&[])), None);
 
-        for i in 1..=11 {
-            assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-        }
-        // Should now split a node.
-        assert_eq!(btree.insert(b(&[12]), b(&[])), None);
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-        // The result should look like this:
-        //                [6]
-        //               /   \
-        // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(6)]);
+            assert_eq!(root.children_len(), 2);
 
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(root.entries(btree.memory()), vec![e(6)]);
-        assert_eq!(root.children_len(), 2);
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(1), e(2), e(3), e(4), e(5)]
+            );
 
-        let child_0 = btree.load_node(root.child(0));
-        assert_eq!(child_0.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_0.entries(btree.memory()),
-            vec![e(1), e(2), e(3), e(4), e(5)]
-        );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(7), e(8), e(9), e(10), e(11), e(12)]
+            );
 
-        let child_1 = btree.load_node(root.child(1));
-        assert_eq!(child_1.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_1.entries(btree.memory()),
-            vec![e(7), e(8), e(9), e(10), e(11), e(12)]
-        );
+            for i in 1..=12 {
+                assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
+            }
 
-        for i in 1..=12 {
-            assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
-        }
+            // Insert more to cause more splitting.
+            assert_eq!(btree.insert(b(&[13]), b(&[])), None);
+            assert_eq!(btree.insert(b(&[14]), b(&[])), None);
+            assert_eq!(btree.insert(b(&[15]), b(&[])), None);
+            assert_eq!(btree.insert(b(&[16]), b(&[])), None);
+            assert_eq!(btree.insert(b(&[17]), b(&[])), None);
+            // Should cause another split
+            assert_eq!(btree.insert(b(&[18]), b(&[])), None);
 
-        // Insert more to cause more splitting.
-        assert_eq!(btree.insert(b(&[13]), b(&[])), None);
-        assert_eq!(btree.insert(b(&[14]), b(&[])), None);
-        assert_eq!(btree.insert(b(&[15]), b(&[])), None);
-        assert_eq!(btree.insert(b(&[16]), b(&[])), None);
-        assert_eq!(btree.insert(b(&[17]), b(&[])), None);
-        // Should cause another split
-        assert_eq!(btree.insert(b(&[18]), b(&[])), None);
+            for i in 1..=18 {
+                assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
+            }
 
-        for i in 1..=18 {
-            assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
-        }
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(6), e(12)],);
+            assert_eq!(root.children_len(), 3);
 
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(root.entries(btree.memory()), vec![e(6), e(12)],);
-        assert_eq!(root.children_len(), 3);
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(1), e(2), e(3), e(4), e(5)]
+            );
 
-        let child_0 = btree.load_node(root.child(0));
-        assert_eq!(child_0.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_0.entries(btree.memory()),
-            vec![e(1), e(2), e(3), e(4), e(5)]
-        );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(7), e(8), e(9), e(10), e(11)]
+            );
 
-        let child_1 = btree.load_node(root.child(1));
-        assert_eq!(child_1.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_1.entries(btree.memory()),
-            vec![e(7), e(8), e(9), e(10), e(11)]
-        );
-
-        let child_2 = btree.load_node(root.child(2));
-        assert_eq!(child_2.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_2.entries(btree.memory()),
-            vec![e(13), e(14), e(15), e(16), e(17), e(18)]
-        );
+            let child_2 = btree.load_node(root.child(2));
+            assert_eq!(child_2.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_2.entries(btree.memory()),
+                vec![e(13), e(14), e(15), e(16), e(17), e(18)]
+            );
+        });
     }
 
     #[test]
     fn remove_simple() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
-
-        assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
-        assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
-        assert_eq!(btree.remove(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
-        assert_eq!(btree.get(&b(&[1, 2, 3])), None);
+        btree_test(|mut btree| {
+            assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
+            assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
+            assert_eq!(btree.remove(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
+            assert_eq!(btree.get(&b(&[1, 2, 3])), None);
+        });
     }
 
     #[test]
     fn remove_case_2a_and_2c() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem.clone());
+        btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(b(&[i]), b(&[])), None);
+            }
+            // Should now split a node.
+            assert_eq!(btree.insert(b(&[0]), b(&[])), None);
 
-        for i in 1..=11 {
-            assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-        }
-        // Should now split a node.
-        assert_eq!(btree.insert(b(&[0]), b(&[])), None);
+            // The result should look like this:
+            //                    [6]
+            //                   /   \
+            // [0, 1, 2, 3, 4, 5]     [7, 8, 9, 10, 11]
 
-        // The result should look like this:
-        //                    [6]
-        //                   /   \
-        // [0, 1, 2, 3, 4, 5]     [7, 8, 9, 10, 11]
+            for i in 0..=11 {
+                assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
+            }
 
-        for i in 0..=11 {
-            assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
-        }
+            // Remove node 6. Triggers case 2.a
+            assert_eq!(btree.remove(&b(&[6])), Some(b(&[])));
 
-        // Remove node 6. Triggers case 2.a
-        assert_eq!(btree.remove(&b(&[6])), Some(b(&[])));
+            // The result should look like this:
+            //                [5]
+            //               /   \
+            // [0, 1, 2, 3, 4]   [7, 8, 9, 10, 11]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(5)]);
+            assert_eq!(root.children_len(), 2);
 
-        // The result should look like this:
-        //                [5]
-        //               /   \
-        // [0, 1, 2, 3, 4]   [7, 8, 9, 10, 11]
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(root.entries(btree.memory()), vec![e(5)]);
-        assert_eq!(root.children_len(), 2);
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(0), e(1), e(2), e(3), e(4)]
+            );
 
-        let child_0 = btree.load_node(root.child(0));
-        assert_eq!(child_0.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_0.entries(btree.memory()),
-            vec![e(0), e(1), e(2), e(3), e(4)]
-        );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(7), e(8), e(9), e(10), e(11)]
+            );
 
-        let child_1 = btree.load_node(root.child(1));
-        assert_eq!(child_1.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_1.entries(btree.memory()),
-            vec![e(7), e(8), e(9), e(10), e(11)]
-        );
+            // There are three allocated nodes.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 3);
 
-        // There are three allocated nodes.
-        assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+            // Remove node 5. Triggers case 2c
+            assert_eq!(btree.remove(&b(&[5])), Some(b(&[])));
 
-        // Remove node 5. Triggers case 2c
-        assert_eq!(btree.remove(&b(&[5])), Some(b(&[])));
+            // Reload the btree to verify that we saved it correctly.
+            let btree = BTreeMap::<Blob<10>, Blob<10>, _>::load(btree.into_memory());
 
-        // Reload the btree to verify that we saved it correctly.
-        let btree = BTreeMap::<Blob<10>, Blob<10>, _>::load(mem);
+            // The result should look like this:
+            // [0, 1, 2, 3, 4, 7, 8, 9, 10, 11]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![e(0), e(1), e(2), e(3), e(4), e(7), e(8), e(9), e(10), e(11)]
+            );
 
-        // The result should look like this:
-        // [0, 1, 2, 3, 4, 7, 8, 9, 10, 11]
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(
-            root.entries(btree.memory()),
-            vec![e(0), e(1), e(2), e(3), e(4), e(7), e(8), e(9), e(10), e(11)]
-        );
-
-        // There is only one node allocated.
-        assert_eq!(btree.allocator.num_allocated_chunks(), 1);
+            // There is only one node allocated.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 1);
+        });
     }
 
     #[test]
     fn remove_case_2b() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(b(&[i]), b(&[])), None);
+            }
+            // Should now split a node.
+            assert_eq!(btree.insert(b(&[12]), b(&[])), None);
 
-        for i in 1..=11 {
-            assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-        }
-        // Should now split a node.
-        assert_eq!(btree.insert(b(&[12]), b(&[])), None);
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-        // The result should look like this:
-        //                [6]
-        //               /   \
-        // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
+            for i in 1..=12 {
+                assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
+            }
 
-        for i in 1..=12 {
-            assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
-        }
+            // Remove node 6. Triggers case 2.b
+            assert_eq!(btree.remove(&b(&[6])), Some(b(&[])));
 
-        // Remove node 6. Triggers case 2.b
-        assert_eq!(btree.remove(&b(&[6])), Some(b(&[])));
+            // The result should look like this:
+            //                [7]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(7)]);
+            assert_eq!(root.children_len(), 2);
 
-        // The result should look like this:
-        //                [7]
-        //               /   \
-        // [1, 2, 3, 4, 5]   [8, 9, 10, 11, 12]
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(root.entries(btree.memory()), vec![e(7)]);
-        assert_eq!(root.children_len(), 2);
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(1), e(2), e(3), e(4), e(5)]
+            );
 
-        let child_0 = btree.load_node(root.child(0));
-        assert_eq!(child_0.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_0.entries(btree.memory()),
-            vec![e(1), e(2), e(3), e(4), e(5)]
-        );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(8), e(9), e(10), e(11), e(12)]
+            );
 
-        let child_1 = btree.load_node(root.child(1));
-        assert_eq!(child_1.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_1.entries(btree.memory()),
-            vec![e(8), e(9), e(10), e(11), e(12)]
-        );
-
-        // Remove node 7. Triggers case 2.c
-        assert_eq!(btree.remove(&b(&[7])), Some(b(&[])));
-        // The result should look like this:
-        //
-        // [1, 2, 3, 4, 5, 8, 9, 10, 11, 12]
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Leaf);
-        assert_eq!(
-            root.entries(btree.memory()),
-            vec![
-                e(1),
-                e(2),
-                e(3),
-                e(4),
-                e(5),
-                e(8),
-                e(9),
-                e(10),
-                e(11),
-                e(12)
-            ]
-        );
+            // Remove node 7. Triggers case 2.c
+            assert_eq!(btree.remove(&b(&[7])), Some(b(&[])));
+            // The result should look like this:
+            //
+            // [1, 2, 3, 4, 5, 8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Leaf);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![
+                    e(1),
+                    e(2),
+                    e(3),
+                    e(4),
+                    e(5),
+                    e(8),
+                    e(9),
+                    e(10),
+                    e(11),
+                    e(12)
+                ]
+            );
+        });
     }
 
     #[test]
     fn remove_case_3a_right() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(b(&[i]), b(&[])), None);
+            }
 
-        for i in 1..=11 {
-            assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-        }
+            // Should now split a node.
+            assert_eq!(btree.insert(b(&[12]), b(&[])), None);
 
-        // Should now split a node.
-        assert_eq!(btree.insert(b(&[12]), b(&[])), None);
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-        // The result should look like this:
-        //                [6]
-        //               /   \
-        // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
+            // Remove node 3. Triggers case 3.a
+            assert_eq!(btree.remove(&b(&[3])), Some(b(&[])));
 
-        // Remove node 3. Triggers case 3.a
-        assert_eq!(btree.remove(&b(&[3])), Some(b(&[])));
+            // The result should look like this:
+            //                [7]
+            //               /   \
+            // [1, 2, 4, 5, 6]   [8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(7)]);
+            assert_eq!(root.children_len(), 2);
 
-        // The result should look like this:
-        //                [7]
-        //               /   \
-        // [1, 2, 4, 5, 6]   [8, 9, 10, 11, 12]
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(root.entries(btree.memory()), vec![e(7)]);
-        assert_eq!(root.children_len(), 2);
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(1), e(2), e(4), e(5), e(6)]
+            );
 
-        let child_0 = btree.load_node(root.child(0));
-        assert_eq!(child_0.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_0.entries(btree.memory()),
-            vec![e(1), e(2), e(4), e(5), e(6)]
-        );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(8), e(9), e(10), e(11), e(12)]
+            );
 
-        let child_1 = btree.load_node(root.child(1));
-        assert_eq!(child_1.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_1.entries(btree.memory()),
-            vec![e(8), e(9), e(10), e(11), e(12)]
-        );
-
-        // There are three allocated nodes.
-        assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+            // There are three allocated nodes.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+        });
     }
 
     #[test]
     fn remove_case_3a_left() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(b(&[i]), b(&[])), None);
+            }
+            // Should now split a node.
+            assert_eq!(btree.insert(b(&[0]), b(&[])), None);
 
-        for i in 1..=11 {
-            assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-        }
-        // Should now split a node.
-        assert_eq!(btree.insert(b(&[0]), b(&[])), None);
+            // The result should look like this:
+            //                   [6]
+            //                  /   \
+            // [0, 1, 2, 3, 4, 5]   [7, 8, 9, 10, 11]
 
-        // The result should look like this:
-        //                   [6]
-        //                  /   \
-        // [0, 1, 2, 3, 4, 5]   [7, 8, 9, 10, 11]
+            // Remove node 8. Triggers case 3.a left
+            assert_eq!(btree.remove(&b(&[8])), Some(b(&[])));
 
-        // Remove node 8. Triggers case 3.a left
-        assert_eq!(btree.remove(&b(&[8])), Some(b(&[])));
+            // The result should look like this:
+            //                [5]
+            //               /   \
+            // [0, 1, 2, 3, 4]   [6, 7, 9, 10, 11]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(5)]);
+            assert_eq!(root.children_len(), 2);
 
-        // The result should look like this:
-        //                [5]
-        //               /   \
-        // [0, 1, 2, 3, 4]   [6, 7, 9, 10, 11]
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(root.entries(btree.memory()), vec![e(5)]);
-        assert_eq!(root.children_len(), 2);
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(0), e(1), e(2), e(3), e(4)]
+            );
 
-        let child_0 = btree.load_node(root.child(0));
-        assert_eq!(child_0.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_0.entries(btree.memory()),
-            vec![e(0), e(1), e(2), e(3), e(4)]
-        );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(6), e(7), e(9), e(10), e(11)]
+            );
 
-        let child_1 = btree.load_node(root.child(1));
-        assert_eq!(child_1.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_1.entries(btree.memory()),
-            vec![e(6), e(7), e(9), e(10), e(11)]
-        );
-
-        // There are three allocated nodes.
-        assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+            // There are three allocated nodes.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+        });
     }
 
     #[test]
     fn remove_case_3b_merge_into_right() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem.clone());
+        btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(b(&[i]), b(&[])), None);
+            }
+            // Should now split a node.
+            assert_eq!(btree.insert(b(&[12]), b(&[])), None);
 
-        for i in 1..=11 {
-            assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-        }
-        // Should now split a node.
-        assert_eq!(btree.insert(b(&[12]), b(&[])), None);
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-        // The result should look like this:
-        //                [6]
-        //               /   \
-        // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
+            for i in 1..=12 {
+                assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
+            }
 
-        for i in 1..=12 {
-            assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
-        }
+            // Remove node 6. Triggers case 2.b
+            assert_eq!(btree.remove(&b(&[6])), Some(b(&[])));
+            // The result should look like this:
+            //                [7]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(7)]);
+            assert_eq!(root.children_len(), 2);
 
-        // Remove node 6. Triggers case 2.b
-        assert_eq!(btree.remove(&b(&[6])), Some(b(&[])));
-        // The result should look like this:
-        //                [7]
-        //               /   \
-        // [1, 2, 3, 4, 5]   [8, 9, 10, 11, 12]
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(root.entries(btree.memory()), vec![e(7)]);
-        assert_eq!(root.children_len(), 2);
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(1), e(2), e(3), e(4), e(5)]
+            );
 
-        let child_0 = btree.load_node(root.child(0));
-        assert_eq!(child_0.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_0.entries(btree.memory()),
-            vec![e(1), e(2), e(3), e(4), e(5)]
-        );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(8), e(9), e(10), e(11), e(12)]
+            );
 
-        let child_1 = btree.load_node(root.child(1));
-        assert_eq!(child_1.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_1.entries(btree.memory()),
-            vec![e(8), e(9), e(10), e(11), e(12)]
-        );
+            // There are three allocated nodes.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 3);
 
-        // There are three allocated nodes.
-        assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+            // Remove node 3. Triggers case 3.b
+            assert_eq!(btree.remove(&b(&[3])), Some(b(&[])));
 
-        // Remove node 3. Triggers case 3.b
-        assert_eq!(btree.remove(&b(&[3])), Some(b(&[])));
+            // Reload the btree to verify that we saved it correctly.
+            let btree = BTreeMap::<Blob<10>, Blob<10>, _>::load(btree.into_memory());
 
-        // Reload the btree to verify that we saved it correctly.
-        let btree = BTreeMap::<Blob<10>, Blob<10>, _>::load(mem);
+            // The result should look like this:
+            //
+            // [1, 2, 4, 5, 7, 8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Leaf);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![
+                    e(1),
+                    e(2),
+                    e(4),
+                    e(5),
+                    e(7),
+                    e(8),
+                    e(9),
+                    e(10),
+                    e(11),
+                    e(12)
+                ]
+            );
 
-        // The result should look like this:
-        //
-        // [1, 2, 4, 5, 7, 8, 9, 10, 11, 12]
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Leaf);
-        assert_eq!(
-            root.entries(btree.memory()),
-            vec![
-                e(1),
-                e(2),
-                e(4),
-                e(5),
-                e(7),
-                e(8),
-                e(9),
-                e(10),
-                e(11),
-                e(12)
-            ]
-        );
-
-        // There is only one allocated node remaining.
-        assert_eq!(btree.allocator.num_allocated_chunks(), 1);
+            // There is only one allocated node remaining.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 1);
+        });
     }
 
     #[test]
@@ -1917,490 +1923,484 @@ mod test {
 
     #[test]
     fn reloading() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem.clone());
+        btree_test(|mut btree| {
+            // The btree is initially empty.
+            assert_eq!(btree.len(), 0);
+            assert!(btree.is_empty());
 
-        // The btree is initially empty.
-        assert_eq!(btree.len(), 0);
-        assert!(btree.is_empty());
+            // Add an entry into the btree.
+            assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
+            assert_eq!(btree.len(), 1);
+            assert!(!btree.is_empty());
 
-        // Add an entry into the btree.
-        assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
-        assert_eq!(btree.len(), 1);
-        assert!(!btree.is_empty());
+            // Reload the btree. The element should still be there, and `len()`
+            // should still be `1`.
+            let btree = BTreeMap::load(btree.into_memory());
+            assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
+            assert_eq!(btree.len(), 1);
+            assert!(!btree.is_empty());
 
-        // Reload the btree. The element should still be there, and `len()`
-        // should still be `1`.
-        let btree = BTreeMap::load(mem.clone());
-        assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
-        assert_eq!(btree.len(), 1);
-        assert!(!btree.is_empty());
+            // Remove an element. Length should be zero.
+            let mut btree = BTreeMap::load(btree.into_memory());
+            assert_eq!(btree.remove(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
+            assert_eq!(btree.len(), 0);
+            assert!(btree.is_empty());
 
-        // Remove an element. Length should be zero.
-        let mut btree = BTreeMap::load(mem.clone());
-        assert_eq!(btree.remove(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
-        assert_eq!(btree.len(), 0);
-        assert!(btree.is_empty());
-
-        // Reload. Btree should still be empty.
-        let btree = BTreeMap::<Blob<10>, Blob<10>, _>::load(mem);
-        assert_eq!(btree.get(&b(&[1, 2, 3])), None);
-        assert_eq!(btree.len(), 0);
-        assert!(btree.is_empty());
+            // Reload. Btree should still be empty.
+            let btree = BTreeMap::<Blob<10>, Blob<10>, _>::load(btree.into_memory());
+            assert_eq!(btree.get(&b(&[1, 2, 3])), None);
+            assert_eq!(btree.len(), 0);
+            assert!(btree.is_empty());
+        });
     }
 
     #[test]
     fn len() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            for i in 0..1000u32 {
+                assert_eq!(btree.insert(b(i.to_le_bytes().as_slice()), b(&[])), None);
+            }
 
-        for i in 0..1000u32 {
-            assert_eq!(btree.insert(b(i.to_le_bytes().as_slice()), b(&[])), None);
-        }
+            assert_eq!(btree.len(), 1000);
+            assert!(!btree.is_empty());
 
-        assert_eq!(btree.len(), 1000);
-        assert!(!btree.is_empty());
+            for i in 0..1000u32 {
+                assert_eq!(btree.remove(&b(i.to_le_bytes().as_slice())), Some(b(&[])));
+            }
 
-        for i in 0..1000u32 {
-            assert_eq!(btree.remove(&b(i.to_le_bytes().as_slice())), Some(b(&[])));
-        }
-
-        assert_eq!(btree.len(), 0);
-        assert!(btree.is_empty());
+            assert_eq!(btree.len(), 0);
+            assert!(btree.is_empty());
+        });
     }
 
     #[test]
     fn contains_key() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            // Insert even numbers from 0 to 1000.
+            for i in (0..1000u32).step_by(2) {
+                assert_eq!(btree.insert(b(i.to_le_bytes().as_slice()), b(&[])), None);
+            }
 
-        // Insert even numbers from 0 to 1000.
-        for i in (0..1000u32).step_by(2) {
-            assert_eq!(btree.insert(b(i.to_le_bytes().as_slice()), b(&[])), None);
-        }
-
-        // Contains key should return true on all the even numbers and false on all the odd
-        // numbers.
-        for i in 0..1000u32 {
-            assert_eq!(
-                btree.contains_key(&b(i.to_le_bytes().as_slice())),
-                i % 2 == 0
-            );
-        }
+            // Contains key should return true on all the even numbers and false on all the odd
+            // numbers.
+            for i in 0..1000u32 {
+                assert_eq!(
+                    btree.contains_key(&b(i.to_le_bytes().as_slice())),
+                    i % 2 == 0
+                );
+            }
+        });
     }
 
     #[test]
     fn range_empty() {
-        let mem = make_memory();
-        let btree = BTreeMap::<Blob<10>, Blob<10>, _>::new(mem);
-
-        // Test prefixes that don't exist in the map.
-        assert_eq!(btree.range(b(&[0])..).collect::<Vec<_>>(), vec![]);
-        assert_eq!(btree.range(b(&[1, 2, 3, 4])..).collect::<Vec<_>>(), vec![]);
+        btree_test(|btree| {
+            // Test prefixes that don't exist in the map.
+            assert_eq!(
+                btree
+                    .range(b(&[0])..)
+                    .collect::<Vec<(Blob<10>, Blob<10>)>>(),
+                vec![]
+            );
+            assert_eq!(btree.range(b(&[1, 2, 3, 4])..).collect::<Vec<_>>(), vec![]);
+        });
     }
 
     // Tests the case where the prefix is larger than all the entries in a leaf node.
     #[test]
     fn range_leaf_prefix_greater_than_all_entries() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            btree.insert(b(&[0]), b(&[]));
 
-        btree.insert(b(&[0]), b(&[]));
-
-        // Test a prefix that's larger than the value in the leaf node. Should be empty.
-        assert_eq!(btree.range(b(&[1])..).collect::<Vec<_>>(), vec![]);
+            // Test a prefix that's larger than the value in the leaf node. Should be empty.
+            assert_eq!(btree.range(b(&[1])..).collect::<Vec<_>>(), vec![]);
+        });
     }
 
     // Tests the case where the prefix is larger than all the entries in an internal node.
     #[test]
     fn range_internal_prefix_greater_than_all_entries() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            for i in 1..=12 {
+                assert_eq!(btree.insert(b(&[i]), b(&[])), None);
+            }
 
-        for i in 1..=12 {
-            assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-        }
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-        // The result should look like this:
-        //                [6]
-        //               /   \
-        // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
-
-        // Test a prefix that's larger than the value in the internal node.
-        assert_eq!(
-            btree.range(b(&[7])..b(&[8])).collect::<Vec<_>>(),
-            vec![(b(&[7]), b(&[]))]
-        );
+            // Test a prefix that's larger than the value in the internal node.
+            assert_eq!(
+                btree.range(b(&[7])..b(&[8])).collect::<Vec<_>>(),
+                vec![(b(&[7]), b(&[]))]
+            );
+        });
     }
 
     #[test]
     fn range_various_prefixes() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            btree.insert(b(&[0, 1]), b(&[]));
+            btree.insert(b(&[0, 2]), b(&[]));
+            btree.insert(b(&[0, 3]), b(&[]));
+            btree.insert(b(&[0, 4]), b(&[]));
+            btree.insert(b(&[1, 1]), b(&[]));
+            btree.insert(b(&[1, 2]), b(&[]));
+            btree.insert(b(&[1, 3]), b(&[]));
+            btree.insert(b(&[1, 4]), b(&[]));
+            btree.insert(b(&[2, 1]), b(&[]));
+            btree.insert(b(&[2, 2]), b(&[]));
+            btree.insert(b(&[2, 3]), b(&[]));
+            btree.insert(b(&[2, 4]), b(&[]));
 
-        btree.insert(b(&[0, 1]), b(&[]));
-        btree.insert(b(&[0, 2]), b(&[]));
-        btree.insert(b(&[0, 3]), b(&[]));
-        btree.insert(b(&[0, 4]), b(&[]));
-        btree.insert(b(&[1, 1]), b(&[]));
-        btree.insert(b(&[1, 2]), b(&[]));
-        btree.insert(b(&[1, 3]), b(&[]));
-        btree.insert(b(&[1, 4]), b(&[]));
-        btree.insert(b(&[2, 1]), b(&[]));
-        btree.insert(b(&[2, 2]), b(&[]));
-        btree.insert(b(&[2, 3]), b(&[]));
-        btree.insert(b(&[2, 4]), b(&[]));
+            // The result should look like this:
+            //                                         [(1, 2)]
+            //                                         /     \
+            // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 1)]       [(1, 3), (1, 4), (2, 1), (2, 2), (2, 3), (2, 4)]
 
-        // The result should look like this:
-        //                                         [(1, 2)]
-        //                                         /     \
-        // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 1)]       [(1, 3), (1, 4), (2, 1), (2, 2), (2, 3), (2, 4)]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![(b(&[1, 2]), vec![])]);
+            assert_eq!(root.children_len(), 2);
 
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(root.entries(btree.memory()), vec![(b(&[1, 2]), vec![])]);
-        assert_eq!(root.children_len(), 2);
+            // Tests a prefix that's smaller than the value in the internal node.
+            assert_eq!(
+                btree.range(b(&[0])..b(&[1])).collect::<Vec<_>>(),
+                vec![
+                    (b(&[0, 1]), b(&[])),
+                    (b(&[0, 2]), b(&[])),
+                    (b(&[0, 3]), b(&[])),
+                    (b(&[0, 4]), b(&[])),
+                ]
+            );
 
-        // Tests a prefix that's smaller than the value in the internal node.
-        assert_eq!(
-            btree.range(b(&[0])..b(&[1])).collect::<Vec<_>>(),
-            vec![
-                (b(&[0, 1]), b(&[])),
-                (b(&[0, 2]), b(&[])),
-                (b(&[0, 3]), b(&[])),
-                (b(&[0, 4]), b(&[])),
-            ]
-        );
+            // Tests a prefix that crosses several nodes.
+            assert_eq!(
+                btree.range(b(&[1])..b(&[2])).collect::<Vec<_>>(),
+                vec![
+                    (b(&[1, 1]), b(&[])),
+                    (b(&[1, 2]), b(&[])),
+                    (b(&[1, 3]), b(&[])),
+                    (b(&[1, 4]), b(&[])),
+                ]
+            );
 
-        // Tests a prefix that crosses several nodes.
-        assert_eq!(
-            btree.range(b(&[1])..b(&[2])).collect::<Vec<_>>(),
-            vec![
-                (b(&[1, 1]), b(&[])),
-                (b(&[1, 2]), b(&[])),
-                (b(&[1, 3]), b(&[])),
-                (b(&[1, 4]), b(&[])),
-            ]
-        );
-
-        // Tests a prefix that's larger than the value in the internal node.
-        assert_eq!(
-            btree.range(b(&[2])..b(&[3])).collect::<Vec<_>>(),
-            vec![
-                (b(&[2, 1]), b(&[])),
-                (b(&[2, 2]), b(&[])),
-                (b(&[2, 3]), b(&[])),
-                (b(&[2, 4]), b(&[])),
-            ]
-        );
+            // Tests a prefix that's larger than the value in the internal node.
+            assert_eq!(
+                btree.range(b(&[2])..b(&[3])).collect::<Vec<_>>(),
+                vec![
+                    (b(&[2, 1]), b(&[])),
+                    (b(&[2, 2]), b(&[])),
+                    (b(&[2, 3]), b(&[])),
+                    (b(&[2, 4]), b(&[])),
+                ]
+            );
+        });
     }
 
     #[test]
     fn range_various_prefixes_2() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            btree.insert(b(&[0, 1]), b(&[]));
+            btree.insert(b(&[0, 2]), b(&[]));
+            btree.insert(b(&[0, 3]), b(&[]));
+            btree.insert(b(&[0, 4]), b(&[]));
+            btree.insert(b(&[1, 2]), b(&[]));
+            btree.insert(b(&[1, 4]), b(&[]));
+            btree.insert(b(&[1, 6]), b(&[]));
+            btree.insert(b(&[1, 8]), b(&[]));
+            btree.insert(b(&[1, 10]), b(&[]));
+            btree.insert(b(&[2, 1]), b(&[]));
+            btree.insert(b(&[2, 2]), b(&[]));
+            btree.insert(b(&[2, 3]), b(&[]));
+            btree.insert(b(&[2, 4]), b(&[]));
+            btree.insert(b(&[2, 5]), b(&[]));
+            btree.insert(b(&[2, 6]), b(&[]));
+            btree.insert(b(&[2, 7]), b(&[]));
+            btree.insert(b(&[2, 8]), b(&[]));
+            btree.insert(b(&[2, 9]), b(&[]));
 
-        btree.insert(b(&[0, 1]), b(&[]));
-        btree.insert(b(&[0, 2]), b(&[]));
-        btree.insert(b(&[0, 3]), b(&[]));
-        btree.insert(b(&[0, 4]), b(&[]));
-        btree.insert(b(&[1, 2]), b(&[]));
-        btree.insert(b(&[1, 4]), b(&[]));
-        btree.insert(b(&[1, 6]), b(&[]));
-        btree.insert(b(&[1, 8]), b(&[]));
-        btree.insert(b(&[1, 10]), b(&[]));
-        btree.insert(b(&[2, 1]), b(&[]));
-        btree.insert(b(&[2, 2]), b(&[]));
-        btree.insert(b(&[2, 3]), b(&[]));
-        btree.insert(b(&[2, 4]), b(&[]));
-        btree.insert(b(&[2, 5]), b(&[]));
-        btree.insert(b(&[2, 6]), b(&[]));
-        btree.insert(b(&[2, 7]), b(&[]));
-        btree.insert(b(&[2, 8]), b(&[]));
-        btree.insert(b(&[2, 9]), b(&[]));
+            // The result should look like this:
+            //                                         [(1, 4), (2, 3)]
+            //                                         /      |       \
+            // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2)]       |        [(2, 4), (2, 5), (2, 6), (2, 7), (2, 8), (2, 9)]
+            //                                                |
+            //                             [(1, 6), (1, 8), (1, 10), (2, 1), (2, 2)]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![(b(&[1, 4]), vec![]), (b(&[2, 3]), vec![])]
+            );
+            assert_eq!(root.children_len(), 3);
 
-        // The result should look like this:
-        //                                         [(1, 4), (2, 3)]
-        //                                         /      |       \
-        // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2)]       |        [(2, 4), (2, 5), (2, 6), (2, 7), (2, 8), (2, 9)]
-        //                                                |
-        //                             [(1, 6), (1, 8), (1, 10), (2, 1), (2, 2)]
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(
-            root.entries(btree.memory()),
-            vec![(b(&[1, 4]), vec![]), (b(&[2, 3]), vec![])]
-        );
-        assert_eq!(root.children_len(), 3);
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![
+                    (b(&[0, 1]), vec![]),
+                    (b(&[0, 2]), vec![]),
+                    (b(&[0, 3]), vec![]),
+                    (b(&[0, 4]), vec![]),
+                    (b(&[1, 2]), vec![]),
+                ]
+            );
 
-        let child_0 = btree.load_node(root.child(0));
-        assert_eq!(child_0.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_0.entries(btree.memory()),
-            vec![
-                (b(&[0, 1]), vec![]),
-                (b(&[0, 2]), vec![]),
-                (b(&[0, 3]), vec![]),
-                (b(&[0, 4]), vec![]),
-                (b(&[1, 2]), vec![]),
-            ]
-        );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![
+                    (b(&[1, 6]), vec![]),
+                    (b(&[1, 8]), vec![]),
+                    (b(&[1, 10]), vec![]),
+                    (b(&[2, 1]), vec![]),
+                    (b(&[2, 2]), vec![]),
+                ]
+            );
 
-        let child_1 = btree.load_node(root.child(1));
-        assert_eq!(child_1.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_1.entries(btree.memory()),
-            vec![
-                (b(&[1, 6]), vec![]),
-                (b(&[1, 8]), vec![]),
-                (b(&[1, 10]), vec![]),
-                (b(&[2, 1]), vec![]),
-                (b(&[2, 2]), vec![]),
-            ]
-        );
+            let child_2 = btree.load_node(root.child(2));
+            assert_eq!(
+                child_2.entries(btree.memory()),
+                vec![
+                    (b(&[2, 4]), vec![]),
+                    (b(&[2, 5]), vec![]),
+                    (b(&[2, 6]), vec![]),
+                    (b(&[2, 7]), vec![]),
+                    (b(&[2, 8]), vec![]),
+                    (b(&[2, 9]), vec![]),
+                ]
+            );
 
-        let child_2 = btree.load_node(root.child(2));
-        assert_eq!(
-            child_2.entries(btree.memory()),
-            vec![
-                (b(&[2, 4]), vec![]),
-                (b(&[2, 5]), vec![]),
-                (b(&[2, 6]), vec![]),
-                (b(&[2, 7]), vec![]),
-                (b(&[2, 8]), vec![]),
-                (b(&[2, 9]), vec![]),
-            ]
-        );
+            // Tests a prefix that doesn't exist, but is in the middle of the root node.
+            assert_eq!(
+                btree.range(b(&[1, 5])..b(&[1, 6])).collect::<Vec<_>>(),
+                vec![]
+            );
 
-        // Tests a prefix that doesn't exist, but is in the middle of the root node.
-        assert_eq!(
-            btree.range(b(&[1, 5])..b(&[1, 6])).collect::<Vec<_>>(),
-            vec![]
-        );
+            // Tests a prefix that crosses several nodes.
+            assert_eq!(
+                btree.range(b(&[1])..b(&[2])).collect::<Vec<_>>(),
+                vec![
+                    (b(&[1, 2]), b(&[])),
+                    (b(&[1, 4]), b(&[])),
+                    (b(&[1, 6]), b(&[])),
+                    (b(&[1, 8]), b(&[])),
+                    (b(&[1, 10]), b(&[])),
+                ]
+            );
 
-        // Tests a prefix that crosses several nodes.
-        assert_eq!(
-            btree.range(b(&[1])..b(&[2])).collect::<Vec<_>>(),
-            vec![
-                (b(&[1, 2]), b(&[])),
-                (b(&[1, 4]), b(&[])),
-                (b(&[1, 6]), b(&[])),
-                (b(&[1, 8]), b(&[])),
-                (b(&[1, 10]), b(&[])),
-            ]
-        );
-
-        // Tests a prefix that starts from a leaf node, then iterates through the root and right
-        // sibling.
-        assert_eq!(
-            btree.range(b(&[2])..).collect::<Vec<_>>(),
-            vec![
-                (b(&[2, 1]), b(&[])),
-                (b(&[2, 2]), b(&[])),
-                (b(&[2, 3]), b(&[])),
-                (b(&[2, 4]), b(&[])),
-                (b(&[2, 5]), b(&[])),
-                (b(&[2, 6]), b(&[])),
-                (b(&[2, 7]), b(&[])),
-                (b(&[2, 8]), b(&[])),
-                (b(&[2, 9]), b(&[])),
-            ]
-        );
+            // Tests a prefix that starts from a leaf node, then iterates through the root and right
+            // sibling.
+            assert_eq!(
+                btree.range(b(&[2])..).collect::<Vec<_>>(),
+                vec![
+                    (b(&[2, 1]), b(&[])),
+                    (b(&[2, 2]), b(&[])),
+                    (b(&[2, 3]), b(&[])),
+                    (b(&[2, 4]), b(&[])),
+                    (b(&[2, 5]), b(&[])),
+                    (b(&[2, 6]), b(&[])),
+                    (b(&[2, 7]), b(&[])),
+                    (b(&[2, 8]), b(&[])),
+                    (b(&[2, 9]), b(&[])),
+                ]
+            );
+        });
     }
 
     #[test]
     fn range_large() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::<Blob<10>, Blob<10>, _>::new(mem);
+        btree_test(|mut btree| {
+            // Insert 1000 elements with prefix 0 and another 1000 elements with prefix 1.
+            for prefix in 0..=1 {
+                for i in 0..1000u32 {
+                    assert_eq!(
+                        btree.insert(
+                            // The key is the prefix followed by the integer's encoding.
+                            // The encoding is big-endian so that the byte representation of the
+                            // integers are sorted.
+                            b([vec![prefix], i.to_be_bytes().to_vec()]
+                                .into_iter()
+                                .flatten()
+                                .collect::<Vec<_>>()
+                                .as_slice()),
+                            b(&[])
+                        ),
+                        None
+                    );
+                }
+            }
 
-        // Insert 1000 elements with prefix 0 and another 1000 elements with prefix 1.
-        for prefix in 0..=1 {
-            for i in 0..1000u32 {
-                assert_eq!(
-                    btree.insert(
-                        // The key is the prefix followed by the integer's encoding.
-                        // The encoding is big-endian so that the byte representation of the
-                        // integers are sorted.
-                        b([vec![prefix], i.to_be_bytes().to_vec()]
+            // Getting the range with a prefix should return all 1000 elements with that prefix.
+            for prefix in 0..=1 {
+                let mut i: u32 = 0;
+                for (key, _) in btree.range(b(&[prefix])..b(&[prefix + 1])) {
+                    assert_eq!(
+                        key,
+                        b(&[vec![prefix], i.to_be_bytes().to_vec()]
                             .into_iter()
                             .flatten()
-                            .collect::<Vec<_>>()
-                            .as_slice()),
-                        b(&[])
-                    ),
-                    None
-                );
+                            .collect::<Vec<_>>())
+                    );
+                    i += 1;
+                }
+                assert_eq!(i, 1000);
             }
-        }
-
-        // Getting the range with a prefix should return all 1000 elements with that prefix.
-        for prefix in 0..=1 {
-            let mut i: u32 = 0;
-            for (key, _) in btree.range(b(&[prefix])..b(&[prefix + 1])) {
-                assert_eq!(
-                    key,
-                    b(&[vec![prefix], i.to_be_bytes().to_vec()]
-                        .into_iter()
-                        .flatten()
-                        .collect::<Vec<_>>())
-                );
-                i += 1;
-            }
-            assert_eq!(i, 1000);
-        }
+        });
     }
 
     #[test]
     fn range_various_prefixes_with_offset() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            btree.insert(b(&[0, 1]), b(&[]));
+            btree.insert(b(&[0, 2]), b(&[]));
+            btree.insert(b(&[0, 3]), b(&[]));
+            btree.insert(b(&[0, 4]), b(&[]));
+            btree.insert(b(&[1, 1]), b(&[]));
+            btree.insert(b(&[1, 2]), b(&[]));
+            btree.insert(b(&[1, 3]), b(&[]));
+            btree.insert(b(&[1, 4]), b(&[]));
+            btree.insert(b(&[2, 1]), b(&[]));
+            btree.insert(b(&[2, 2]), b(&[]));
+            btree.insert(b(&[2, 3]), b(&[]));
+            btree.insert(b(&[2, 4]), b(&[]));
 
-        btree.insert(b(&[0, 1]), b(&[]));
-        btree.insert(b(&[0, 2]), b(&[]));
-        btree.insert(b(&[0, 3]), b(&[]));
-        btree.insert(b(&[0, 4]), b(&[]));
-        btree.insert(b(&[1, 1]), b(&[]));
-        btree.insert(b(&[1, 2]), b(&[]));
-        btree.insert(b(&[1, 3]), b(&[]));
-        btree.insert(b(&[1, 4]), b(&[]));
-        btree.insert(b(&[2, 1]), b(&[]));
-        btree.insert(b(&[2, 2]), b(&[]));
-        btree.insert(b(&[2, 3]), b(&[]));
-        btree.insert(b(&[2, 4]), b(&[]));
+            // The result should look like this:
+            //                                         [(1, 2)]
+            //                                         /     \
+            // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 1)]       [(1, 3), (1, 4), (2, 1), (2, 2), (2, 3), (2, 4)]
 
-        // The result should look like this:
-        //                                         [(1, 2)]
-        //                                         /     \
-        // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 1)]       [(1, 3), (1, 4), (2, 1), (2, 2), (2, 3), (2, 4)]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![(b(&[1, 2]), vec![])]);
+            assert_eq!(root.children_len(), 2);
 
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(root.entries(btree.memory()), vec![(b(&[1, 2]), vec![])]);
-        assert_eq!(root.children_len(), 2);
+            assert_eq!(
+                btree.range(b(&[0])..b(&[1])).collect::<Vec<_>>(),
+                vec![
+                    (b(&[0, 1]), b(&[])),
+                    (b(&[0, 2]), b(&[])),
+                    (b(&[0, 3]), b(&[])),
+                    (b(&[0, 4]), b(&[])),
+                ]
+            );
 
-        assert_eq!(
-            btree.range(b(&[0])..b(&[1])).collect::<Vec<_>>(),
-            vec![
-                (b(&[0, 1]), b(&[])),
-                (b(&[0, 2]), b(&[])),
-                (b(&[0, 3]), b(&[])),
-                (b(&[0, 4]), b(&[])),
-            ]
-        );
+            // Tests a offset that has a value somewhere in the range of values of an internal node.
+            assert_eq!(
+                btree.range(b(&[1, 3])..b(&[2])).collect::<Vec<_>>(),
+                vec![(b(&[1, 3]), b(&[])), (b(&[1, 4]), b(&[])),]
+            );
 
-        // Tests a offset that has a value somewhere in the range of values of an internal node.
-        assert_eq!(
-            btree.range(b(&[1, 3])..b(&[2])).collect::<Vec<_>>(),
-            vec![(b(&[1, 3]), b(&[])), (b(&[1, 4]), b(&[])),]
-        );
-
-        // Tests a offset that's larger than the value in the internal node.
-        assert_eq!(btree.range(b(&[2, 5])..).collect::<Vec<_>>(), vec![]);
+            // Tests a offset that's larger than the value in the internal node.
+            assert_eq!(btree.range(b(&[2, 5])..).collect::<Vec<_>>(), vec![]);
+        });
     }
 
     #[test]
     fn range_various_prefixes_with_offset_2() {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            btree.insert(b(&[0, 1]), b(&[]));
+            btree.insert(b(&[0, 2]), b(&[]));
+            btree.insert(b(&[0, 3]), b(&[]));
+            btree.insert(b(&[0, 4]), b(&[]));
+            btree.insert(b(&[1, 2]), b(&[]));
+            btree.insert(b(&[1, 4]), b(&[]));
+            btree.insert(b(&[1, 6]), b(&[]));
+            btree.insert(b(&[1, 8]), b(&[]));
+            btree.insert(b(&[1, 10]), b(&[]));
+            btree.insert(b(&[2, 1]), b(&[]));
+            btree.insert(b(&[2, 2]), b(&[]));
+            btree.insert(b(&[2, 3]), b(&[]));
+            btree.insert(b(&[2, 4]), b(&[]));
+            btree.insert(b(&[2, 5]), b(&[]));
+            btree.insert(b(&[2, 6]), b(&[]));
+            btree.insert(b(&[2, 7]), b(&[]));
+            btree.insert(b(&[2, 8]), b(&[]));
+            btree.insert(b(&[2, 9]), b(&[]));
 
-        btree.insert(b(&[0, 1]), b(&[]));
-        btree.insert(b(&[0, 2]), b(&[]));
-        btree.insert(b(&[0, 3]), b(&[]));
-        btree.insert(b(&[0, 4]), b(&[]));
-        btree.insert(b(&[1, 2]), b(&[]));
-        btree.insert(b(&[1, 4]), b(&[]));
-        btree.insert(b(&[1, 6]), b(&[]));
-        btree.insert(b(&[1, 8]), b(&[]));
-        btree.insert(b(&[1, 10]), b(&[]));
-        btree.insert(b(&[2, 1]), b(&[]));
-        btree.insert(b(&[2, 2]), b(&[]));
-        btree.insert(b(&[2, 3]), b(&[]));
-        btree.insert(b(&[2, 4]), b(&[]));
-        btree.insert(b(&[2, 5]), b(&[]));
-        btree.insert(b(&[2, 6]), b(&[]));
-        btree.insert(b(&[2, 7]), b(&[]));
-        btree.insert(b(&[2, 8]), b(&[]));
-        btree.insert(b(&[2, 9]), b(&[]));
+            // The result should look like this:
+            //                                         [(1, 4), (2, 3)]
+            //                                         /      |       \
+            // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2)]       |        [(2, 4), (2, 5), (2, 6), (2, 7), (2, 8), (2, 9)]
+            //                                                |
+            //                             [(1, 6), (1, 8), (1, 10), (2, 1), (2, 2)]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![(b(&[1, 4]), vec![]), (b(&[2, 3]), vec![])]
+            );
+            assert_eq!(root.children_len(), 3);
 
-        // The result should look like this:
-        //                                         [(1, 4), (2, 3)]
-        //                                         /      |       \
-        // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2)]       |        [(2, 4), (2, 5), (2, 6), (2, 7), (2, 8), (2, 9)]
-        //                                                |
-        //                             [(1, 6), (1, 8), (1, 10), (2, 1), (2, 2)]
-        let root = btree.load_node(btree.root_addr);
-        assert_eq!(root.node_type(), NodeType::Internal);
-        assert_eq!(
-            root.entries(btree.memory()),
-            vec![(b(&[1, 4]), vec![]), (b(&[2, 3]), vec![])]
-        );
-        assert_eq!(root.children_len(), 3);
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![
+                    (b(&[0, 1]), vec![]),
+                    (b(&[0, 2]), vec![]),
+                    (b(&[0, 3]), vec![]),
+                    (b(&[0, 4]), vec![]),
+                    (b(&[1, 2]), vec![]),
+                ]
+            );
 
-        let child_0 = btree.load_node(root.child(0));
-        assert_eq!(child_0.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_0.entries(btree.memory()),
-            vec![
-                (b(&[0, 1]), vec![]),
-                (b(&[0, 2]), vec![]),
-                (b(&[0, 3]), vec![]),
-                (b(&[0, 4]), vec![]),
-                (b(&[1, 2]), vec![]),
-            ]
-        );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![
+                    (b(&[1, 6]), vec![]),
+                    (b(&[1, 8]), vec![]),
+                    (b(&[1, 10]), vec![]),
+                    (b(&[2, 1]), vec![]),
+                    (b(&[2, 2]), vec![]),
+                ]
+            );
 
-        let child_1 = btree.load_node(root.child(1));
-        assert_eq!(child_1.node_type(), NodeType::Leaf);
-        assert_eq!(
-            child_1.entries(btree.memory()),
-            vec![
-                (b(&[1, 6]), vec![]),
-                (b(&[1, 8]), vec![]),
-                (b(&[1, 10]), vec![]),
-                (b(&[2, 1]), vec![]),
-                (b(&[2, 2]), vec![]),
-            ]
-        );
+            let child_2 = btree.load_node(root.child(2));
+            assert_eq!(
+                child_2.entries(btree.memory()),
+                vec![
+                    (b(&[2, 4]), vec![]),
+                    (b(&[2, 5]), vec![]),
+                    (b(&[2, 6]), vec![]),
+                    (b(&[2, 7]), vec![]),
+                    (b(&[2, 8]), vec![]),
+                    (b(&[2, 9]), vec![]),
+                ]
+            );
 
-        let child_2 = btree.load_node(root.child(2));
-        assert_eq!(
-            child_2.entries(btree.memory()),
-            vec![
-                (b(&[2, 4]), vec![]),
-                (b(&[2, 5]), vec![]),
-                (b(&[2, 6]), vec![]),
-                (b(&[2, 7]), vec![]),
-                (b(&[2, 8]), vec![]),
-                (b(&[2, 9]), vec![]),
-            ]
-        );
+            // Tests a offset that crosses several nodes.
+            assert_eq!(
+                btree.range(b(&[1, 4])..b(&[2])).collect::<Vec<_>>(),
+                vec![
+                    (b(&[1, 4]), b(&[])),
+                    (b(&[1, 6]), b(&[])),
+                    (b(&[1, 8]), b(&[])),
+                    (b(&[1, 10]), b(&[])),
+                ]
+            );
 
-        // Tests a offset that crosses several nodes.
-        assert_eq!(
-            btree.range(b(&[1, 4])..b(&[2])).collect::<Vec<_>>(),
-            vec![
-                (b(&[1, 4]), b(&[])),
-                (b(&[1, 6]), b(&[])),
-                (b(&[1, 8]), b(&[])),
-                (b(&[1, 10]), b(&[])),
-            ]
-        );
-
-        // Tests a offset that starts from a leaf node, then iterates through the root and right
-        // sibling.
-        assert_eq!(
-            btree.range(b(&[2, 2])..b(&[3])).collect::<Vec<_>>(),
-            vec![
-                (b(&[2, 2]), b(&[])),
-                (b(&[2, 3]), b(&[])),
-                (b(&[2, 4]), b(&[])),
-                (b(&[2, 5]), b(&[])),
-                (b(&[2, 6]), b(&[])),
-                (b(&[2, 7]), b(&[])),
-                (b(&[2, 8]), b(&[])),
-                (b(&[2, 9]), b(&[])),
-            ]
-        );
+            // Tests a offset that starts from a leaf node, then iterates through the root and right
+            // sibling.
+            assert_eq!(
+                btree.range(b(&[2, 2])..b(&[3])).collect::<Vec<_>>(),
+                vec![
+                    (b(&[2, 2]), b(&[])),
+                    (b(&[2, 3]), b(&[])),
+                    (b(&[2, 4]), b(&[])),
+                    (b(&[2, 5]), b(&[])),
+                    (b(&[2, 6]), b(&[])),
+                    (b(&[2, 7]), b(&[])),
+                    (b(&[2, 8]), b(&[])),
+                    (b(&[2, 9]), b(&[])),
+                ]
+            );
+        });
     }
 
     #[test]
@@ -2441,89 +2441,87 @@ mod test {
 
     #[test]
     fn bruteforce_range_search() {
-        use super::BTreeMap as StableBTreeMap;
-        use std::collections::BTreeMap;
+        btree_test(|mut stable_map| {
+            use std::collections::BTreeMap;
+            const NKEYS: u64 = 60;
+            let mut std_map = BTreeMap::new();
 
-        const NKEYS: u64 = 60;
-
-        let mut std_map = BTreeMap::new();
-        let mut stable_map = StableBTreeMap::new(make_memory());
-
-        for k in 0..NKEYS {
-            std_map.insert(k, k);
-            stable_map.insert(k, k);
-        }
-
-        assert_eq!(
-            std_map.range(..).map(|(k, v)| (*k, *v)).collect::<Vec<_>>(),
-            stable_map.range(..).collect::<Vec<_>>()
-        );
-
-        for l in 0..=NKEYS {
-            assert_eq!(
-                std_map
-                    .range(l..)
-                    .map(|(k, v)| (*k, *v))
-                    .collect::<Vec<_>>(),
-                stable_map.range(l..).collect::<Vec<_>>()
-            );
+            for k in 0..NKEYS {
+                std_map.insert(k, k);
+                stable_map.insert(k, k);
+            }
 
             assert_eq!(
-                std_map
-                    .range(..l)
-                    .map(|(k, v)| (*k, *v))
-                    .collect::<Vec<_>>(),
-                stable_map.range(..l).collect::<Vec<_>>()
+                std_map.range(..).map(|(k, v)| (*k, *v)).collect::<Vec<_>>(),
+                stable_map.range(..).collect::<Vec<_>>()
             );
 
-            assert_eq!(
-                std_map
-                    .range(..=l)
-                    .map(|(k, v)| (*k, *v))
-                    .collect::<Vec<_>>(),
-                stable_map.range(..=l).collect::<Vec<_>>()
-            );
+            for l in 0..=NKEYS {
+                assert_eq!(
+                    std_map
+                        .range(l..)
+                        .map(|(k, v)| (*k, *v))
+                        .collect::<Vec<_>>(),
+                    stable_map.range(l..).collect::<Vec<_>>()
+                );
 
-            for r in l + 1..=NKEYS {
-                for lbound in [Bound::Included(l), Bound::Excluded(l)] {
-                    for rbound in [Bound::Included(r), Bound::Excluded(r)] {
-                        let range = (lbound, rbound);
-                        assert_eq!(
-                            std_map
-                                .range(range)
-                                .map(|(k, v)| (*k, *v))
-                                .collect::<Vec<_>>(),
-                            stable_map.range(range).collect::<Vec<_>>(),
-                            "range: {range:?}"
-                        );
+                assert_eq!(
+                    std_map
+                        .range(..l)
+                        .map(|(k, v)| (*k, *v))
+                        .collect::<Vec<_>>(),
+                    stable_map.range(..l).collect::<Vec<_>>()
+                );
+
+                assert_eq!(
+                    std_map
+                        .range(..=l)
+                        .map(|(k, v)| (*k, *v))
+                        .collect::<Vec<_>>(),
+                    stable_map.range(..=l).collect::<Vec<_>>()
+                );
+
+                for r in l + 1..=NKEYS {
+                    for lbound in [Bound::Included(l), Bound::Excluded(l)] {
+                        for rbound in [Bound::Included(r), Bound::Excluded(r)] {
+                            let range = (lbound, rbound);
+                            assert_eq!(
+                                std_map
+                                    .range(range)
+                                    .map(|(k, v)| (*k, *v))
+                                    .collect::<Vec<_>>(),
+                                stable_map.range(range).collect::<Vec<_>>(),
+                                "range: {range:?}"
+                            );
+                        }
                     }
                 }
             }
-        }
+        });
     }
 
     #[test]
     fn test_iter_upper_bound() {
-        let mut stable_map = super::BTreeMap::new(make_memory());
-        for k in 0..100u64 {
-            stable_map.insert(k, ());
-            for i in 0..=k {
+        btree_test(|mut btree| {
+            for k in 0..100u64 {
+                btree.insert(k, ());
+                for i in 0..=k {
+                    assert_eq!(
+                        Some((i, ())),
+                        btree.iter_upper_bound(&(i + 1)).next(),
+                        "failed to get an upper bound for key {}",
+                        i + 1
+                    );
+                }
                 assert_eq!(
-                    Some((i, ())),
-                    stable_map.iter_upper_bound(&(i + 1)).next(),
-                    "failed to get an upper bound for key {}",
-                    i + 1
+                    None,
+                    btree.iter_upper_bound(&0).next(),
+                    "key 0 must not have an upper bound"
                 );
             }
-            assert_eq!(
-                None,
-                stable_map.iter_upper_bound(&0).next(),
-                "key 0 must not have an upper bound"
-            );
-        }
+        });
     }
 
-    /*
     #[test]
     #[should_panic(expected = "Key is too large. Expected <= 0 bytes, found 4 bytes")]
     fn panics_if_key_is_too_large() {
@@ -2574,7 +2572,7 @@ mod test {
 
         let mut btree: BTreeMap<(), V, _> = BTreeMap::init(make_memory());
         btree.insert((), V);
-    }*/
+    }
 
     // To generate the memory dump file for the current version:
     //   cargo test create_btreemap_dump_file -- --include-ignored

--- a/src/btreemap/node/tests.rs
+++ b/src/btreemap/node/tests.rs
@@ -37,8 +37,10 @@ impl NodeV1Data {
         let mut node = Node::new_v1(
             address,
             self.node_type,
-            self.max_key_size,
-            self.max_value_size,
+            DerivedPageSize {
+                max_key_size: self.max_key_size,
+                max_value_size: self.max_value_size,
+            },
         );
 
         // Push the entries

--- a/src/btreemap/node/v1.rs
+++ b/src/btreemap/node/v1.rs
@@ -40,11 +40,7 @@ use super::*;
 
 impl<K: Storable + Ord + Clone> Node<K> {
     /// Creates a new v1 node at the given address.
-    pub fn new_v1(
-        address: Address,
-        node_type: NodeType,
-        page_size: DerivedPageSize,
-    ) -> Node<K> {
+    pub fn new_v1(address: Address, node_type: NodeType, page_size: DerivedPageSize) -> Node<K> {
         Node {
             address,
             node_type,

--- a/src/btreemap/node/v1.rs
+++ b/src/btreemap/node/v1.rs
@@ -40,11 +40,10 @@ use super::*;
 
 impl<K: Storable + Ord + Clone> Node<K> {
     /// Creates a new v1 node at the given address.
-    pub(super) fn new_v1(
+    pub fn new_v1(
         address: Address,
         node_type: NodeType,
-        max_key_size: u32,
-        max_value_size: u32,
+        page_size: DerivedPageSize,
     ) -> Node<K> {
         Node {
             address,
@@ -52,10 +51,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
             keys: vec![],
             encoded_values: RefCell::default(),
             children: vec![],
-            version: Version::V1(DerivedPageSize {
-                max_key_size,
-                max_value_size,
-            }),
+            version: Version::V1(page_size),
             overflow: None,
         }
     }

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -96,7 +96,7 @@ const MINIMUM_PAGE_SIZE: u32 = 128;
 
 impl<K: Storable + Ord + Clone> Node<K> {
     /// Creates a new v2 node at the given address.
-    pub(super) fn new_v2(address: Address, node_type: NodeType, page_size: PageSize) -> Node<K> {
+    pub fn new_v2(address: Address, node_type: NodeType, page_size: PageSize) -> Node<K> {
         assert!(page_size.get() >= MINIMUM_PAGE_SIZE);
 
         Node {
@@ -192,7 +192,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
 
     // Saves the node to memory.
     pub(super) fn save_v2<M: Memory>(&self, allocator: &mut Allocator<M>) {
-        let page_size = self.version.page_size();
+        let page_size = self.version.page_size().get();
         assert!(page_size >= MINIMUM_PAGE_SIZE);
         assert_eq!(self.keys.len(), self.encoded_values.borrow().len());
 

--- a/src/btreemap/proptests.rs
+++ b/src/btreemap/proptests.rs
@@ -1,13 +1,10 @@
-use crate::{btreemap::test::b, storable::Blob, BTreeMap};
+use crate::{
+    btreemap::test::{b, btree_test},
+    storable::Blob,
+};
 use proptest::collection::btree_set as pset;
 use proptest::collection::vec as pvec;
 use proptest::prelude::*;
-use std::cell::RefCell;
-use std::rc::Rc;
-
-fn make_memory() -> Rc<RefCell<Vec<u8>>> {
-    Rc::new(RefCell::new(Vec::new()))
-}
 
 fn arb_blob() -> impl Strategy<Value = Blob<10>> {
     pvec(0..u8::MAX, 0..10).prop_map(|v| Blob::<10>::try_from(v.as_slice()).unwrap())
@@ -17,47 +14,51 @@ proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
     #[test]
     fn insert(keys in pset(arb_blob(), 1000..10_000)) {
-        let mem = make_memory();
-        let mut btree = BTreeMap::new(mem);
+        btree_test(|mut btree| {
+            let keys = keys.clone();
+            for key in keys.iter() {
+                assert_eq!(btree.insert(*key, *key), None);
+            }
 
-        for key in keys.iter() {
-            assert_eq!(btree.insert(*key, *key), None);
-        }
-
-        for key in keys.into_iter() {
-            // Assert we retrieved the old value correctly.
-            assert_eq!(btree.insert(key, b(&[])), Some(key));
-            // Assert we retrieved the new value correctly.
-            assert_eq!(btree.get(&key), Some(b(&[])));
-        }
+            for key in keys.into_iter() {
+                // Assert we retrieved the old value correctly.
+                assert_eq!(btree.insert(key, b(&[])), Some(key));
+                // Assert we retrieved the new value correctly.
+                assert_eq!(btree.get(&key), Some(b(&[])));
+            }
+        });
     }
 
     #[test]
     fn map_min_max(keys in pvec(any::<u64>(), 10..100)) {
-        let mut map = BTreeMap::<u64, u64, _>::new(make_memory());
+        btree_test(|mut map| {
+            prop_assert_eq!(map.first_key_value(), None);
+            prop_assert_eq!(map.last_key_value(), None);
 
-        prop_assert_eq!(map.first_key_value(), None);
-        prop_assert_eq!(map.last_key_value(), None);
+            for (n, key) in keys.iter().enumerate() {
+                map.insert(*key, *key);
 
-        for (n, key) in keys.iter().enumerate() {
-            map.insert(*key, *key);
+                let min = keys[0..=n].iter().min().unwrap();
+                let max = keys[0..=n].iter().max().unwrap();
 
-            let min = keys[0..=n].iter().min().unwrap();
-            let max = keys[0..=n].iter().max().unwrap();
+                prop_assert_eq!(map.first_key_value(), Some((*min, *min)));
+                prop_assert_eq!(map.last_key_value(), Some((*max, *max)))
+            }
 
-            prop_assert_eq!(map.first_key_value(), Some((*min, *min)));
-            prop_assert_eq!(map.last_key_value(), Some((*max, *max)))
-        }
+            Ok(())
+        });
     }
 
     #[test]
     fn map_upper_bound_iter(keys in pvec(0u64..u64::MAX -1 , 10..100)) {
-        let mut map = BTreeMap::<u64, (), _>::new(make_memory());
+        btree_test(|mut map| {
+            for k in keys.iter() {
+                map.insert(*k, ());
 
-        for k in keys.iter() {
-            map.insert(*k, ());
+                prop_assert_eq!(Some((*k, ())), map.iter_upper_bound(&(k + 1)).next());
+            }
 
-            prop_assert_eq!(Some((*k, ())), map.iter_upper_bound(&(k + 1)).next());
-        }
+            Ok(())
+        });
     }
 }


### PR DESCRIPTION
This commit introduces V2 of BTreeMap which supports unbounded keys and values.

* V2 so far is intended only for beta testing and should not be used in any production setting. By default, BTreeMaps are using V1. V2 nodes are available only when initializing a BTreeMap with `init_v2` or `new_v2`. In the future, V1 maps will be migrated automatically to V2.
* Tests are updated to run for both V1 and V2 versions of the map.
* Benchmarks now include both V1 and V2. V2 is significantly slower at the moment per the benchmarking results below, but optimizations to follow on this PR will narrow that gap.

```
btreemap_insert_blob_4_1024
                        time:   [914.81 M Instructions 914.81 M Instructions 914.81 M Instructions]
                        change: [+0.1085% +0.1085% +0.1085%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_blob_4_1024_v2
                        time:   [5074.9 M Instructions 5074.9 M Instructions 5074.9 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_insert_blob_8_1024
                        time:   [1054.3 M Instructions 1054.3 M Instructions 1054.3 M Instructions]
                        change: [+0.1306% +0.1306% +0.1306%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_blob_8_1024_v2
                        time:   [5533.1 M Instructions 5533.1 M Instructions 5533.1 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_insert_blob_16_1024
                        time:   [1150.9 M Instructions 1150.9 M Instructions 1150.9 M Instructions]
                        change: [+0.1327% +0.1327% +0.1327%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_blob_16_1024_v2
                        time:   [5638.8 M Instructions 5638.8 M Instructions 5638.8 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_insert_blob_32_1024
                        time:   [1194.9 M Instructions 1194.9 M Instructions 1194.9 M Instructions]
                        change: [+0.1312% +0.1312% +0.1312%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_blob_32_1024_v2
                        time:   [5813.9 M Instructions 5813.9 M Instructions 5813.9 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_insert_blob_64_1024
                        time:   [1434.8 M Instructions 1434.8 M Instructions 1434.8 M Instructions]
                        change: [+0.1131% +0.1131% +0.1131%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_blob_64_1024_v2
                        time:   [6414.8 M Instructions 6414.8 M Instructions 6414.8 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_insert_blob_128_1024
                        time:   [1694.4 M Instructions 1694.4 M Instructions 1694.4 M Instructions]
                        change: [+0.0955% +0.0955% +0.0955%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_blob_128_1024_v2
                        time:   [7011.3 M Instructions 7011.3 M Instructions 7011.3 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_insert_blob_256_1024
                        time:   [2211.4 M Instructions 2211.4 M Instructions 2211.4 M Instructions]
                        change: [+0.0733% +0.0733% +0.0733%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_blob_256_1024_v2
                        time:   [7715.7 M Instructions 7715.7 M Instructions 7715.7 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_insert_blob_512_1024
                        time:   [3272.6 M Instructions 3272.6 M Instructions 3272.6 M Instructions]
                        change: [+0.0501% +0.0501% +0.0501%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_blob_512_1024_v2
                        time:   [9668.8 M Instructions 9668.8 M Instructions 9668.8 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_insert_u64_u64 time:   [771.21 M Instructions 771.21 M Instructions 771.21 M Instructions]
                        change: [+0.1894% +0.1894% +0.1894%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_u64_u64_v2
                        time:   [1187.0 M Instructions 1187.0 M Instructions 1187.0 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_insert_u64_blob_8
                        time:   [744.40 M Instructions 744.40 M Instructions 744.40 M Instructions]
                        change: [+0.2643% +0.2643% +0.2643%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_u64_blob_8_v2
                        time:   [1123.4 M Instructions 1123.4 M Instructions 1123.4 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_insert_blob_8_u64
                        time:   [655.21 M Instructions 655.21 M Instructions 655.21 M Instructions]
                        change: [+0.1334% +0.1334% +0.1334%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_insert_blob_8_u64_v2
                        time:   [1091.2 M Instructions 1091.2 M Instructions 1091.2 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_get_blob_4_1024
                        time:   [401.24 M Instructions 401.24 M Instructions 401.24 M Instructions]
                        change: [+0.2791% +0.2791% +0.2791%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_get_blob_4_1024_v2
                        time:   [4919.7 M Instructions 4919.7 M Instructions 4919.7 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_get_blob_8_1024
                        time:   [468.41 M Instructions 468.41 M Instructions 468.41 M Instructions]
                        change: [+0.3022% +0.3022% +0.3022%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_get_blob_8_1024_v2
                        time:   [4541.9 M Instructions 4541.9 M Instructions 4541.9 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_get_blob_16_1024
                        time:   [550.95 M Instructions 550.95 M Instructions 550.95 M Instructions]
                        change: [+0.2571% +0.2571% +0.2571%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_get_blob_16_1024_v2
                        time:   [4599.1 M Instructions 4599.1 M Instructions 4599.1 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_get_blob_32_1024
                        time:   [581.65 M Instructions 581.65 M Instructions 581.65 M Instructions]
                        change: [+0.2433% +0.2433% +0.2433%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_get_blob_32_1024_v2
                        time:   [5042.3 M Instructions 5042.3 M Instructions 5042.3 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_get_blob_64_1024
                        time:   [805.48 M Instructions 805.48 M Instructions 805.48 M Instructions]
                        change: [+0.1756% +0.1756% +0.1756%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_get_blob_64_1024_v2
                        time:   [5444.2 M Instructions 5444.2 M Instructions 5444.2 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_get_blob_128_1024
                        time:   [1027.1 M Instructions 1027.1 M Instructions 1027.1 M Instructions]
                        change: [+0.1376% +0.1376% +0.1376%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_get_blob_128_1024_v2
                        time:   [5956.1 M Instructions 5956.1 M Instructions 5956.1 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_get_u64_u64    time:   [398.59 M Instructions 398.59 M Instructions 398.59 M Instructions]
                        change: [+0.1511% +0.1511% +0.1511%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_get_u64_u64_v2 time:   [873.64 M Instructions 873.64 M Instructions 873.64 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_get_u64_blob_8 time:   [394.74 M Instructions 394.74 M Instructions 394.74 M Instructions]
                        change: [+0.1526% +0.1526% +0.1526%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_get_u64_blob_8_v2
                        time:   [826.19 M Instructions 826.19 M Instructions 826.19 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_get_blob_8_u64 time:   [413.86 M Instructions 413.86 M Instructions 413.86 M Instructions]
                        change: [+0.3417% +0.3417% +0.3417%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_get_blob_8_u64_v2
                        time:   [939.20 M Instructions 939.20 M Instructions 939.20 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_get_blob_256_1024
                        time:   [1516.9 M Instructions 1516.9 M Instructions 1516.9 M Instructions]
                        change: [+0.0931% +0.0931% +0.0931%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_get_blob_256_1024_v2
                        time:   [6626.5 M Instructions 6626.5 M Instructions 6626.5 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_get_blob_512_1024
                        time:   [2482.5 M Instructions 2482.5 M Instructions 2482.5 M Instructions]
                        change: [+0.0569% +0.0569% +0.0569%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_get_blob_512_1024_v2
                        time:   [8287.2 M Instructions 8287.2 M Instructions 8287.2 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_remove_blob_4_1024
                        time:   [992.32 M Instructions 992.32 M Instructions 992.32 M Instructions]
                        change: [+0.2592% +0.2592% +0.2592%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_blob_4_1024_v2
                        time:   [992.32 M Instructions 992.32 M Instructions 992.32 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_remove_blob_8_1024
                        time:   [1270.9 M Instructions 1270.9 M Instructions 1270.9 M Instructions]
                        change: [+0.2561% +0.2561% +0.2561%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_blob_8_1024_v2
                        time:   [1270.9 M Instructions 1270.9 M Instructions 1270.9 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_remove_blob_16_1024
                        time:   [1515.7 M Instructions 1515.7 M Instructions 1515.7 M Instructions]
                        change: [+0.2385% +0.2385% +0.2385%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_blob_16_1024_v2
                        time:   [6992.4 M Instructions 6992.4 M Instructions 6992.4 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

btreemap_remove_blob_32_1024
                        time:   [1591.1 M Instructions 1591.1 M Instructions 1591.1 M Instructions]
                        change: [+0.2333% +0.2333% +0.2333%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_blob_32_1024_v2
                        time:   [7302.3 M Instructions 7302.3 M Instructions 7302.3 M Instructions]

btreemap_remove_blob_64_1024
                        time:   [1885.5 M Instructions 1885.5 M Instructions 1885.5 M Instructions]
                        change: [+0.2106% +0.2106% +0.2106%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_blob_64_1024_v2
                        time:   [7648.3 M Instructions 7648.3 M Instructions 7648.3 M Instructions]

btreemap_remove_blob_128_1024
                        time:   [2208.4 M Instructions 2208.4 M Instructions 2208.4 M Instructions]
                        change: [+0.1834% +0.1834% +0.1834%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_blob_128_1024_v2
                        time:   [8196.6 M Instructions 8196.6 M Instructions 8196.6 M Instructions]

btreemap_remove_blob_256_1024
                        time:   [2817.9 M Instructions 2817.9 M Instructions 2817.9 M Instructions]
                        change: [+0.1411% +0.1411% +0.1411%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_blob_256_1024_v2
                        time:   [9505.1 M Instructions 9505.1 M Instructions 9505.1 M Instructions]

btreemap_remove_blob_512_1024
                        time:   [4114.4 M Instructions 4114.4 M Instructions 4114.4 M Instructions]
                        change: [+0.0992% +0.0992% +0.0992%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_blob_512_1024_v2
                        time:   [11.583 B Instructions 11.583 B Instructions 11.583 B Instructions]

btreemap_remove_u64_u64 time:   [1094.6 M Instructions 1094.6 M Instructions 1094.6 M Instructions]
                        change: [+0.2506% +0.2506% +0.2506%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_u64_u64_v2
                        time:   [1486.5 M Instructions 1486.5 M Instructions 1486.5 M Instructions]

btreemap_remove_u64_blob_8
                        time:   [1053.1 M Instructions 1053.1 M Instructions 1053.1 M Instructions]
                        change: [+0.2572% +0.2572% +0.2572%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_u64_blob_8_v2
                        time:   [1411.6 M Instructions 1411.6 M Instructions 1411.6 M Instructions]

btreemap_remove_blob_8_u64
                        time:   [868.16 M Instructions 868.16 M Instructions 868.16 M Instructions]
                        change: [+0.3910% +0.3910% +0.3910%] (p = 0.00 < 0.05)
                        Change within noise threshold.

btreemap_remove_blob_8_u64_v2
                        time:   [1346.4 M Instructions 1346.4 M Instructions 1346.4 M Instructions]
```