### PR TITLE
perf: [BTreeMap V2] avoid allocating large buffer on save.

### DIFF
--- a/benchmarks/benchmark.rs
+++ b/benchmarks/benchmark.rs
@@ -24,7 +24,7 @@ lazy_static::lazy_static! {
         "memory_manager_overhead",
 
         // BTree benchmarks
-        //"btreemap_insert_10mib_values",
+        "btreemap_insert_10mib_values",
         "btreemap_insert_blob_4_1024",
         "btreemap_insert_blob_4_1024_v2",
         "btreemap_insert_blob_8_1024",

--- a/benchmarks/benchmark.rs
+++ b/benchmarks/benchmark.rs
@@ -24,7 +24,7 @@ lazy_static::lazy_static! {
         "memory_manager_overhead",
 
         // BTree benchmarks
-        "btreemap_insert_10mib_values",
+        //"btreemap_insert_10mib_values",
         "btreemap_insert_blob_4_1024",
         "btreemap_insert_blob_4_1024_v2",
         "btreemap_insert_blob_8_1024",

--- a/benchmarks/results.yml
+++ b/benchmarks/results.yml
@@ -5,7 +5,7 @@ btreemap_get_blob_128_1024:
     stable_memory_size: 261
 btreemap_get_blob_128_1024_v2:
   measurements:
-    instructions: 1140173768
+    instructions: 1140173858
     node_load_v2: 933785784
     stable_memory_size: 261
 btreemap_get_blob_16_1024:
@@ -25,7 +25,7 @@ btreemap_get_blob_256_1024:
     stable_memory_size: 293
 btreemap_get_blob_256_1024_v2:
   measurements:
-    instructions: 1628351182
+    instructions: 1628351272
     node_load_v2: 1392993062
     stable_memory_size: 293
 btreemap_get_blob_32_1024:
@@ -85,7 +85,7 @@ btreemap_get_blob_8_u64:
     stable_memory_size: 7
 btreemap_get_blob_8_u64_v2:
   measurements:
-    instructions: 511860402
+    instructions: 511860381
     node_load_v2: 373992060
     stable_memory_size: 7
 btreemap_get_u64_blob_8:
@@ -95,7 +95,7 @@ btreemap_get_u64_blob_8:
     stable_memory_size: 8
 btreemap_get_u64_blob_8_v2:
   measurements:
-    instructions: 465392548
+    instructions: 465392638
     node_load_v2: 342799065
     stable_memory_size: 8
 btreemap_get_u64_u64:
@@ -105,278 +105,278 @@ btreemap_get_u64_u64:
     stable_memory_size: 8
 btreemap_get_u64_u64_v2:
   measurements:
-    instructions: 469869216
+    instructions: 469869306
     node_load_v2: 341278594
     stable_memory_size: 8
 btreemap_insert_10mib_values:
   measurements:
-    instructions: 278228334
+    instructions: 158321842
     node_load_v2: 10377468
-    node_save_v2: 245958554
+    node_save_v2: 126007892
     stable_memory_size: 33
 btreemap_insert_blob_128_1024:
   measurements:
-    instructions: 1730313092
+    instructions: 1729768012
     node_load_v1: 818923030
-    node_save_v1: 424573804
+    node_save_v1: 424336331
     stable_memory_size: 261
 btreemap_insert_blob_128_1024_v2:
   measurements:
-    instructions: 2230838398
-    node_load_v2: 916541484
-    node_save_v2: 814310656
+    instructions: 1885672741
+    node_load_v2: 916598797
+    node_save_v2: 470957703
     stable_memory_size: 261
 btreemap_insert_blob_16_1024:
   measurements:
-    instructions: 1177421502
+    instructions: 1176903332
     node_load_v1: 362914338
-    node_save_v1: 403464072
+    node_save_v1: 403232566
     stable_memory_size: 216
 btreemap_insert_blob_16_1024_v2:
   measurements:
-    instructions: 1588380303
-    node_load_v2: 440217654
-    node_save_v2: 740158362
+    instructions: 1295546890
+    node_load_v2: 440399043
+    node_save_v2: 448818266
     stable_memory_size: 216
 btreemap_insert_blob_256_1024:
   measurements:
-    instructions: 2255818313
+    instructions: 2255269553
     node_load_v1: 1272224795
-    node_save_v1: 430174789
+    node_save_v1: 429936500
     stable_memory_size: 293
 btreemap_insert_blob_256_1024_v2:
   measurements:
-    instructions: 2794604284
-    node_load_v2: 1368657545
-    node_save_v2: 852071559
+    instructions: 2416164659
+    node_load_v2: 1368714490
+    node_save_v2: 476456802
     stable_memory_size: 293
 btreemap_insert_blob_32_1024:
   measurements:
-    instructions: 1224612399
+    instructions: 1224078359
     node_load_v1: 390780802
-    node_save_v1: 415826600
+    node_save_v1: 415591575
     stable_memory_size: 231
 btreemap_insert_blob_32_1024_v2:
   measurements:
-    instructions: 1655865121
-    node_load_v2: 477569310
-    node_save_v2: 769212087
+    instructions: 1345918082
+    node_load_v2: 477582317
+    node_save_v2: 461418653
     stable_memory_size: 231
 btreemap_insert_blob_4_1024:
   measurements:
-    instructions: 938860652
+    instructions: 938459480
     node_load_v1: 246219371
-    node_save_v1: 370094431
+    node_save_v1: 369888833
     stable_memory_size: 124
 btreemap_insert_blob_4_1024_v2:
   measurements:
-    instructions: 1285008726
-    node_load_v2: 302568355
-    node_save_v2: 661401273
+    instructions: 1033183548
+    node_load_v2: 302721338
+    node_save_v2: 410566944
     stable_memory_size: 124
 btreemap_insert_blob_512_1024:
   measurements:
-    instructions: 3306816049
+    instructions: 3306266369
     node_load_v1: 2162164471
-    node_save_v1: 447463180
+    node_save_v1: 447224687
     stable_memory_size: 352
 btreemap_insert_blob_512_1024_v2:
   measurements:
-    instructions: 3902159318
-    node_load_v2: 2249757429
-    node_save_v2: 953704203
+    instructions: 3439168228
+    node_load_v2: 2249806809
+    node_save_v2: 493589161
     stable_memory_size: 352
 btreemap_insert_blob_64_1024:
   measurements:
-    instructions: 1464177820
+    instructions: 1463634810
     node_load_v1: 595998298
-    node_save_v1: 418743231
+    node_save_v1: 418506217
     stable_memory_size: 246
 btreemap_insert_blob_64_1024_v2:
   measurements:
-    instructions: 1928899440
-    node_load_v2: 692235029
-    node_save_v2: 785502958
+    instructions: 1606536169
+    node_load_v2: 692239035
+    node_save_v2: 464863981
     stable_memory_size: 246
 btreemap_insert_blob_8_1024:
   measurements:
-    instructions: 1084934108
+    instructions: 1084454578
     node_load_v1: 286595797
-    node_save_v1: 394314301
+    node_save_v1: 394091363
     stable_memory_size: 184
 btreemap_insert_blob_8_1024_v2:
   measurements:
-    instructions: 1458702229
-    node_load_v2: 344795705
-    node_save_v2: 711905405
+    instructions: 1183969018
+    node_load_v2: 344994802
+    node_save_v2: 438155700
     stable_memory_size: 184
 btreemap_insert_blob_8_u64:
   measurements:
-    instructions: 684689096
+    instructions: 684209106
     node_load_v1: 277937358
-    node_save_v1: 189388784
+    node_save_v1: 189165744
     stable_memory_size: 7
 btreemap_insert_blob_8_u64_v2:
   measurements:
-    instructions: 798815035
-    node_load_v2: 354784651
-    node_save_v2: 229763111
+    instructions: 802688497
+    node_load_v2: 354976358
+    node_save_v2: 234878135
     stable_memory_size: 7
 btreemap_insert_u64_blob_8:
   measurements:
-    instructions: 750190911
+    instructions: 749642151
     node_load_v1: 276866073
-    node_save_v1: 255664450
+    node_save_v1: 255566331
     stable_memory_size: 8
 btreemap_insert_u64_blob_8_v2:
   measurements:
-    instructions: 806054449
-    node_load_v2: 320348500
-    node_save_v2: 272090265
+    instructions: 820358615
+    node_load_v2: 320406521
+    node_save_v2: 287445446
     stable_memory_size: 8
 btreemap_insert_u64_u64:
   measurements:
-    instructions: 771845193
+    instructions: 771295973
     node_load_v1: 274520203
-    node_save_v1: 266527196
+    node_save_v1: 266429035
     stable_memory_size: 8
 btreemap_insert_u64_u64_v2:
   measurements:
-    instructions: 842560173
-    node_load_v2: 320954654
-    node_save_v2: 295257753
+    instructions: 844848075
+    node_load_v2: 320667801
+    node_save_v2: 298115032
     stable_memory_size: 8
 btreemap_remove_blob_128_1024:
   measurements:
-    instructions: 2236575844
+    instructions: 2235786044
     node_load_v1: 922607545
-    node_save_v1: 716920195
+    node_save_v1: 716437888
     stable_memory_size: 261
 btreemap_remove_blob_128_1024_v2:
   measurements:
-    instructions: 3031421182
-    node_load_v2: 1029479582
-    node_save_v2: 1412273798
+    instructions: 2434217251
+    node_load_v2: 1029552036
+    node_save_v2: 813731257
     stable_memory_size: 261
 btreemap_remove_blob_16_1024:
   measurements:
-    instructions: 1544917110
+    instructions: 1544195176
     node_load_v1: 420249550
-    node_save_v1: 654430779
+    node_save_v1: 653989748
     stable_memory_size: 216
 btreemap_remove_blob_16_1024_v2:
   measurements:
-    instructions: 2218571732
-    node_load_v2: 513947291
-    node_save_v2: 1243892246
+    instructions: 1718977571
+    node_load_v2: 514792050
+    node_save_v2: 742821168
     stable_memory_size: 216
 btreemap_remove_blob_256_1024:
   measurements:
-    instructions: 2839195280
+    instructions: 2838422216
     node_load_v1: 1421754484
-    node_save_v1: 722710062
+    node_save_v1: 722240539
     stable_memory_size: 293
 btreemap_remove_blob_256_1024_v2:
   measurements:
-    instructions: 3696452312
-    node_load_v2: 1528516744
-    node_save_v2: 1475117328
+    instructions: 3039500513
+    node_load_v2: 1528561438
+    node_save_v2: 816969139
     stable_memory_size: 293
 btreemap_remove_blob_32_1024:
   measurements:
-    instructions: 1622774819
+    instructions: 1622025795
     node_load_v1: 443614945
-    node_save_v1: 681136613
+    node_save_v1: 680680401
     stable_memory_size: 231
 btreemap_remove_blob_32_1024_v2:
   measurements:
-    instructions: 2327712353
-    node_load_v2: 545936021
-    node_save_v2: 1296028720
+    instructions: 1805728812
+    node_load_v2: 545888022
+    node_save_v2: 773231206
     stable_memory_size: 231
 btreemap_remove_blob_4_1024:
   measurements:
-    instructions: 1006445824
+    instructions: 1005989932
     node_load_v1: 269171795
-    node_save_v1: 421165272
+    node_save_v1: 420883123
     stable_memory_size: 124
 btreemap_remove_blob_4_1024_v2:
   measurements:
-    instructions: 1417663977
-    node_load_v2: 334152992
-    node_save_v2: 771242703
+    instructions: 1123916215
+    node_load_v2: 334520048
+    node_save_v2: 477506500
     stable_memory_size: 124
 btreemap_remove_blob_512_1024:
   measurements:
-    instructions: 4124317339
+    instructions: 4123516635
     node_load_v1: 2441544783
-    node_save_v1: 765030850
+    node_save_v1: 764541981
     stable_memory_size: 352
 btreemap_remove_blob_512_1024_v2:
   measurements:
-    instructions: 5148960911
-    node_load_v2: 2551453898
-    node_save_v2: 1679801019
+    instructions: 4332567176
+    node_load_v2: 2551503756
+    node_save_v2: 863236858
     stable_memory_size: 352
 btreemap_remove_blob_64_1024:
   measurements:
-    instructions: 1917032351
+    instructions: 1916261049
     node_load_v1: 675469604
-    node_save_v1: 700312977
+    node_save_v1: 699843250
     stable_memory_size: 246
 btreemap_remove_blob_64_1024_v2:
   measurements:
-    instructions: 2663931711
-    node_load_v2: 783139557
-    node_save_v2: 1347977662
+    instructions: 2111770035
+    node_load_v2: 783191220
+    node_save_v2: 795030992
     stable_memory_size: 246
 btreemap_remove_blob_8_1024:
   measurements:
-    instructions: 1300448303
+    instructions: 1299825273
     node_load_v1: 325916114
-    node_save_v1: 562174712
+    node_save_v1: 561793980
     stable_memory_size: 184
 btreemap_remove_blob_8_1024_v2:
   measurements:
-    instructions: 1842012771
-    node_load_v2: 391438934
-    node_save_v2: 1045529346
+    instructions: 1435762834
+    node_load_v2: 391933707
+    node_save_v2: 638595044
     stable_memory_size: 184
 btreemap_remove_blob_8_u64:
   measurements:
-    instructions: 903826016
+    instructions: 903169486
     node_load_v1: 318747944
-    node_save_v1: 302202576
+    node_save_v1: 301798231
     stable_memory_size: 7
 btreemap_remove_blob_8_u64_v2:
   measurements:
-    instructions: 1038966741
-    node_load_v2: 397153759
-    node_save_v2: 361390361
+    instructions: 1066956998
+    node_load_v2: 399537975
+    node_save_v2: 382247298
     stable_memory_size: 7
 btreemap_remove_u64_blob_8:
   measurements:
-    instructions: 1072866879
+    instructions: 1072102455
     node_load_v1: 313757215
-    node_save_v1: 457702957
+    node_save_v1: 457512144
     stable_memory_size: 8
 btreemap_remove_u64_blob_8_v2:
   measurements:
-    instructions: 1128519819
-    node_load_v2: 362925019
-    node_save_v2: 463945611
+    instructions: 1186857459
+    node_load_v2: 364726642
+    node_save_v2: 517296661
     stable_memory_size: 8
 btreemap_remove_u64_u64:
   measurements:
-    instructions: 1110124274
+    instructions: 1109353494
     node_load_v1: 314148033
-    node_save_v1: 483110284
+    node_save_v1: 482917665
     stable_memory_size: 8
 btreemap_remove_u64_u64_v2:
   measurements:
-    instructions: 1181708460
-    node_load_v2: 364710321
-    node_save_v2: 503803249
+    instructions: 1227062933
+    node_load_v2: 366608916
+    node_save_v2: 543163993
     stable_memory_size: 8
 memory_manager_baseline:
   measurements:

--- a/benchmarks/results.yml
+++ b/benchmarks/results.yml
@@ -110,9 +110,9 @@ btreemap_get_u64_u64_v2:
     stable_memory_size: 7
 btreemap_insert_10mib_values:
   measurements:
-    instructions: 158321842
+    instructions: 153745217
     node_load_v2: 10377468
-    node_save_v2: 126007892
+    node_save_v2: 121431267
     stable_memory_size: 33
 btreemap_insert_blob_128_1024:
   measurements:
@@ -122,9 +122,9 @@ btreemap_insert_blob_128_1024:
     stable_memory_size: 261
 btreemap_insert_blob_128_1024_v2:
   measurements:
-    instructions: 1885426376
+    instructions: 1885312232
     node_load_v2: 916598797
-    node_save_v2: 470711703
+    node_save_v2: 470597559
     stable_memory_size: 196
 btreemap_insert_blob_16_1024:
   measurements:
@@ -134,9 +134,9 @@ btreemap_insert_blob_16_1024:
     stable_memory_size: 216
 btreemap_insert_blob_16_1024_v2:
   measurements:
-    instructions: 1295285052
+    instructions: 1295167866
     node_load_v2: 440404989
-    node_save_v2: 448552635
+    node_save_v2: 448435449
     stable_memory_size: 162
 btreemap_insert_blob_256_1024:
   measurements:
@@ -146,9 +146,9 @@ btreemap_insert_blob_256_1024:
     stable_memory_size: 293
 btreemap_insert_blob_256_1024_v2:
   measurements:
-    instructions: 2415990126
+    instructions: 2415876387
     node_load_v2: 1368714490
-    node_save_v2: 476282802
+    node_save_v2: 476169063
     stable_memory_size: 220
 btreemap_insert_blob_32_1024:
   measurements:
@@ -158,9 +158,9 @@ btreemap_insert_blob_32_1024:
     stable_memory_size: 231
 btreemap_insert_blob_32_1024_v2:
   measurements:
-    instructions: 1345658885
+    instructions: 1345546619
     node_load_v2: 477582317
-    node_save_v2: 461160653
+    node_save_v2: 461048387
     stable_memory_size: 174
 btreemap_insert_blob_4_1024:
   measurements:
@@ -170,9 +170,9 @@ btreemap_insert_blob_4_1024:
     stable_memory_size: 124
 btreemap_insert_blob_4_1024_v2:
   measurements:
-    instructions: 1033034897
+    instructions: 1032956555
     node_load_v2: 302721338
-    node_save_v2: 410420944
+    node_save_v2: 410342602
     stable_memory_size: 93
 btreemap_insert_blob_512_1024:
   measurements:
@@ -182,9 +182,9 @@ btreemap_insert_blob_512_1024:
     stable_memory_size: 352
 btreemap_insert_blob_512_1024_v2:
   measurements:
-    instructions: 3439064380
+    instructions: 3438950584
     node_load_v2: 2249806809
-    node_save_v2: 493487161
+    node_save_v2: 493373365
     stable_memory_size: 264
 btreemap_insert_blob_64_1024:
   measurements:
@@ -194,9 +194,9 @@ btreemap_insert_blob_64_1024:
     stable_memory_size: 246
 btreemap_insert_blob_64_1024_v2:
   measurements:
-    instructions: 1606272867
+    instructions: 1606159890
     node_load_v2: 692239035
-    node_save_v2: 464598981
+    node_save_v2: 464486004
     stable_memory_size: 184
 btreemap_insert_blob_8_1024:
   measurements:
@@ -206,9 +206,9 @@ btreemap_insert_blob_8_1024:
     stable_memory_size: 184
 btreemap_insert_blob_8_1024_v2:
   measurements:
-    instructions: 1183760259
+    instructions: 1183662633
     node_load_v2: 344998681
-    node_save_v2: 437944464
+    node_save_v2: 437846838
     stable_memory_size: 139
 btreemap_insert_blob_8_u64:
   measurements:
@@ -218,9 +218,9 @@ btreemap_insert_blob_8_u64:
     stable_memory_size: 7
 btreemap_insert_blob_8_u64_v2:
   measurements:
-    instructions: 811127219
+    instructions: 810706169
     node_load_v2: 358652286
-    node_save_v2: 237233172
+    node_save_v2: 236812122
     stable_memory_size: 5
 btreemap_insert_u64_blob_8:
   measurements:
@@ -230,9 +230,9 @@ btreemap_insert_u64_blob_8:
     stable_memory_size: 8
 btreemap_insert_u64_blob_8_v2:
   measurements:
-    instructions: 821522654
+    instructions: 821061744
     node_load_v2: 320684381
-    node_save_v2: 288040804
+    node_save_v2: 287579894
     stable_memory_size: 6
 btreemap_insert_u64_u64:
   measurements:
@@ -242,9 +242,9 @@ btreemap_insert_u64_u64:
     stable_memory_size: 8
 btreemap_insert_u64_u64_v2:
   measurements:
-    instructions: 852232016
+    instructions: 851451139
     node_load_v2: 324640651
-    node_save_v2: 300506147
+    node_save_v2: 299725270
     stable_memory_size: 7
 btreemap_remove_blob_128_1024:
   measurements:
@@ -254,9 +254,9 @@ btreemap_remove_blob_128_1024:
     stable_memory_size: 261
 btreemap_remove_blob_128_1024_v2:
   measurements:
-    instructions: 2434075251
+    instructions: 2433740025
     node_load_v2: 1029552036
-    node_save_v2: 813589257
+    node_save_v2: 813254031
     stable_memory_size: 196
 btreemap_remove_blob_16_1024:
   measurements:
@@ -266,9 +266,9 @@ btreemap_remove_blob_16_1024:
     stable_memory_size: 216
 btreemap_remove_blob_16_1024_v2:
   measurements:
-    instructions: 1718854571
+    instructions: 1718554037
     node_load_v2: 514792050
-    node_save_v2: 742698168
+    node_save_v2: 742397634
     stable_memory_size: 162
 btreemap_remove_blob_256_1024:
   measurements:
@@ -278,9 +278,9 @@ btreemap_remove_blob_256_1024:
     stable_memory_size: 293
 btreemap_remove_blob_256_1024_v2:
   measurements:
-    instructions: 3039382513
+    instructions: 3039070285
     node_load_v2: 1528561438
-    node_save_v2: 816851139
+    node_save_v2: 816538911
     stable_memory_size: 220
 btreemap_remove_blob_32_1024:
   measurements:
@@ -290,9 +290,9 @@ btreemap_remove_blob_32_1024:
     stable_memory_size: 231
 btreemap_remove_blob_32_1024_v2:
   measurements:
-    instructions: 1805574712
+    instructions: 1805280484
     node_load_v2: 545887374
-    node_save_v2: 773078003
+    node_save_v2: 772783775
     stable_memory_size: 174
 btreemap_remove_blob_4_1024:
   measurements:
@@ -302,9 +302,9 @@ btreemap_remove_blob_4_1024:
     stable_memory_size: 124
 btreemap_remove_blob_4_1024_v2:
   measurements:
-    instructions: 1123853333
+    instructions: 1123652378
     node_load_v2: 334523075
-    node_save_v2: 477440771
+    node_save_v2: 477239816
     stable_memory_size: 93
 btreemap_remove_blob_512_1024:
   measurements:
@@ -314,9 +314,9 @@ btreemap_remove_blob_512_1024:
     stable_memory_size: 352
 btreemap_remove_blob_512_1024_v2:
   measurements:
-    instructions: 4332504816
+    instructions: 4332164229
     node_load_v2: 2551504154
-    node_save_v2: 863174292
+    node_save_v2: 862833705
     stable_memory_size: 264
 btreemap_remove_blob_64_1024:
   measurements:
@@ -326,9 +326,9 @@ btreemap_remove_blob_64_1024:
     stable_memory_size: 246
 btreemap_remove_blob_64_1024_v2:
   measurements:
-    instructions: 2111618035
+    instructions: 2111313280
     node_load_v2: 783191220
-    node_save_v2: 794878992
+    node_save_v2: 794574237
     stable_memory_size: 184
 btreemap_remove_blob_8_1024:
   measurements:
@@ -338,9 +338,9 @@ btreemap_remove_blob_8_1024:
     stable_memory_size: 184
 btreemap_remove_blob_8_1024_v2:
   measurements:
-    instructions: 1435636851
+    instructions: 1435373289
     node_load_v2: 391933707
-    node_save_v2: 638471002
+    node_save_v2: 638207440
     stable_memory_size: 139
 btreemap_remove_blob_8_u64:
   measurements:
@@ -350,9 +350,9 @@ btreemap_remove_blob_8_u64:
     stable_memory_size: 7
 btreemap_remove_blob_8_u64_v2:
   measurements:
-    instructions: 1084484647
+    instructions: 1083124566
     node_load_v2: 407619215
-    node_save_v2: 390754384
+    node_save_v2: 389394303
     stable_memory_size: 5
 btreemap_remove_u64_blob_8:
   measurements:
@@ -362,9 +362,9 @@ btreemap_remove_u64_blob_8:
     stable_memory_size: 8
 btreemap_remove_u64_blob_8_v2:
   measurements:
-    instructions: 1190622107
+    instructions: 1189636395
     node_load_v2: 366667638
-    node_save_v2: 519170883
+    node_save_v2: 518185171
     stable_memory_size: 6
 btreemap_remove_u64_u64:
   measurements:
@@ -374,9 +374,9 @@ btreemap_remove_u64_u64:
     stable_memory_size: 8
 btreemap_remove_u64_u64_v2:
   measurements:
-    instructions: 1245095146
+    instructions: 1243004765
     node_load_v2: 374499836
-    node_save_v2: 553398290
+    node_save_v2: 551307909
     stable_memory_size: 7
 memory_manager_baseline:
   measurements:

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -348,6 +348,11 @@ impl<K: Storable + Ord + Clone> Node<K> {
             .collect()
     }
 
+    #[cfg(test)]
+    pub fn overflows(&self) -> &[Address] {
+        &self.overflows
+    }
+
     /// Returns the number of entries in the node.
     pub fn entries_len(&self) -> usize {
         self.keys.len()

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -8,13 +8,13 @@ use crate::{
 use std::borrow::{Borrow, Cow};
 use std::cell::{Ref, RefCell};
 
-mod reader;
+mod io;
 #[cfg(test)]
 mod tests;
 mod v1;
 mod v2;
 
-use reader::NodeReader;
+use io::NodeReader;
 
 // The minimum degree to use in the btree.
 // This constant is taken from Rust's std implementation of BTreeMap.

--- a/src/btreemap/node/io.rs
+++ b/src/btreemap/node/io.rs
@@ -178,7 +178,7 @@ pub struct NodeWriterContext<'a> {
 pub fn write<M: Memory>(
     offset: Address,
     src: &[u8],
-    allocator: &Allocator<M>,
+    allocator: &mut Allocator<M>,
     ctx: &NodeWriterContext,
 ) {
     let offset = offset.get();
@@ -229,7 +229,7 @@ pub fn write<M: Memory>(
 pub fn write_u32<M: Memory>(
     offset: Address,
     val: u32,
-    allocator: &Allocator<M>,
+    allocator: &mut Allocator<M>,
     ctx: &NodeWriterContext,
 ) {
     write(offset, &val.to_le_bytes(), allocator, ctx);
@@ -238,7 +238,7 @@ pub fn write_u32<M: Memory>(
 pub fn write_u64<M: Memory>(
     offset: Address,
     val: u64,
-    allocator: &Allocator<M>,
+    allocator: &mut Allocator<M>,
     ctx: &NodeWriterContext,
 ) {
     write(offset, &val.to_le_bytes(), allocator, ctx);
@@ -247,7 +247,7 @@ pub fn write_u64<M: Memory>(
 pub fn write_struct<T, M: Memory>(
     t: &T,
     addr: Address,
-    allocator: &Allocator<M>,
+    allocator: &mut Allocator<M>,
     ctx: &NodeWriterContext,
 ) {
     let slice = unsafe {

--- a/src/btreemap/node/io.rs
+++ b/src/btreemap/node/io.rs
@@ -201,6 +201,8 @@ impl<'a, M: Memory> NodeWriter<'a, M> {
         }
     }
 
+    /// Finished the writing process by returning the node's overflow pages.
+    /// Any unused pages are deallocated to prevent memory leaks.
     pub fn finish(mut self) -> Vec<Address> {
         self.deallocate_unused_pages();
         self.overflows

--- a/src/btreemap/node/io.rs
+++ b/src/btreemap/node/io.rs
@@ -175,7 +175,7 @@ pub struct NodeWriterContext<'a> {
     pub page_size: PageSize,
 }
 
-pub fn write_node<M: Memory>(
+pub fn write<M: Memory>(
     offset: Address,
     src: &[u8],
     allocator: &Allocator<M>,
@@ -185,7 +185,7 @@ pub fn write_node<M: Memory>(
     let memory = allocator.memory();
 
     if (offset + src.len() as u64) < ctx.page_size.get() as u64 {
-        write(memory, ctx.address.get() + offset, src);
+        crate::write(memory, ctx.address.get() + offset, src);
         return;
     }
 
@@ -205,7 +205,7 @@ pub fn write_node<M: Memory>(
     } in iter
     {
         if page_idx == 0 {
-            write(
+            crate::write(
                 memory,
                 (ctx.address + offset).get(),
                 &src[bytes_written as usize..(bytes_written + length.get()) as usize],
@@ -215,7 +215,7 @@ pub fn write_node<M: Memory>(
                 panic!("shouldn't happen");
             }
 
-            write(
+            crate::write(
                 memory,
                 (ctx.overflows[page_idx - 1] + offset).get(),
                 &src[bytes_written as usize..(bytes_written + length.get()) as usize],
@@ -232,7 +232,7 @@ pub fn write_u32<M: Memory>(
     allocator: &Allocator<M>,
     ctx: &NodeWriterContext,
 ) {
-    write_node(offset, &val.to_le_bytes(), allocator, ctx);
+    write(offset, &val.to_le_bytes(), allocator, ctx);
 }
 
 pub fn write_u64<M: Memory>(
@@ -241,7 +241,7 @@ pub fn write_u64<M: Memory>(
     allocator: &Allocator<M>,
     ctx: &NodeWriterContext,
 ) {
-    write_node(offset, &val.to_le_bytes(), allocator, ctx);
+    write(offset, &val.to_le_bytes(), allocator, ctx);
 }
 
 pub fn write_struct<T, M: Memory>(
@@ -254,5 +254,5 @@ pub fn write_struct<T, M: Memory>(
         core::slice::from_raw_parts(t as *const _ as *const u8, core::mem::size_of::<T>())
     };
 
-    write_node(addr, slice, allocator, ctx)
+    write(addr, slice, allocator, ctx)
 }

--- a/src/btreemap/node/io.rs
+++ b/src/btreemap/node/io.rs
@@ -169,7 +169,7 @@ impl Iterator for NodeIterator {
     }
 }
 
-pub struct NodeWriter2<'a> {
+pub struct NodeWriterContext<'a> {
     pub address: Address,
     pub overflows: &'a [Address],
     pub page_size: PageSize,
@@ -179,7 +179,7 @@ pub fn write_node<M: Memory>(
     offset: Address,
     src: &[u8],
     allocator: &Allocator<M>,
-    ctx: &NodeWriter2,
+    ctx: &NodeWriterContext,
 ) {
     let offset = offset.get();
     let memory = allocator.memory();
@@ -230,7 +230,7 @@ pub fn write_u32<M: Memory>(
     offset: Address,
     val: u32,
     allocator: &Allocator<M>,
-    ctx: &NodeWriter2,
+    ctx: &NodeWriterContext,
 ) {
     write_node(offset, &val.to_le_bytes(), allocator, ctx);
 }
@@ -239,7 +239,7 @@ pub fn write_u64<M: Memory>(
     offset: Address,
     val: u64,
     allocator: &Allocator<M>,
-    ctx: &NodeWriter2,
+    ctx: &NodeWriterContext,
 ) {
     write_node(offset, &val.to_le_bytes(), allocator, ctx);
 }
@@ -248,7 +248,7 @@ pub fn write_struct<T, M: Memory>(
     t: &T,
     addr: Address,
     allocator: &Allocator<M>,
-    ctx: &NodeWriter2,
+    ctx: &NodeWriterContext,
 ) {
     let slice = unsafe {
         core::slice::from_raw_parts(t as *const _ as *const u8, core::mem::size_of::<T>())

--- a/src/btreemap/node/reader.rs
+++ b/src/btreemap/node/reader.rs
@@ -168,3 +168,79 @@ impl Iterator for NodeIterator {
         })
     }
 }
+
+/// TODO
+pub struct NodeWriter<'a, M: Memory> {
+    pub address: Address,
+    pub overflows: &'a [Address],
+    pub page_size: PageSize,
+    pub allocator: &'a Allocator<M>,
+}
+
+impl<'a, M: Memory> Memory for NodeWriter<'a, M> {
+    fn read(&self, _: u64, _: &mut [u8]) {
+        unreachable!("NodeWriter does not call read")
+    }
+
+    fn write(&self, offset: u64, src: &[u8]) {
+        let memory = self.allocator.memory();
+
+        if (offset + src.len() as u64) < self.page_size.get() as u64 {
+            write(memory, self.address.get() + offset, src);
+            return;
+        }
+
+        let iter = NodeIterator::new(
+            VirtualSegment {
+                address: Address::from(offset),
+                length: Bytes::from(src.len() as u64),
+            },
+            Bytes::from(self.page_size.get()),
+        );
+
+        let mut bytes_written = 0;
+        for RealSegment {
+            page_idx,
+            offset,
+            length,
+        } in iter
+        {
+            if page_idx == 0 {
+                write(
+                    memory,
+                    (self.address + offset).get(),
+                    &src[bytes_written as usize..(bytes_written + length.get()) as usize],
+                );
+            } else {
+                if self.overflows.len() < page_idx {
+                    panic!("shouldn't happen");
+
+                }
+
+                write(
+                    memory,
+                    (self.overflows[page_idx - 1] + offset).get(),
+                    &src[bytes_written as usize..(bytes_written + length.get()) as usize],
+                );
+            }
+
+            bytes_written += length.get();
+        }
+    }
+
+    fn size(&self) -> u64 {
+        100 // FIXME
+    }
+
+    fn grow(&self, _: u64) -> i64 {
+        unreachable!("NodeReader does not call grow")
+    }
+
+    /*fn add_overflow_page(&mut self) {
+        let new_page = allocator.allocate();
+
+        // TODO: set the header of the overflow page.
+
+        // Make the previous page point to the new page.
+    }*/
+}

--- a/src/btreemap/node/reader.rs
+++ b/src/btreemap/node/reader.rs
@@ -214,7 +214,6 @@ impl<'a, M: Memory> Memory for NodeWriter<'a, M> {
             } else {
                 if self.overflows.len() < page_idx {
                     panic!("shouldn't happen");
-
                 }
 
                 write(

--- a/src/btreemap/node/tests.rs
+++ b/src/btreemap/node/tests.rs
@@ -203,7 +203,11 @@ fn growing_and_shrinking_entries_does_not_leak_memory() {
     let allocator_addr = Address::from(0);
     let mut allocator = Allocator::new(mem, allocator_addr, PageSize::Value(500).get().into());
 
-    let mut node = Node::new_v2(allocator_addr, NodeType::Leaf, PageSize::Value(500));
+    let mut node = Node::new_v2(
+        allocator.allocate(),
+        NodeType::Leaf,
+        PageSize::Value(500),
+    );
 
     // Insert an entry substantially larger than the page size and save it.
     node.push_entry((vec![1, 2, 3], vec![0; 10000]));

--- a/src/btreemap/node/tests.rs
+++ b/src/btreemap/node/tests.rs
@@ -1,5 +1,11 @@
 use super::*;
-use crate::btreemap::Allocator;
+use crate::{
+    btreemap::{
+        node::v2::{OVERFLOW_ADDRESS_OFFSET, PAGE_OVERFLOW_NEXT_OFFSET},
+        Allocator,
+    },
+    types::NULL,
+};
 use proptest::collection::btree_map as pmap;
 use proptest::collection::vec as pvec;
 use std::cell::RefCell;
@@ -203,11 +209,7 @@ fn growing_and_shrinking_entries_does_not_leak_memory() {
     let allocator_addr = Address::from(0);
     let mut allocator = Allocator::new(mem, allocator_addr, PageSize::Value(500).get().into());
 
-    let mut node = Node::new_v2(
-        allocator.allocate(),
-        NodeType::Leaf,
-        PageSize::Value(500),
-    );
+    let mut node = Node::new_v2(allocator.allocate(), NodeType::Leaf, PageSize::Value(500));
 
     // Insert an entry substantially larger than the page size and save it.
     node.push_entry((vec![1, 2, 3], vec![0; 10000]));
@@ -239,45 +241,51 @@ fn growing_and_shrinking_entries_does_not_leak_memory() {
 }
 
 #[test]
-fn growing_and_shrinking_2() {
+fn overflows_end_with_null_after_nodes_growing_and_shrinking() {
     let mem = make_memory();
     let allocator_addr = Address::from(0);
-    let mut allocator = Allocator::new(mem.clone(), allocator_addr, PageSize::Value(500).get().into());
+    let page_size = PageSize::Value(500);
+    let mut allocator = Allocator::new(mem.clone(), allocator_addr, page_size.get().into());
 
     let node_addr = allocator.allocate();
-    let mut node = Node::new_v2(
-        node_addr,
-        NodeType::Leaf,
-        PageSize::Value(500),
+    let mut node = Node::new_v2(node_addr, NodeType::Leaf, page_size);
+
+    // Insert an entry larger than the page size and save it.
+    node.push_entry((vec![1, 2, 3], vec![13; 1000]));
+    node.save(&mut allocator);
+
+    // Expect two overflow pages.
+    assert_eq!(node.overflows().len(), 2);
+
+    // The last overflow page should point to NULL.
+    assert_eq!(
+        read_u64(&mem, node.overflows()[1] + PAGE_OVERFLOW_NEXT_OFFSET),
+        NULL.get()
     );
 
-    // Insert an entry substantially larger than the page size and save it.
-    node.push_entry((vec![1, 2, 3], vec![0; 10000]));
+    // Replace the entry with a smaller value such that only one overflow page is needed.
+    node.swap_entry(0, (vec![1, 2, 3], vec![7; 500]), allocator.memory());
     node.save(&mut allocator);
 
-    let num_allocated_chunks = allocator.num_allocated_chunks();
+    // Expect one overflow page.
+    assert_eq!(node.overflows().len(), 1);
 
-    // The node is more than one page.
-    assert!(num_allocated_chunks > 1);
-
-    // Swap the value with a much smaller value.
-    node.swap_entry(0, (vec![1, 2, 3], vec![4, 5, 6]), allocator.memory());
-    node.save(&mut allocator);
-
-    let mut node2: Node<Vec<u8>> = Node::new_v2(
-        allocator.allocate(),
-        NodeType::Leaf,
-        PageSize::Value(500),
+    // The last overflow page should point to NULL.
+    assert_eq!(
+        read_u64(&mem, node.overflows()[0] + PAGE_OVERFLOW_NEXT_OFFSET),
+        NULL.get()
     );
 
-    node2.push_entry((vec![1], vec![2]));
-    node2.save(&mut allocator);
-
-    let mut node = Node::load_v2(node_addr, PageSize::Value(500), &mem);
-
-    // Swap the value with one that is similar in size to the original value.
-    node.swap_entry(0, (vec![1, 2, 3], vec![3; 10000]), allocator.memory());
+    // Replace the entry with a smaller value such that no overflow pages are needed.
+    node.swap_entry(0, (vec![1, 2, 3], vec![]), allocator.memory());
     node.save(&mut allocator);
-    // The extra chunks are deallocated and we're back to the original number of chunks.
-//    assert_eq!(num_allocated_chunks, allocator.num_allocated_chunks());
+
+    // Expect no overflow pages.
+    assert_eq!(node.overflows().len(), 0);
+
+    // The initial page should point to NULL as it's overflow page.
+    assert_eq!(
+        read_u64(&mem, node_addr + OVERFLOW_ADDRESS_OFFSET),
+        NULL.get()
+    );
 }

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -268,7 +268,11 @@ impl<K: Storable + Ord + Clone> Node<K> {
         offset += NodeHeader::size();
         // Add a null overflow address. This might get overwritten later in case the node
         // does overflow.
-        //writer.write(offset.get(), &[0; 8]);
+        write_u64(
+            &writer,
+            offset,
+            self.overflows.get(0).unwrap_or(&Address::from(0)).get(),
+        );
         offset += Bytes::from(8u64);
 
         // A buffer to serialize the node into first, then write to memory.

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -297,7 +297,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
             }
 
             // Write the key.
-            io::write_node(offset, key_bytes.borrow(), allocator, &write_ctx);
+            io::write(offset, key_bytes.borrow(), allocator, &write_ctx);
             offset += Bytes::from(key_bytes.len());
         }
 
@@ -309,7 +309,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
             offset += U32_SIZE;
 
             // Write the value.
-            io::write_node(offset, &value, allocator, &write_ctx);
+            io::write(offset, &value, allocator, &write_ctx);
             offset += Bytes::from(value.len());
         }
     }

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -235,10 +235,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
 
         // Add a null overflow address.
         // This might get overwritten later in case the node does overflow.
-        writer.write_u64(
-            offset,
-            self.overflows.get(0).unwrap_or(&NULL).get(),
-        );
+        writer.write_u64(offset, self.overflows.get(0).unwrap_or(&NULL).get());
         offset += Bytes::from(8u64);
 
         // Write the children


### PR DESCRIPTION
When saving a BTreeMap V2 node, a large buffer was allocated where we first serialize the node, and then at a later stage we break this buffer into smaller pages and write those into stable memory. This was simpler to implement, yet inefficient.

This PR removes the large buffer allocation and instead uses a `NodeWriter`, which write the node incrementally without the need to allocate large buffers on the heap.

This narrows the performance gap even further between v1 and v2 as seen by the following benchmark report.

```
---------------------------------------------------

Benchmark: memory_manager_baseline
  measurements:
    instructions: 1176576551 (0.00%) (no change)
    stable_memory_size: 8000 (0.00%) (no change)

---------------------------------------------------

Benchmark: memory_manager_overhead
  measurements:
    instructions: 1182012269 (0.00%) (no change)
    stable_memory_size: 8321 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_10mib_values
  measurements:
    instructions: 158321842 (improved by 43.10%)
    node_load_v2: 10377468 (0.00%) (no change)
    node_save_v2: 126007892 (improved by 48.77%)
    stable_memory_size: 33 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_4_1024
  measurements:
    instructions: 938459480 (-0.04%) (change within noise threshold)
    node_load_v1: 246219371 (0.00%) (no change)
    node_save_v1: 369888833 (-0.06%) (change within noise threshold)
    stable_memory_size: 124 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_4_1024_v2
  measurements:
    instructions: 1033183548 (improved by 19.60%)
    node_load_v2: 302721338 (0.05%) (change within noise threshold)
    node_save_v2: 410566944 (improved by 37.92%)
    stable_memory_size: 124 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_8_1024
  measurements:
    instructions: 1084454578 (-0.04%) (change within noise threshold)
    node_load_v1: 286595797 (0.00%) (no change)
    node_save_v1: 394091363 (-0.06%) (change within noise threshold)
    stable_memory_size: 184 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_8_1024_v2
  measurements:
    instructions: 1183969018 (improved by 18.83%)
    node_load_v2: 344994802 (0.06%) (change within noise threshold)
    node_save_v2: 438155700 (improved by 38.45%)
    stable_memory_size: 184 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_16_1024
  measurements:
    instructions: 1176903332 (-0.04%) (change within noise threshold)
    node_load_v1: 362914338 (0.00%) (no change)
    node_save_v1: 403232566 (-0.06%) (change within noise threshold)
    stable_memory_size: 216 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_16_1024_v2
  measurements:
    instructions: 1295546890 (improved by 18.44%)
    node_load_v2: 440399043 (0.04%) (change within noise threshold)
    node_save_v2: 448818266 (improved by 39.36%)
    stable_memory_size: 216 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_32_1024
  measurements:
    instructions: 1224078359 (-0.04%) (change within noise threshold)
    node_load_v1: 390780802 (0.00%) (no change)
    node_save_v1: 415591575 (-0.06%) (change within noise threshold)
    stable_memory_size: 231 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_32_1024_v2
  measurements:
    instructions: 1345918082 (improved by 18.72%)
    node_load_v2: 477582317 (0.00%) (change within noise threshold)
    node_save_v2: 461418653 (improved by 40.01%)
    stable_memory_size: 231 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_64_1024
  measurements:
    instructions: 1463634810 (-0.04%) (change within noise threshold)
    node_load_v1: 595998298 (0.00%) (no change)
    node_save_v1: 418506217 (-0.06%) (change within noise threshold)
    stable_memory_size: 246 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_64_1024_v2
  measurements:
    instructions: 1606536169 (improved by 16.71%)
    node_load_v2: 692239035 (0.00%) (change within noise threshold)
    node_save_v2: 464863981 (improved by 40.82%)
    stable_memory_size: 246 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_128_1024
  measurements:
    instructions: 1729768012 (-0.03%) (change within noise threshold)
    node_load_v1: 818923030 (0.00%) (no change)
    node_save_v1: 424336331 (-0.06%) (change within noise threshold)
    stable_memory_size: 261 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_128_1024_v2
  measurements:
    instructions: 1885672741 (improved by 15.47%)
    node_load_v2: 916598797 (0.01%) (change within noise threshold)
    node_save_v2: 470957703 (improved by 42.16%)
    stable_memory_size: 261 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_256_1024
  measurements:
    instructions: 2255269553 (-0.02%) (change within noise threshold)
    node_load_v1: 1272224795 (0.00%) (no change)
    node_save_v1: 429936500 (-0.06%) (change within noise threshold)
    stable_memory_size: 293 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_256_1024_v2
  measurements:
    instructions: 2416164659 (improved by 13.54%)
    node_load_v2: 1368714490 (0.00%) (change within noise threshold)
    node_save_v2: 476456802 (improved by 44.08%)
    stable_memory_size: 293 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_512_1024
  measurements:
    instructions: 3306266369 (-0.02%) (change within noise threshold)
    node_load_v1: 2162164471 (0.00%) (no change)
    node_save_v1: 447224687 (-0.05%) (change within noise threshold)
    stable_memory_size: 352 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_512_1024_v2
  measurements:
    instructions: 3439168228 (improved by 11.86%)
    node_load_v2: 2249806809 (0.00%) (change within noise threshold)
    node_save_v2: 493589161 (improved by 48.25%)
    stable_memory_size: 352 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_u64_u64
  measurements:
    instructions: 771295973 (-0.07%) (change within noise threshold)
    node_load_v1: 274520203 (0.00%) (no change)
    node_save_v1: 266429035 (-0.04%) (change within noise threshold)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_u64_u64_v2
  measurements:
    instructions: 844848075 (0.27%) (change within noise threshold)
    node_load_v2: 320667801 (-0.09%) (change within noise threshold)
    node_save_v2: 298115032 (0.97%) (change within noise threshold)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_u64_blob_8
  measurements:
    instructions: 749642151 (-0.07%) (change within noise threshold)
    node_load_v1: 276866073 (0.00%) (no change)
    node_save_v1: 255566331 (-0.04%) (change within noise threshold)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_u64_blob_8_v2
  measurements:
    instructions: 820358615 (1.77%) (change within noise threshold)
    node_load_v2: 320406521 (0.02%) (change within noise threshold)
    node_save_v2: 287445446 (regressed by 5.64%)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_8_u64
  measurements:
    instructions: 684209106 (-0.07%) (change within noise threshold)
    node_load_v1: 277937358 (0.00%) (no change)
    node_save_v1: 189165744 (-0.12%) (change within noise threshold)
    stable_memory_size: 7 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_insert_blob_8_u64_v2
  measurements:
    instructions: 802688497 (0.48%) (change within noise threshold)
    node_load_v2: 354976358 (0.05%) (change within noise threshold)
    node_save_v2: 234878135 (regressed by 2.23%)
    stable_memory_size: 7 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_4_1024
  measurements:
    instructions: 401718154 (0.00%) (no change)
    node_load_v1: 259275488 (0.00%) (no change)
    stable_memory_size: 124 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_4_1024_v2
  measurements:
    instructions: 480241876 (0.00%) (no change)
    node_load_v2: 329436785 (0.00%) (no change)
    stable_memory_size: 124 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_8_1024
  measurements:
    instructions: 473964224 (0.00%) (no change)
    node_load_v1: 304258691 (0.00%) (no change)
    stable_memory_size: 184 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_8_1024_v2
  measurements:
    instructions: 549627424 (0.00%) (no change)
    node_load_v2: 371386524 (0.00%) (no change)
    stable_memory_size: 184 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_16_1024
  measurements:
    instructions: 553966238 (0.00%) (no change)
    node_load_v1: 383794822 (0.00%) (no change)
    stable_memory_size: 216 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_16_1024_v2
  measurements:
    instructions: 637391324 (0.00%) (no change)
    node_load_v2: 464133703 (0.00%) (no change)
    stable_memory_size: 216 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_32_1024
  measurements:
    instructions: 591716960 (0.00%) (no change)
    node_load_v1: 410436451 (0.00%) (no change)
    stable_memory_size: 231 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_32_1024_v2
  measurements:
    instructions: 679662006 (0.00%) (no change)
    node_load_v2: 495574095 (0.00%) (no change)
    stable_memory_size: 231 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_64_1024
  measurements:
    instructions: 814621589 (0.00%) (no change)
    node_load_v1: 627796876 (0.00%) (no change)
    stable_memory_size: 246 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_64_1024_v2
  measurements:
    instructions: 902934555 (0.00%) (no change)
    node_load_v2: 708745655 (0.00%) (no change)
    stable_memory_size: 246 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_128_1024
  measurements:
    instructions: 1036041908 (0.00%) (no change)
    node_load_v1: 839537545 (0.00%) (no change)
    stable_memory_size: 261 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_128_1024_v2
  measurements:
    instructions: 1140173858 (0.00%) (change within noise threshold)
    node_load_v2: 933785784 (0.00%) (no change)
    stable_memory_size: 261 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_u64_u64
  measurements:
    instructions: 412643077 (0.00%) (no change)
    node_load_v1: 290922161 (0.00%) (no change)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_u64_u64_v2
  measurements:
    instructions: 469869306 (0.00%) (change within noise threshold)
    node_load_v2: 341278594 (0.00%) (no change)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_u64_blob_8
  measurements:
    instructions: 409579480 (0.00%) (no change)
    node_load_v1: 292395667 (0.00%) (no change)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_u64_blob_8_v2
  measurements:
    instructions: 465392638 (0.00%) (change within noise threshold)
    node_load_v2: 342799065 (0.00%) (no change)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_8_u64
  measurements:
    instructions: 426482546 (0.00%) (no change)
    node_load_v1: 294602061 (0.00%) (no change)
    stable_memory_size: 7 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_8_u64_v2
  measurements:
    instructions: 511860381 (-0.00%) (change within noise threshold)
    node_load_v2: 373992060 (0.00%) (no change)
    stable_memory_size: 7 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_256_1024
  measurements:
    instructions: 1523593515 (0.00%) (no change)
    node_load_v1: 1301924960 (0.00%) (no change)
    stable_memory_size: 293 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_256_1024_v2
  measurements:
    instructions: 1628351272 (0.00%) (change within noise threshold)
    node_load_v2: 1392993062 (0.00%) (no change)
    stable_memory_size: 293 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_512_1024
  measurements:
    instructions: 2489215042 (0.00%) (no change)
    node_load_v1: 2219164452 (0.00%) (no change)
    stable_memory_size: 352 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_get_blob_512_1024_v2
  measurements:
    instructions: 2596163236 (0.00%) (no change)
    node_load_v2: 2312346281 (0.00%) (no change)
    stable_memory_size: 352 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_4_1024
  measurements:
    instructions: 1005989932 (-0.05%) (change within noise threshold)
    node_load_v1: 269171795 (0.00%) (no change)
    node_save_v1: 420883123 (-0.07%) (change within noise threshold)
    stable_memory_size: 124 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_4_1024_v2
  measurements:
    instructions: 1123916215 (improved by 20.72%)
    node_load_v2: 334520048 (0.11%) (change within noise threshold)
    node_save_v2: 477506500 (improved by 38.09%)
    stable_memory_size: 124 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_8_1024
  measurements:
    instructions: 1299825273 (-0.05%) (change within noise threshold)
    node_load_v1: 325916114 (0.00%) (no change)
    node_save_v1: 561793980 (-0.07%) (change within noise threshold)
    stable_memory_size: 184 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_8_1024_v2
  measurements:
    instructions: 1435762834 (improved by 22.05%)
    node_load_v2: 391933707 (0.13%) (change within noise threshold)
    node_save_v2: 638595044 (improved by 38.92%)
    stable_memory_size: 184 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_16_1024
  measurements:
    instructions: 1544195176 (-0.05%) (change within noise threshold)
    node_load_v1: 420249550 (0.00%) (no change)
    node_save_v1: 653989748 (-0.07%) (change within noise threshold)
    stable_memory_size: 216 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_16_1024_v2
  measurements:
    instructions: 1718977571 (improved by 22.52%)
    node_load_v2: 514792050 (0.16%) (change within noise threshold)
    node_save_v2: 742821168 (improved by 40.28%)
    stable_memory_size: 216 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_32_1024
  measurements:
    instructions: 1622025795 (-0.05%) (change within noise threshold)
    node_load_v1: 443614945 (0.00%) (no change)
    node_save_v1: 680680401 (-0.07%) (change within noise threshold)
    stable_memory_size: 231 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_32_1024_v2
  measurements:
    instructions: 1805728812 (improved by 22.42%)
    node_load_v2: 545888022 (-0.01%) (change within noise threshold)
    node_save_v2: 773231206 (improved by 40.34%)
    stable_memory_size: 231 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_64_1024
  measurements:
    instructions: 1916261049 (-0.04%) (change within noise threshold)
    node_load_v1: 675469604 (0.00%) (no change)
    node_save_v1: 699843250 (-0.07%) (change within noise threshold)
    stable_memory_size: 246 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_64_1024_v2
  measurements:
    instructions: 2111770035 (improved by 20.73%)
    node_load_v2: 783191220 (0.01%) (change within noise threshold)
    node_save_v2: 795030992 (improved by 41.02%)
    stable_memory_size: 246 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_128_1024
  measurements:
    instructions: 2235786044 (-0.04%) (change within noise threshold)
    node_load_v1: 922607545 (0.00%) (no change)
    node_save_v1: 716437888 (-0.07%) (change within noise threshold)
    stable_memory_size: 261 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_128_1024_v2
  measurements:
    instructions: 2434217251 (improved by 19.70%)
    node_load_v2: 1029552036 (0.01%) (change within noise threshold)
    node_save_v2: 813731257 (improved by 42.38%)
    stable_memory_size: 261 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_256_1024
  measurements:
    instructions: 2838422216 (-0.03%) (change within noise threshold)
    node_load_v1: 1421754484 (0.00%) (no change)
    node_save_v1: 722240539 (-0.06%) (change within noise threshold)
    stable_memory_size: 293 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_256_1024_v2
  measurements:
    instructions: 3039500513 (improved by 17.77%)
    node_load_v2: 1528561438 (0.00%) (change within noise threshold)
    node_save_v2: 816969139 (improved by 44.62%)
    stable_memory_size: 293 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_512_1024
  measurements:
    instructions: 4123516635 (-0.02%) (change within noise threshold)
    node_load_v1: 2441544783 (0.00%) (no change)
    node_save_v1: 764541981 (-0.06%) (change within noise threshold)
    stable_memory_size: 352 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_512_1024_v2
  measurements:
    instructions: 4332567176 (improved by 15.86%)
    node_load_v2: 2551503756 (0.00%) (change within noise threshold)
    node_save_v2: 863236858 (improved by 48.61%)
    stable_memory_size: 352 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_u64_u64
  measurements:
    instructions: 1109353494 (-0.07%) (change within noise threshold)
    node_load_v1: 314148033 (0.00%) (no change)
    node_save_v1: 482917665 (-0.04%) (change within noise threshold)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_u64_u64_v2
  measurements:
    instructions: 1227062933 (regressed by 3.84%)
    node_load_v2: 366608916 (0.52%) (change within noise threshold)
    node_save_v2: 543163993 (regressed by 7.81%)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_u64_blob_8
  measurements:
    instructions: 1072102455 (-0.07%) (change within noise threshold)
    node_load_v1: 313757215 (0.00%) (no change)
    node_save_v1: 457512144 (-0.04%) (change within noise threshold)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_u64_blob_8_v2
  measurements:
    instructions: 1186857459 (regressed by 5.17%)
    node_load_v2: 364726642 (0.50%) (change within noise threshold)
    node_save_v2: 517296661 (regressed by 11.50%)
    stable_memory_size: 8 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_8_u64
  measurements:
    instructions: 903169486 (-0.07%) (change within noise threshold)
    node_load_v1: 318747944 (0.00%) (no change)
    node_save_v1: 301798231 (-0.13%) (change within noise threshold)
    stable_memory_size: 7 (0.00%) (no change)

---------------------------------------------------

Benchmark: btreemap_remove_blob_8_u64_v2
  measurements:
    instructions: 1066956998 (regressed by 2.69%)
    node_load_v2: 399537975 (0.60%) (change within noise threshold)
    node_save_v2: 382247298 (regressed by 5.77%)
    stable_memory_size: 7 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_insert_blob_4
  measurements:
    instructions: 5187495 (0.00%) (no change)
    stable_memory_size: 1 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_insert_blob_8
  measurements:
    instructions: 5216814 (0.00%) (no change)
    stable_memory_size: 2 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_insert_blob_16
  measurements:
    instructions: 5186050 (0.00%) (no change)
    stable_memory_size: 3 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_insert_blob_32
  measurements:
    instructions: 5394984 (0.00%) (no change)
    stable_memory_size: 6 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_insert_blob_128
  measurements:
    instructions: 6109513 (0.00%) (no change)
    stable_memory_size: 20 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_insert_u64
  measurements:
    instructions: 12149357 (0.00%) (no change)
    stable_memory_size: 2 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_get_blob_4
  measurements:
    instructions: 10027133 (0.00%) (no change)
    stable_memory_size: 1 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_get_blob_8
  measurements:
    instructions: 11988806 (0.00%) (no change)
    stable_memory_size: 2 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_get_blob_16
  measurements:
    instructions: 14914959 (0.00%) (no change)
    stable_memory_size: 3 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_get_blob_32
  measurements:
    instructions: 15584015 (0.00%) (no change)
    stable_memory_size: 6 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_get_blob_128
  measurements:
    instructions: 25331980 (0.00%) (no change)
    stable_memory_size: 20 (0.00%) (no change)

---------------------------------------------------

Benchmark: vec_get_u64
  measurements:
    instructions: 11430290 (0.00%) (no change)
    stable_memory_size: 2 (0.00%) (no change)
Successfully persisted results to results.yml
```