### PR TITLE
perf: update BTreeMap v2 default page size from 500 bytes to 1024 bytes

### DIFF
--- a/benchmark-canisters/src/btreemap.rs
+++ b/benchmark-canisters/src/btreemap.rs
@@ -199,6 +199,26 @@ pub fn btreemap_insert_blob_8_u64_v2() -> BenchResult {
     insert_helper::<Blob<8>, u64>(btree)
 }
 
+#[query]
+pub fn btreemap_insert_10mib_values() -> BenchResult {
+    let mut btree = BTreeMap::new_v2(DefaultMemoryImpl::default());
+
+    // Insert 200 10MiB values.
+    let mut rng = Rng::from_seed(0);
+    let mut values = vec![];
+    for _ in 0..200 {
+        values.push(rng.iter(Rand::rand_u8).take(10 * 1024).collect::<Vec<_>>());
+    }
+
+    benchmark(|| {
+        let mut i = 0u64;
+        for value in values.into_iter() {
+            btree.insert(i, value);
+            i += 1;
+        }
+    })
+}
+
 /// Benchmarks removing keys from a BTreeMap.
 #[query]
 pub fn btreemap_remove_blob_4_1024() -> BenchResult {

--- a/benchmarks/benchmark.rs
+++ b/benchmarks/benchmark.rs
@@ -24,6 +24,7 @@ lazy_static::lazy_static! {
         "memory_manager_overhead",
 
         // BTree benchmarks
+        "btreemap_insert_10mib_values",
         "btreemap_insert_blob_4_1024",
         "btreemap_insert_blob_4_1024_v2",
         "btreemap_insert_blob_8_1024",

--- a/benchmarks/results.yml
+++ b/benchmarks/results.yml
@@ -108,6 +108,12 @@ btreemap_get_u64_u64_v2:
     instructions: 469869216
     node_load_v2: 341278594
     stable_memory_size: 8
+btreemap_insert_10mib_values:
+  measurements:
+    instructions: 278228334
+    node_load_v2: 10377468
+    node_save_v2: 245958554
+    stable_memory_size: 33
 btreemap_insert_blob_128_1024:
   measurements:
     instructions: 1730313092

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -46,10 +46,13 @@ mod proptests;
 const MAGIC: &[u8; 3] = b"BTR";
 const LAYOUT_VERSION: u8 = 1;
 const LAYOUT_VERSION_2: u8 = 2;
-/// The sum of all the header fields, i.e. size of a packed header.
+// The sum of all the header fields, i.e. size of a packed header.
 const PACKED_HEADER_SIZE: usize = 28;
-/// The offset where the allocator begins.
+// The offset where the allocator begins.
 const ALLOCATOR_OFFSET: usize = 52;
+
+// The default page size to use in BTreeMap V2.
+const DEFAULT_PAGE_SIZE: u32 = 1024;
 
 /// A "stable" map based on a B-tree.
 ///
@@ -186,7 +189,7 @@ where
                 },
             ) => PageSize::Value(Node::<K>::size(max_key_size, max_value_size).get() as u32),
             // Use a default page size.
-            _ => PageSize::Value(1024),
+            _ => PageSize::Value(DEFAULT_PAGE_SIZE),
         };
 
         let btree = Self {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -186,7 +186,7 @@ where
                 },
             ) => PageSize::Value(Node::<K>::size(max_key_size, max_value_size).get() as u32),
             // Use a default page size.
-            _ => PageSize::Value(500),
+            _ => PageSize::Value(1024),
         };
 
         let btree = Self {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -51,7 +51,7 @@ const PACKED_HEADER_SIZE: usize = 28;
 // The offset where the allocator begins.
 const ALLOCATOR_OFFSET: usize = 52;
 
-// The default page size to use in BTreeMap V2.
+// The default page size to use in BTreeMap V2 in bytes.
 const DEFAULT_PAGE_SIZE: u32 = 1024;
 
 /// A "stable" map based on a B-tree.


### PR DESCRIPTION
The page size used by the BTreeMap dictates how big the chunks are that are allocated. The smaller the page size, the more chunks that need to be allocated to store the same amount of data, and consequently the more reads and writes are required to load/save each node. On the other hand, a large page size also can incur additional memory overhead, so we need to be careful to not set it too high.

To explore this, I added a benchmark that stores 200 10MiB vectors in a BTreeMap. I tested different page sizes to explore its effect on both memory and instructions.

When using a larger pages size, from 1KiB to 20MiB, this is the best increase in performance I had seen:

(relative performance is measured against the base line of `page_size = 500`)
```
Benchmark: btreemap_insert_10mib_values
  measurements:
    instructions: 252642984 (improved by 16.29%)
    node_load_v2: 3607078 (improved by 76.06%)
    node_save_v2: 227974389 (improved by 13.72%)
    stable_memory_size: 596 (regressed by 1652.94%)
```

And I tried a page size of 1024:

```
Benchmark: btreemap_insert_10mib_values
  measurements:
    instructions: 278228334 (improved by 7.81%)
    node_load_v2: 10377468 (improved by 31.12%)
    node_save_v2: 245958554 (improved by 6.92%)
    stable_memory_size: 33 (improved by 2.94%)
```

As we can see, we captured nearly half of the performance improvement without increasing the page size too much, which seems to strike a good balance and it makes sense to have it as a default value.