### PR TITLE
refactor: determine node version automatically on load

### DIFF
--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1155,7 +1155,7 @@ where
     }
 
     fn load_node(&self, address: Address) -> Node<K> {
-        Node::load(address, self.memory(), self.version)
+        Node::load(address, self.version.page_size(), self.memory())
     }
 
     // Saves the map to memory.

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -21,7 +21,8 @@ use io::NodeReader;
 const B: usize = 6;
 // The maximum number of entries per node.
 const CAPACITY: usize = 2 * B - 1;
-const LAYOUT_VERSION: u8 = 1;
+const LAYOUT_VERSION_1: u8 = 1;
+const LAYOUT_VERSION_2: u8 = 2;
 const MAGIC: &[u8; 3] = b"BTN";
 const LEAF_NODE_TYPE: u8 = 0;
 const INTERNAL_NODE_TYPE: u8 = 1;
@@ -65,13 +66,24 @@ pub struct Node<K: Storable + Ord + Clone> {
 
 impl<K: Storable + Ord + Clone> Node<K> {
     /// Loads a node from memory at the given address.
-    pub fn load<M: Memory>(address: Address, memory: &M, version: Version) -> Self {
-        match version {
-            Version::V1(DerivedPageSize {
-                max_key_size,
-                max_value_size,
-            }) => Self::load_v1(address, max_key_size, max_value_size, memory),
-            Version::V2(page_size) => Self::load_v2(address, page_size, memory),
+    pub fn load<M: Memory>(address: Address, page_size: PageSize, memory: &M) -> Self {
+        // Load the header to determine which version the node is, then load the node accordingly.
+        let header: NodeHeader = read_struct(address, memory);
+        assert_eq!(&header.magic, MAGIC, "Bad magic.");
+        match header.version {
+            LAYOUT_VERSION_1 => {
+                if let PageSize::Derived(DerivedPageSize {
+                    max_key_size,
+                    max_value_size,
+                }) = page_size
+                {
+                    Self::load_v1(header, address, max_key_size, max_value_size, memory)
+                } else {
+                    unreachable!("Tried to load a V1 node without a derived PageSize.")
+                }
+            }
+            LAYOUT_VERSION_2 => Self::load_v2(address, page_size, header, memory),
+            unknown_version => unreachable!("Unsupported version {unknown_version}."),
         }
     }
 
@@ -108,8 +120,8 @@ impl<K: Storable + Ord + Clone> Node<K> {
                         .children
                         .last()
                         .expect("An internal node must have children."),
+                    self.version.page_size(),
                     memory,
-                    self.version,
                 );
                 last_child.get_max(memory)
             }
@@ -127,8 +139,8 @@ impl<K: Storable + Ord + Clone> Node<K> {
                 let first_child = Self::load(
                     // NOTE: an internal node must have children, so this access is safe.
                     self.children[0],
+                    self.version.page_size(),
                     memory,
-                    self.version,
                 );
                 first_child.get_min(memory)
             }

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -71,17 +71,15 @@ impl<K: Storable + Ord + Clone> Node<K> {
         let header: NodeHeader = read_struct(address, memory);
         assert_eq!(&header.magic, MAGIC, "Bad magic.");
         match header.version {
-            LAYOUT_VERSION_1 => {
-                if let PageSize::Derived(DerivedPageSize {
+            LAYOUT_VERSION_1 => match page_size {
+                PageSize::Derived(DerivedPageSize {
                     max_key_size,
                     max_value_size,
-                }) = page_size
-                {
-                    Self::load_v1(header, address, max_key_size, max_value_size, memory)
-                } else {
+                }) => Self::load_v1(header, address, max_key_size, max_value_size, memory),
+                PageSize::Value(_) => {
                     unreachable!("Tried to load a V1 node without a derived PageSize.")
                 }
-            }
+            },
             LAYOUT_VERSION_2 => Self::load_v2(address, page_size, header, memory),
             unknown_version => unreachable!("Unsupported version {unknown_version}."),
         }

--- a/src/btreemap/node/tests.rs
+++ b/src/btreemap/node/tests.rs
@@ -126,10 +126,12 @@ fn saving_and_loading_v1_preserves_data(node_data: NodeV1Data) {
     node.save_v1(&mem);
 
     // Load the node and double check all the entries and children are correct.
-    let node = Node::load_v1(
+    let node = Node::load(
         node_addr,
-        node_data.max_key_size,
-        node_data.max_value_size,
+        PageSize::Derived(DerivedPageSize {
+            max_key_size: node_data.max_key_size,
+            max_value_size: node_data.max_value_size,
+        }),
         &mem,
     );
 
@@ -156,7 +158,7 @@ fn saving_and_loading_v2_preserves_data(node_data: NodeV2Data) {
     node.save_v2(&mut allocator);
 
     // Reload the node and double check all the entries and children are correct.
-    let node = Node::load_v2(node_addr, PageSize::Value(node_data.page_size), &mem);
+    let node = Node::load(node_addr, PageSize::Value(node_data.page_size), &mem);
 
     assert_eq!(node.children, node_data.children());
     assert_eq!(
@@ -178,16 +180,18 @@ fn migrating_v1_nodes_to_v2(node_data: NodeV1Data) {
     node.save_v1(allocator.memory());
 
     // Reload the v1 node and save it as v2.
-    let mut node = Node::<Vec<u8>>::load_v1(
+    let mut node = Node::<Vec<u8>>::load(
         node_addr,
-        node_data.max_key_size,
-        node_data.max_value_size,
+        PageSize::Derived(DerivedPageSize {
+            max_key_size: node_data.max_key_size,
+            max_value_size: node_data.max_value_size,
+        }),
         allocator.memory(),
     );
     node.save_v2(&mut allocator);
 
     // Reload the now v2 node and double check all the entries and children are correct.
-    let node = Node::load_v2(
+    let node = Node::load(
         node_addr,
         PageSize::Derived(DerivedPageSize {
             max_key_size: node_data.max_key_size,

--- a/src/btreemap/node/v1.rs
+++ b/src/btreemap/node/v1.rs
@@ -54,6 +54,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
 
     /// Loads a v1 node from memory at the given address.
     pub(super) fn load_v1<M: Memory>(
+        header: NodeHeader,
         address: Address,
         max_key_size: u32,
         max_value_size: u32,
@@ -61,11 +62,6 @@ impl<K: Storable + Ord + Clone> Node<K> {
     ) -> Self {
         #[cfg(feature = "profiler")]
         let _p = profiler::profile("node_load_v1");
-
-        // Load the header.
-        let header: NodeHeader = read_struct(address, memory);
-        assert_eq!(&header.magic, MAGIC, "Bad magic.");
-        assert_eq!(header.version, LAYOUT_VERSION, "Unsupported version.");
 
         // Load the entries.
         let mut keys = Vec::with_capacity(header.num_entries as usize);
@@ -149,7 +145,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
 
         let header = NodeHeader {
             magic: *MAGIC,
-            version: LAYOUT_VERSION,
+            version: LAYOUT_VERSION_1,
             node_type: match self.node_type {
                 NodeType::Leaf => LEAF_NODE_TYPE,
                 NodeType::Internal => INTERNAL_NODE_TYPE,

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -80,7 +80,6 @@ use crate::{
 };
 
 // Initial page
-const LAYOUT_VERSION_2: u8 = 2;
 pub(super) const OVERFLOW_ADDRESS_OFFSET: Bytes = Bytes::new(7);
 const ENTRIES_OFFSET: Bytes = Bytes::new(15);
 
@@ -111,7 +110,12 @@ impl<K: Storable + Ord + Clone> Node<K> {
     }
 
     /// Loads a v2 node from memory at the given address.
-    pub(super) fn load_v2<M: Memory>(address: Address, page_size: PageSize, memory: &M) -> Self {
+    pub(super) fn load_v2<M: Memory>(
+        address: Address,
+        page_size: PageSize,
+        header: NodeHeader,
+        memory: &M,
+    ) -> Self {
         #[cfg(feature = "profiler")]
         let _p = profiler::profile("node_load_v2");
 
@@ -126,8 +130,6 @@ impl<K: Storable + Ord + Clone> Node<K> {
         };
 
         let mut offset = Address::from(0);
-
-        let header: NodeHeader = read_struct(Address::from(0), &reader);
 
         // Load the node type.
         let node_type = match header.node_type {


### PR DESCRIPTION
Prior to this commit, the caller of `Node::load` needed to specify the node version that will be loaded. This is acceptable if all nodes have the same version, but given that a BTreeMap may have different versions of nodes (migration will be introduced in subsequent commits), this needs to change such that the node's version is detected on load.