### PR TITLE
chore: Add benchmark test with allocation of many buckets to StableStructures

### DIFF
--- a/benchmark-canisters/src/memory_manager.rs
+++ b/benchmark-canisters/src/memory_manager.rs
@@ -5,6 +5,8 @@ use ic_stable_structures::{DefaultMemoryImpl, Memory};
 const WASM_PAGE_SIZE: usize = 65536;
 const MB: usize = 1024 * 1024;
 const MB_IN_PAGES: usize = MB / WASM_PAGE_SIZE;
+const BUCKET_SIZE_IN_PAGES: u64 = 128;
+const MAX_NUM_BUCKETS: u64 = 32768;
 
 /// Benchmarks accessing stable memory without using a `MemoryManager` to establish a baseline.
 #[ic_cdk_macros::query]
@@ -53,6 +55,24 @@ pub fn memory_manager_overhead() -> BenchResult {
         for i in 0..num_memories {
             let memory = mem_mgr.get(MemoryId::new(i));
             memory.read(0, &mut buf);
+        }
+    })
+}
+
+/// Benchmarks the `MemoryManager`
+#[ic_cdk_macros::query]
+pub fn memory_manager_buckets_allocation() -> BenchResult {
+    let mem_mgr = MemoryManager::init(DefaultMemoryImpl::default());
+
+    let num_memories = 10;
+    let buckets_per_memory = MAX_NUM_BUCKETS / num_memories;
+
+    crate::benchmark(|| {
+        for i in 0..num_memories {
+            let memory = mem_mgr.get(MemoryId::new(i as u8));
+            for _ in 0..buckets_per_memory {
+                memory.grow(BUCKET_SIZE_IN_PAGES);
+            }
         }
     })
 }

--- a/benchmarks/benchmark.rs
+++ b/benchmarks/benchmark.rs
@@ -22,6 +22,7 @@ lazy_static::lazy_static! {
         // MemoryManager benchmarks
         "memory_manager_baseline",
         "memory_manager_overhead",
+        "buckets_allocation",
 
         // BTree benchmarks
         "btreemap_insert_10mib_values",


### PR DESCRIPTION
Add a benchmark where we allocate a large number of buckets and see how this current PR affects the performance of that benchmark.