### PR TITLE
chore: remove redundant utility methods

### DIFF
--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -28,7 +28,7 @@ mod allocator;
 mod iter;
 mod node;
 use crate::{
-    storable::{max_size, Bound as StorableBound},
+    storable::Bound as StorableBound,
     types::{Address, NULL},
     Memory, Storable,
 };
@@ -197,8 +197,8 @@ where
     /// This is only exposed for testing and benchmarking.
     #[cfg(any(feature = "profiler", test))]
     pub fn new_v1(memory: M) -> Self {
-        let max_key_size = max_size::<K>();
-        let max_value_size = max_size::<V>();
+        let max_key_size = K::BOUND.max_size();
+        let max_value_size = V::BOUND.max_size();
 
         let btree = Self {
             root_addr: NULL,
@@ -235,12 +235,12 @@ where
                 max_value_size: expected_value_size,
             }) => {
                 assert!(
-                    max_size::<K>() <= expected_key_size,
+                    K::BOUND.max_size() <= expected_key_size,
                     "max_key_size must be <= {expected_key_size}"
                 );
 
                 assert!(
-                    max_size::<V>() <= expected_value_size,
+                    V::BOUND.max_size() <= expected_value_size,
                     "max_value_size must be <= {expected_value_size}"
                 );
             }

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -75,7 +75,6 @@ use super::*;
 use crate::btreemap::Allocator;
 use crate::{
     btreemap::node::io::NodeWriter,
-    storable::{is_fixed_size, max_size},
     types::NULL,
 };
 
@@ -159,9 +158,9 @@ impl<K: Storable + Ord + Clone> Node<K> {
         let mut buf = vec![];
         for _ in 0..num_entries {
             // Load the key's size.
-            let key_size = if is_fixed_size::<K>() {
+            let key_size = if K::BOUND.is_fixed_size() {
                 // Key is fixed in size. The size of the key is always its max size.
-                max_size::<K>()
+                K::BOUND.max_size()
             } else {
                 // Key is not fixed in size. Read the size from memory.
                 let value = read_u32(&reader, offset);
@@ -251,7 +250,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
             let key_bytes = key.to_bytes_checked();
 
             // Write the size of the key if it isn't fixed in size.
-            if !is_fixed_size::<K>() {
+            if !K::BOUND.is_fixed_size() {
                 writer.write_u32(offset, key_bytes.len() as u32);
                 offset += U32_SIZE;
             }

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -73,10 +73,7 @@
 
 use super::*;
 use crate::btreemap::Allocator;
-use crate::{
-    btreemap::node::io::NodeWriter,
-    types::NULL,
-};
+use crate::{btreemap::node::io::NodeWriter, types::NULL};
 
 // Initial page
 pub(super) const OVERFLOW_ADDRESS_OFFSET: Bytes = Bytes::new(7);

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -491,25 +491,6 @@ pub(crate) const fn bounds<A: Storable>() -> Bounds {
     }
 }
 
-/// Returns the max size of the given type if bounded, panics if unbounded.
-pub const fn max_size<A: Storable>() -> u32 {
-    if let Bound::Bounded { max_size, .. } = A::BOUND {
-        max_size
-    } else {
-        panic!("Cannot get max size of unbounded type.");
-    }
-}
-
-/// Returns true if the type is fixed in size, false otherwise.
-pub const fn is_fixed_size<A: Storable>() -> bool {
-    if let Bound::Bounded { is_fixed_size, .. } = A::BOUND {
-        is_fixed_size
-    } else {
-        // Unbounded types do not have a fixed size.
-        false
-    }
-}
-
 fn decode_size(src: &[u8], bounds: &Bounds) -> usize {
     if bounds.is_fixed_size {
         bounds.max_size as usize


### PR DESCRIPTION
#142 introduced some utility methods in the `Bound` struct. We had copies of these utility methods elsewhere, which are no longer needed and are removed in this commit.