### PR TITLE
chore: release 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.0-beta.1"
+version = "0.6.0"
 dependencies = [
  "candid",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-stable-structures"
-version = "0.6.0-beta.2"
+version = "0.6.0"
 edition = "2021"
 description = "A collection of data structures for fearless canister upgrades."
 homepage = "https://docs.rs/ic-stable-structures"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.0-beta.2"
+version = "0.6.0"
 
 [[package]]
 name = "ic0"


### PR DESCRIPTION
Version 0.6.0 has been in beta for a few weeks. We ran fuzz tests for ~1 week and tested the release on the Bitcoin testnet canister with no issues, so we're now ready for a production release.