### PR TITLE
fix: init_v2 BTreeMap::new

### DIFF
--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -120,7 +120,7 @@ where
     pub fn init_v2(memory: M) -> Self {
         if memory.size() == 0 {
             // Memory is empty. Create a new map.
-            return BTreeMap::new(memory);
+            return BTreeMap::new_v2(memory);
         }
 
         // Check if the magic in the memory corresponds to a BTreeMap.


### PR DESCRIPTION
Hi @ielashi,

I'm not sure but, is it possible that the init of a new `BTreeMap::new` in `init_v2` is incorrect in your PR and should be replaced with `BTreeMap::new_v2`?

At least, while testing your PR, I was facing following error which seems to be resolved by tweaking those.

> 2023-08-26 14:42:36.677876 UTC: [Canister by6od-j4aaa-aaaaa-qaadq-cai] Panicked at 'Cannot get max size of unbounded type.', /Users/daviddalbusco/.cargo/git/checkouts/stable-structures-10185dfe005f3b12/8620b4f/src/storable.rs:450:9