### PR TITLE
chore: update rust to 1.73

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ 1.72.0 ]
+        rust: [ 1.73.0 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.72.0"
+channel = "1.73.0"
 targets = ["wasm32-unknown-unknown"]

--- a/src/log/tests.rs
+++ b/src/log/tests.rs
@@ -230,7 +230,7 @@ fn test_iter() {
     assert_eq!(log.iter().nth(usize::MAX), None);
 
     assert_eq!(log.iter().count(), 3);
-    assert_eq!(log.iter().skip(0).count(), 3);
+    assert_eq!(log.iter().count(), 3);
     assert_eq!(log.iter().skip(1).count(), 2);
     assert_eq!(log.iter().skip(2).count(), 1);
     assert_eq!(log.iter().skip(3).count(), 0);
@@ -271,7 +271,7 @@ fn test_thread_local_iter() {
     assert_eq!(new_iter().nth(usize::MAX), None);
 
     assert_eq!(new_iter().count(), 3);
-    assert_eq!(new_iter().skip(0).count(), 3);
+    assert_eq!(new_iter().count(), 3);
     assert_eq!(new_iter().skip(1).count(), 2);
     assert_eq!(new_iter().skip(2).count(), 1);
     assert_eq!(new_iter().skip(3).count(), 0);

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -328,7 +328,7 @@ impl<M: Memory> MemoryManagerInner<M> {
 
             self.memory_buckets
                 .entry(id)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(new_bucket_id);
 
             // Write in stable store that this bucket belongs to the memory with the provided `id`.

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -154,7 +154,7 @@ impl<const N: usize> PartialEq for Blob<N> {
 
 impl<const N: usize> PartialOrd for Blob<N> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.as_slice().partial_cmp(other.as_slice())
+        Some(self.cmp(other))
     }
 }
 

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -193,7 +193,7 @@ fn test_iter() {
     assert_eq!(sv.iter().nth(usize::MAX), None);
 
     assert_eq!(sv.iter().count(), 3);
-    assert_eq!(sv.iter().skip(0).count(), 3);
+    assert_eq!(sv.iter().count(), 3);
     assert_eq!(sv.iter().skip(1).count(), 2);
     assert_eq!(sv.iter().skip(2).count(), 1);
     assert_eq!(sv.iter().skip(3).count(), 0);


### PR DESCRIPTION
Rust 1.73 introduces some the `div_ceil` method on integers, which is something we can use to make parts of the code more readable.