### PR TITLE
fix: memory leak in BTreeMap V2

### DIFF
--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -690,7 +690,7 @@ where
                         assert!(right_child.at_minimum());
 
                         // Merge the right child into the left child.
-                        let new_child = self.merge(
+                        let mut new_child = self.merge(
                             right_child,
                             left_child,
                             node.remove_entry(idx, self.memory()),

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -76,7 +76,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
     }
 
     /// Saves the node to memory.
-    pub fn save<M: Memory>(&self, allocator: &mut Allocator<M>) {
+    pub fn save<M: Memory>(&mut self, allocator: &mut Allocator<M>) {
         match self.version {
             Version::V1(_) => self.save_v1(allocator.memory()),
             Version::V2(_) => self.save_v2(allocator),

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -196,12 +196,6 @@ impl<K: Storable + Ord + Clone> Node<K> {
         assert!(page_size >= MINIMUM_PAGE_SIZE);
         assert_eq!(self.keys.len(), self.encoded_values.borrow().len());
 
-        // We should never be saving an empty node.
-       // assert!(!self.keys.is_empty() || !self.children.is_empty());
-
-        // Assert entries are sorted in strictly increasing order.
-        //assert!(self.keys.windows(2).all(|e| e[0] < e[1]));
-
         // A buffer to serialize the node into first, then write to memory.
         let mut buf = vec![];
         buf.extend_from_slice(MAGIC);

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -188,13 +188,19 @@ impl<K: Storable + Ord + Clone> Node<K> {
     }
 
     // Saves the node to memory.
-    pub(super) fn save_v2<M: Memory>(&self, allocator: &mut Allocator<M>) {
+    pub(super) fn save_v2<M: Memory>(&mut self, allocator: &mut Allocator<M>) {
         #[cfg(feature = "profiler")]
         let _p = profiler::profile("node_save_v2");
 
         let page_size = self.version.page_size().get();
         assert!(page_size >= MINIMUM_PAGE_SIZE);
         assert_eq!(self.keys.len(), self.encoded_values.borrow().len());
+
+        // We should never be saving an empty node.
+       // assert!(!self.keys.is_empty() || !self.children.is_empty());
+
+        // Assert entries are sorted in strictly increasing order.
+        //assert!(self.keys.windows(2).all(|e| e[0] < e[1]));
 
         // A buffer to serialize the node into first, then write to memory.
         let mut buf = vec![];
@@ -248,13 +254,13 @@ impl<K: Storable + Ord + Clone> Node<K> {
     // Writes a buffer into pages of the given page size.
     // Pages can be allocated and deallocated as needed.
     fn write_paginated<M: Memory>(
-        &self,
+        &mut self,
         buf: Vec<u8>,
         allocator: &mut Allocator<M>,
         page_size: usize,
     ) {
         // Compute how many overflow pages are needed.
-        let additional_pages_needed = if buf.len() > page_size {
+        let overflow_pages_needed = if buf.len() > page_size {
             debug_assert!(page_size >= PAGE_OVERFLOW_DATA_OFFSET.get() as usize);
             let overflow_page_capacity = page_size - PAGE_OVERFLOW_DATA_OFFSET.get() as usize;
             let overflow_data_len = buf.len() - page_size;
@@ -266,17 +272,17 @@ impl<K: Storable + Ord + Clone> Node<K> {
         };
 
         // Retrieve the addresses for the overflow pages, making the necessary allocations.
-        let overflows = self.reallocate_overflow_pages(additional_pages_needed, allocator);
+        self.reallocate_overflow_pages(overflow_pages_needed, allocator);
 
         // Write the first page
         let memory = allocator.memory();
         memory.write(self.address.get(), &buf[..min(page_size, buf.len())]);
-        if !overflows.is_empty() {
+        if !self.overflows.is_empty() {
             // Write the next overflow address to the first page.
             write_u64(
                 memory,
                 self.address + OVERFLOW_ADDRESS_OFFSET,
-                overflows[0].get(),
+                self.overflows[0].get(),
             );
         }
 
@@ -293,17 +299,17 @@ impl<K: Storable + Ord + Clone> Node<K> {
             }
 
             // Write magic and next address
-            memory.write(overflows[i].get(), &OVERFLOW_MAGIC[..]);
-            let next_address = overflows.get(i + 1).unwrap_or(&NULL);
+            memory.write(self.overflows[i].get(), &OVERFLOW_MAGIC[..]);
+            let next_address = self.overflows.get(i + 1).unwrap_or(&NULL);
             write_u64(
                 memory,
-                overflows[i] + PAGE_OVERFLOW_NEXT_OFFSET,
+                self.overflows[i] + PAGE_OVERFLOW_NEXT_OFFSET,
                 next_address.get(),
             );
 
             // Write the overflow page contents
             memory.write(
-                (overflows[i] + PAGE_OVERFLOW_DATA_OFFSET).get(),
+                (self.overflows[i] + PAGE_OVERFLOW_DATA_OFFSET).get(),
                 &buf[start_idx..end_idx],
             );
 
@@ -312,25 +318,20 @@ impl<K: Storable + Ord + Clone> Node<K> {
     }
 
     fn reallocate_overflow_pages<M: Memory>(
-        &self,
+        &mut self,
         num_overflow_pages: usize,
         allocator: &mut Allocator<M>,
-    ) -> Vec<Address> {
-        // Fetch the overflow page addresses of this node.
-        let mut addresses = self.overflows.clone();
-
+    ) {
         // If there are too many overflow addresses, deallocate some until we've reached
         // the number we need.
-        while addresses.len() > num_overflow_pages {
-            allocator.deallocate(addresses.pop().unwrap());
+        while self.overflows.len() > num_overflow_pages {
+            allocator.deallocate(self.overflows.pop().unwrap());
         }
 
         // Allocate more pages to accommodate the number requested, if needed.
-        while addresses.len() < num_overflow_pages {
-            addresses.push(allocator.allocate());
+        while self.overflows.len() < num_overflow_pages {
+            self.overflows.push(allocator.allocate());
         }
-
-        addresses
     }
 }
 


### PR DESCRIPTION
Prior to this commit, BTreeMap V2 could leak memory as it wasn't saving the overflow pages properly when `save` was called (the `overflows` field). This commit fixes this issue and adds a test to prevent this moving forward.

There is no performance impact due to this fix:

```
btreemap_insert_blob_4_1024
                        time:   [990.51 M Instructions 990.51 M Instructions 990.51 M Instructions]
                        change: [-0.0050% -0.0050% -0.0050%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_4_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:33:19.716822 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "481_303_388 (30%)",
    "node_save_v2": "776_936_733 (48%)",
}

btreemap_insert_blob_4_1024_v2
                        time:   [1599.6 M Instructions 1599.6 M Instructions 1599.6 M Instructions]
                        change: [-0.8885% -0.8885% -0.8885%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_8_1024: Warming up for 1.0000 ms
2023-08-30 14:33:21.354203 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "321_869_274 (28%)",
    "node_save_v1": "403_319_104 (35%)",
}

btreemap_insert_blob_8_1024
                        time:   [1137.9 M Instructions 1137.9 M Instructions 1137.9 M Instructions]
                        change: [-0.0047% -0.0047% -0.0047%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_8_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:33:22.860324 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "537_227_227 (29%)",
    "node_save_v2": "839_017_866 (46%)",
}

btreemap_insert_blob_8_1024_v2
                        time:   [1798.7 M Instructions 1798.7 M Instructions 1798.7 M Instructions]
                        change: [-0.8437% -0.8437% -0.8437%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_16_1024: Warming up for 1.0000 ms
2023-08-30 14:33:24.532605 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "402_518_468 (32%)",
    "node_save_v1": "412_342_578 (33%)",
}

btreemap_insert_blob_16_1024
                        time:   [1234.0 M Instructions 1234.0 M Instructions 1234.0 M Instructions]
                        change: [-0.0045% -0.0045% -0.0045%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_16_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:33:26.053395 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "637_840_110 (32%)",
    "node_save_v2": "872_267_407 (44%)",
}

btreemap_insert_blob_16_1024_v2
                        time:   [1940.3 M Instructions 1940.3 M Instructions 1940.3 M Instructions]
                        change: [-0.8126% -0.8126% -0.8126%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_32_1024: Warming up for 1.0000 ms
2023-08-30 14:33:28.082664 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "424_603_999 (33%)",
    "node_save_v1": "424_971_825 (33%)",
}

btreemap_insert_blob_32_1024
                        time:   [1275.1 M Instructions 1275.1 M Instructions 1275.1 M Instructions]
                        change: [-0.0045% -0.0045% -0.0045%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_32_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:33:29.939485 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "674_135_581 (33%)",
    "node_save_v2": "906_604_624 (45%)",
}

btreemap_insert_blob_32_1024_v2
                        time:   [2009.9 M Instructions 2009.9 M Instructions 2009.9 M Instructions]
                        change: [-0.8276% -0.8276% -0.8276%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_64_1024: Warming up for 1.0000 ms
2023-08-30 14:33:31.753180 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "629_811_234 (41%)",
    "node_save_v1": "427_811_631 (28%)",
}

btreemap_insert_blob_64_1024
                        time:   [1515.3 M Instructions 1515.3 M Instructions 1515.3 M Instructions]
                        change: [-0.0038% -0.0038% -0.0038%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_64_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:33:33.433889 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "901_993_047 (39%)",
    "node_save_v2": "927_964_791 (40%)",
}

btreemap_insert_blob_64_1024_v2
                        time:   [2303.1 M Instructions 2303.1 M Instructions 2303.1 M Instructions]
                        change: [-0.7062% -0.7062% -0.7062%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_128_1024: Warming up for 1.0000 ms
2023-08-30 14:33:35.288956 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "854_194_111 (47%)",
    "node_save_v1": "433_801_175 (24%)",
}

btreemap_insert_blob_128_1024
                        time:   [1782.9 M Instructions 1782.9 M Instructions 1782.9 M Instructions]
                        change: [-0.0032% -0.0032% -0.0032%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_128_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:33:36.883892 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "1_181_761_705 (44%)",
    "node_save_v2": "964_262_416 (36%)",
}

btreemap_insert_blob_128_1024_v2
                        time:   [2675.1 M Instructions 2675.1 M Instructions 2675.1 M Instructions]
                        change: [-0.6362% -0.6362% -0.6362%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_256_1024: Warming up for 1.0000 ms
2023-08-30 14:33:38.754954 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "1_308_925_598 (56%)",
    "node_save_v1": "439_514_594 (19%)",
}

btreemap_insert_blob_256_1024
                        time:   [2311.1 M Instructions 2311.1 M Instructions 2311.1 M Instructions]
                        change: [-0.0025% -0.0025% -0.0025%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_256_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:33:40.481188 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "1_702_809_442 (50%)",
    "node_save_v2": "1_011_065_919 (30%)",
}

btreemap_insert_blob_256_1024_v2
                        time:   [3342.2 M Instructions 3342.2 M Instructions 3342.2 M Instructions]
                        change: [-0.5520% -0.5520% -0.5520%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_512_1024: Warming up for 1.0000 ms
2023-08-30 14:33:42.992443 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "2_198_537_195 (65%)",
    "node_save_v1": "455_856_248 (13%)",
}

btreemap_insert_blob_512_1024
                        time:   [3362.4 M Instructions 3362.4 M Instructions 3362.4 M Instructions]
                        change: [-0.0017% -0.0017% -0.0017%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_512_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:33:45.192640 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "2_654_402_360 (58%)",
    "node_save_v2": "1_127_874_679 (25%)",
}

btreemap_insert_blob_512_1024_v2
                        time:   [4510.5 M Instructions 4510.5 M Instructions 4510.5 M Instructions]
                        change: [-0.4423% -0.4423% -0.4423%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_u64_u64: Warming up for 1.0000 ms
2023-08-30 14:33:47.793934 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "306_179_398 (35%)",
    "node_save_v1": "306_950_389 (35%)",
}

btreemap_insert_u64_u64 time:   [858.20 M Instructions 858.20 M Instructions 858.20 M Instructions]
                        change: [-0.0035% -0.0035% -0.0035%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_u64_u64_v2: Warming up for 1.0000 ms
2023-08-30 14:33:49.111880 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "385_750_590 (39%)",
    "node_save_v2": "339_918_117 (35%)",
}

btreemap_insert_u64_u64_v2
                        time:   [966.45 M Instructions 966.45 M Instructions 966.45 M Instructions]
                        change: [-0.1207% -0.1207% -0.1207%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_u64_blob_8: Warming up for 1.0000 ms
2023-08-30 14:33:50.358094 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "308_458_700 (37%)",
    "node_save_v1": "294_121_912 (35%)",
}

btreemap_insert_u64_blob_8
                        time:   [831.38 M Instructions 831.38 M Instructions 831.38 M Instructions]
                        change: [-0.0036% -0.0036% -0.0036%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_u64_blob_8_v2: Warming up for 1.0000 ms
2023-08-30 14:33:51.642667 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "384_546_931 (41%)",
    "node_save_v2": "312_992_065 (33%)",
}

btreemap_insert_u64_blob_8_v2
                        time:   [922.31 M Instructions 922.31 M Instructions 922.31 M Instructions]
                        change: [-0.1255% -0.1255% -0.1255%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_8_u64: Warming up for 1.0000 ms
2023-08-30 14:33:52.928786 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "310_026_924 (41%)",
    "node_save_v1": "201_998_071 (27%)",
}

btreemap_insert_blob_8_u64
                        time:   [740.22 M Instructions 740.22 M Instructions 740.22 M Instructions]
                        change: [-0.0073% -0.0073% -0.0073%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_insert_blob_8_u64_v2: Warming up for 1.0000 ms
2023-08-30 14:33:54.305760 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "387_941_334 (45%)",
    "node_save_v2": "246_878_434 (28%)",
}

btreemap_insert_blob_8_u64_v2
                        time:   [859.75 M Instructions 859.75 M Instructions 859.75 M Instructions]
                        change: [-0.1113% -0.1113% -0.1113%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_get_blob_4_1024: Warming up for 1.0000 ms
2023-08-30 14:33:55.733324 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "293_795_450 (66%)",
}

btreemap_get_blob_4_1024
                        time:   [442.36 M Instructions 442.36 M Instructions 442.36 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_4_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:33:57.557737 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "516_995_139 (74%)",
}

btreemap_get_blob_4_1024_v2
                        time:   [692.81 M Instructions 692.81 M Instructions 692.81 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_8_1024: Warming up for 1.0000 ms
2023-08-30 14:33:59.758312 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "344_728_885 (66%)",
}

btreemap_get_blob_8_1024
                        time:   [520.76 M Instructions 520.76 M Instructions 520.76 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_8_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:34:01.747715 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "547_592_745 (72%)",
}

btreemap_get_blob_8_1024_v2
                        time:   [751.56 M Instructions 751.56 M Instructions 751.56 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_16_1024: Warming up for 1.0000 ms
2023-08-30 14:34:03.738953 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "425_809_809 (70%)",
}

btreemap_get_blob_16_1024
                        time:   [602.40 M Instructions 602.40 M Instructions 602.40 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_16_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:34:05.559180 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "646_405_838 (76%)",
}

btreemap_get_blob_16_1024_v2
                        time:   [845.21 M Instructions 845.21 M Instructions 845.21 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_32_1024: Warming up for 1.0000 ms
2023-08-30 14:34:07.604326 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "444_926_271 (70%)",
}

btreemap_get_blob_32_1024
                        time:   [632.59 M Instructions 632.59 M Instructions 632.59 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_32_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:34:09.368822 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "683_036_393 (76%)",
}

btreemap_get_blob_32_1024_v2
                        time:   [893.12 M Instructions 893.12 M Instructions 893.12 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_64_1024: Warming up for 1.0000 ms
2023-08-30 14:34:11.499751 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "663_035_945 (77%)",
}

btreemap_get_blob_64_1024
                        time:   [856.36 M Instructions 856.36 M Instructions 856.36 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_64_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:34:13.661272 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "906_869_057 (80%)",
}

btreemap_get_blob_64_1024_v2
                        time:   [1127.3 M Instructions 1127.3 M Instructions 1127.3 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_128_1024: Warming up for 1.0000 ms
2023-08-30 14:34:16.070254 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "875_716_723 (81%)",
}

btreemap_get_blob_128_1024
                        time:   [1078.9 M Instructions 1078.9 M Instructions 1078.9 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_128_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:34:18.311380 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "1_199_414_614 (83%)",
}

btreemap_get_blob_128_1024_v2
                        time:   [1434.3 M Instructions 1434.3 M Instructions 1434.3 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_u64_u64: Warming up for 1.0000 ms
2023-08-30 14:34:20.865349 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "323_182_267 (71%)",
}

btreemap_get_u64_u64    time:   [450.17 M Instructions 450.17 M Instructions 450.17 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_u64_u64_v2: Warming up for 1.0000 ms
2023-08-30 14:34:22.459775 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "403_618_361 (75%)",
}

btreemap_get_u64_u64_v2 time:   [536.77 M Instructions 536.77 M Instructions 536.77 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_u64_blob_8: Warming up for 1.0000 ms
2023-08-30 14:34:24.038977 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "324_661_032 (72%)",
}

btreemap_get_u64_blob_8 time:   [446.62 M Instructions 446.62 M Instructions 446.62 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_u64_blob_8_v2: Warming up for 1.0000 ms
2023-08-30 14:34:25.636963 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "405_206_697 (76%)",
}

btreemap_get_u64_blob_8_v2
                        time:   [531.93 M Instructions 531.93 M Instructions 531.93 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_8_u64: Warming up for 1.0000 ms
2023-08-30 14:34:27.136912 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "327_829_305 (70%)",
}

Benchmarking btreemap_get_blob_8_u64: Collecting 10 samples in estimated 330.29 s (220 it
btreemap_get_blob_8_u64 time:   [464.82 M Instructions 464.82 M Instructions 464.82 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_8_u64_v2: Warming up for 1.0000 ms
2023-08-30 14:34:28.620120 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "405_354_044 (74%)",
}

Benchmarking btreemap_get_blob_8_u64_v2: Collecting 10 samples in estimated 326.19 s (220
btreemap_get_blob_8_u64_v2
                        time:   [547.72 M Instructions 547.72 M Instructions 547.72 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_256_1024: Warming up for 1.0000 ms
2023-08-30 14:34:30.186105 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "1_339_890_114 (85%)",
}

Benchmarking btreemap_get_blob_256_1024: Collecting 10 samples in estimated 414.96 s (165
btreemap_get_blob_256_1024
                        time:   [1568.1 M Instructions 1568.1 M Instructions 1568.1 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_256_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:34:32.703287 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "1_724_578_760 (86%)",
}

Benchmarking btreemap_get_blob_256_1024_v2: Collecting 10 samples in estimated 394.78 s (
btreemap_get_blob_256_1024_v2
                        time:   [1986.7 M Instructions 1986.7 M Instructions 1986.7 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_512_1024: Warming up for 1.0000 ms
2023-08-30 14:34:35.176575 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "2_257_152_362 (89%)",
}

Benchmarking btreemap_get_blob_512_1024: Collecting 10 samples in estimated 391.28 s (165
btreemap_get_blob_512_1024
                        time:   [2533.8 M Instructions 2533.8 M Instructions 2533.8 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_get_blob_512_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:34:37.561090 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "2_704_747_759 (89%)",
}

Benchmarking btreemap_get_blob_512_1024_v2: Collecting 10 samples in estimated 314.44 s (
btreemap_get_blob_512_1024_v2
                        time:   [3015.4 M Instructions 3015.4 M Instructions 3015.4 M Instructions]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

Benchmarking btreemap_remove_blob_4_1024: Warming up for 1.0000 ms
2023-08-30 14:34:40.489420 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "307_574_353 (28%)",
    "node_save_v1": "429_554_241 (39%)",
}

Benchmarking btreemap_remove_blob_4_1024: Collecting 10 samples in estimated 395.10 s (22
btreemap_remove_blob_4_1024
                        time:   [1078.4 M Instructions 1078.4 M Instructions 1078.4 M Instructions]
                        change: [-0.0068% -0.0068% -0.0068%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_4_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:34:42.278557 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "525_229_100 (29%)",
    "node_save_v2": "898_550_230 (50%)",
}

Benchmarking btreemap_remove_blob_4_1024_v2: Collecting 10 samples in estimated 347.19 s
btreemap_remove_blob_4_1024_v2
                        time:   [1781.0 M Instructions 1781.0 M Instructions 1781.0 M Instructions]
                        change: [-1.1326% -1.1326% -1.1326%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking btreemap_remove_blob_8_1024: Warming up for 1.0000 ms
2023-08-30 14:34:44.429011 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "367_298_948 (26%)",
    "node_save_v1": "572_351_615 (41%)",
}

Benchmarking btreemap_remove_blob_8_1024: Collecting 10 samples in estimated 308.94 s (16
btreemap_remove_blob_8_1024
                        time:   [1381.5 M Instructions 1381.5 M Instructions 1381.5 M Instructions]
                        change: [-0.0072% -0.0072% -0.0072%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_8_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:34:46.372314 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "592_398_586 (26%)",
    "node_save_v2": "1_216_001_320 (53%)",
}

Benchmarking btreemap_remove_blob_8_1024_v2: Collecting 10 samples in estimated 381.28 s
btreemap_remove_blob_8_1024_v2
                        time:   [2266.7 M Instructions 2266.7 M Instructions 2266.7 M Instructions]
                        change: [-1.2676% -1.2676% -1.2676%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking btreemap_remove_blob_16_1024: Warming up for 1.0000 ms
2023-08-30 14:34:48.713385 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "465_498_356 (28%)",
    "node_save_v1": "665_886_809 (40%)",
}

Benchmarking btreemap_remove_blob_16_1024: Collecting 10 samples in estimated 322.52 s (1
btreemap_remove_blob_16_1024
                        time:   [1634.9 M Instructions 1634.9 M Instructions 1634.9 M Instructions]
                        change: [-0.0070% -0.0070% -0.0070%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_16_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:34:50.710020 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "731_199_273 (27%)",
    "node_save_v2": "1_443_887_027 (53%)",
}

Benchmarking btreemap_remove_blob_16_1024_v2: Collecting 10 samples in estimated 413.66 s
btreemap_remove_blob_16_1024_v2
                        time:   [2696.1 M Instructions 2696.1 M Instructions 2696.1 M Instructions]
                        change: [-1.2724% -1.2724% -1.2724%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking btreemap_remove_blob_32_1024: Warming up for 1.0000 ms
2023-08-30 14:34:53.239805 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "483_509_883 (28%)",
    "node_save_v1": "692_809_425 (40%)",
}

Benchmarking btreemap_remove_blob_32_1024: Collecting 10 samples in estimated 336.11 s (1
btreemap_remove_blob_32_1024
                        time:   [1709.1 M Instructions 1709.1 M Instructions 1709.1 M Instructions]
                        change: [-0.0069% -0.0069% -0.0069%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_32_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:34:55.283549 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "771_427_283 (27%)",
    "node_save_v2": "1_509_016_646 (53%)",
}

Benchmarking btreemap_remove_blob_32_1024_v2: Collecting 10 samples in estimated 414.03 s
btreemap_remove_blob_32_1024_v2
                        time:   [2831.2 M Instructions 2831.2 M Instructions 2831.2 M Instructions]
                        change: [-1.1081% -1.1081% -1.1081%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking btreemap_remove_blob_64_1024: Warming up for 1.0000 ms
2023-08-30 14:34:57.872659 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "713_539_284 (35%)",
    "node_save_v1": "712_391_962 (35%)",
}

Benchmarking btreemap_remove_blob_64_1024: Collecting 10 samples in estimated 359.50 s (1
btreemap_remove_blob_64_1024
                        time:   [2002.7 M Instructions 2002.7 M Instructions 2002.7 M Instructions]
                        change: [-0.0061% -0.0061% -0.0061%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_64_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:35:00.068805 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "1_005_991_258 (31%)",
    "node_save_v2": "1_572_037_926 (49%)",
}

Benchmarking btreemap_remove_blob_64_1024_v2: Collecting 10 samples in estimated 437.15 s
btreemap_remove_blob_64_1024_v2
                        time:   [3177.6 M Instructions 3177.6 M Instructions 3177.6 M Instructions]
                        change: [-0.9309% -0.9309% -0.9309%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_128_1024: Warming up for 1.0000 ms
2023-08-30 14:35:02.771372 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "961_751_320 (41%)",
    "node_save_v1": "728_794_708 (31%)",
}

Benchmarking btreemap_remove_blob_128_1024: Collecting 10 samples in estimated 367.41 s (
btreemap_remove_blob_128_1024
                        time:   [2326.7 M Instructions 2326.7 M Instructions 2326.7 M Instructions]
                        change: [-0.0054% -0.0054% -0.0054%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_128_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:35:05.035872 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "1_317_470_897 (36%)",
    "node_save_v2": "1_646_705_331 (45%)",
}

Benchmarking btreemap_remove_blob_128_1024_v2: Collecting 10 samples in estimated 315.70
btreemap_remove_blob_128_1024_v2
                        time:   [3625.3 M Instructions 3625.3 M Instructions 3625.3 M Instructions]
                        change: [-0.9730% -0.9730% -0.9730%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_256_1024: Warming up for 1.0000 ms
2023-08-30 14:35:07.908418 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "1_463_074_911 (49%)",
    "node_save_v1": "733_887_166 (24%)",
}

Benchmarking btreemap_remove_blob_256_1024: Collecting 10 samples in estimated 405.89 s (
btreemap_remove_blob_256_1024
                        time:   [2936.5 M Instructions 2936.5 M Instructions 2936.5 M Instructions]
                        change: [-0.0042% -0.0042% -0.0042%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_256_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:35:10.440269 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "1_911_944_875 (43%)",
    "node_save_v2": "1_727_949_076 (39%)",
}

btreemap_remove_blob_256_1024_v2
                        time:   [4410.0 M Instructions 4410.0 M Instructions 4410.0 M Instructions]
                        change: [-0.8063% -0.8063% -0.8063%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_512_1024: Warming up for 1.0000 ms
2023-08-30 14:35:13.610952 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "2_483_999_494 (58%)",
    "node_save_v1": "775_463_121 (18%)",
}

btreemap_remove_blob_512_1024
                        time:   [4235.2 M Instructions 4235.2 M Instructions 4235.2 M Instructions]
                        change: [-0.0030% -0.0030% -0.0030%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_512_1024_v2: Warming up for 1.0000 ms
2023-08-30 14:35:16.391136 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "2_997_503_870 (50%)",
    "node_save_v2": "1_957_586_732 (32%)",
}

btreemap_remove_blob_512_1024_v2
                        time:   [5965.6 M Instructions 5965.6 M Instructions 5965.6 M Instructions]
                        change: [-0.7012% -0.7012% -0.7012%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_u64_u64: Warming up for 1.0000 ms
2023-08-30 14:35:19.923143 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "348_586_038 (28%)",
    "node_save_v1": "532_211_397 (43%)",
}

btreemap_remove_u64_u64 time:   [1214.8 M Instructions 1214.8 M Instructions 1214.8 M Instructions]
                        change: [-0.0055% -0.0055% -0.0055%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_u64_u64_v2: Warming up for 1.0000 ms
2023-08-30 14:35:21.679538 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "431_636_337 (32%)",
    "node_save_v2": "556_293_483 (42%)",
}

btreemap_remove_u64_u64_v2
                        time:   [1321.2 M Instructions 1321.2 M Instructions 1321.2 M Instructions]
                        change: [-0.1731% -0.1731% -0.1731%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_u64_blob_8: Warming up for 1.0000 ms
2023-08-30 14:35:23.328388 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "348_727_728 (29%)",
    "node_save_v1": "504_278_705 (42%)",
}

btreemap_remove_u64_blob_8
                        time:   [1174.5 M Instructions 1174.5 M Instructions 1174.5 M Instructions]
                        change: [-0.0056% -0.0056% -0.0056%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_u64_blob_8_v2: Warming up for 1.0000 ms
2023-08-30 14:35:25.138512 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "429_769_109 (34%)",
    "node_save_v2": "510_358_326 (40%)",
}

btreemap_remove_u64_blob_8_v2
                        time:   [1260.7 M Instructions 1260.7 M Instructions 1260.7 M Instructions]
                        change: [-0.1785% -0.1785% -0.1785%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_8_u64: Warming up for 1.0000 ms
2023-08-30 14:35:26.857461 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v1": "353_086_064 (35%)",
    "node_save_v1": "315_700_943 (32%)",
}

btreemap_remove_blob_8_u64
                        time:   [981.01 M Instructions 981.01 M Instructions 981.01 M Instructions]
                        change: [-0.0108% -0.0108% -0.0108%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking btreemap_remove_blob_8_u64_v2: Warming up for 1.0000 ms
2023-08-30 14:35:28.521651 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] {
    "node_load_v2": "428_189_803 (38%)",
    "node_save_v2": "379_306_206 (33%)",
}

btreemap_remove_blob_8_u64_v2
                        time:   [1116.4 M Instructions 1116.4 M Instructions 1116.4 M Instructions]
                        change: [-0.1553% -0.1553% -0.1553%] (p = 0.00 < 0.05)
                        Change within noise threshold.

```