### PR TITLE
bug: contains_key doesn't work in btree v2

### DIFF
--- a/src/btreemap/proptests.rs
+++ b/src/btreemap/proptests.rs
@@ -91,6 +91,8 @@ fn insert_stable_principal() {
         assert_eq!(key1, key2);
 
         btree.insert(key1.clone(), ());
+
+        assert_eq!(btree.len(), 1);
         assert!(btree.contains_key(&key1));
     });
 }

--- a/src/btreemap/proptests.rs
+++ b/src/btreemap/proptests.rs
@@ -78,7 +78,7 @@ impl Storable for StorablePrincipal {
     }
     const BOUND: Bound = Bound::Bounded {
         max_size: 29,
-        is_fixed_size: true,
+        is_fixed_size: false,
     };
 }
 


### PR DESCRIPTION
cargo test insert_stable_principal