### PR TITLE
refactor: add config file for benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,7 @@ dependencies = [
  "maplit",
  "profiler",
  "proptest",
+ "serde_yaml",
  "tempfile",
  "test-strategy",
 ]
@@ -1034,6 +1035,7 @@ name = "profiler"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "clap",
  "colored",
  "flate2",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,6 @@ name = "profiler"
 version = "0.1.0"
 dependencies = [
  "candid",
- "clap",
  "colored",
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ ic-cdk-macros.workspace = true
 maplit = "1.0.2"
 profiler = { path = "./profiler", features = ["benchmark"] }
 proptest = "1"
+serde_yaml = "0.9"
 tempfile = "3.3.0"
 test-strategy = "0.3.1"
 

--- a/bench.yml
+++ b/bench.yml
@@ -1,0 +1,8 @@
+build_cmd:
+  cargo build -p benchmarks --release --target wasm32-unknown-unknown
+
+wasm_path:
+  ./target/wasm32-unknown-unknown/release/benchmarks.wasm
+
+results_path:
+  ./benchmarks/results.yml

--- a/benchmarks/benchmark.rs
+++ b/benchmarks/benchmark.rs
@@ -1,7 +1,7 @@
 //! A script for running benchmarks on a canister.
 //! To run this script, run `cargo bench`.
 use clap::Parser;
-use std::{env, path::PathBuf};
+use std::{collections::BTreeMap, fs::File, io::Read, path::PathBuf, process::Command};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -21,21 +21,35 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    profiler::run_benchmarks(
-        PathBuf::new()
-            .join(env::var("CARGO_MANIFEST_DIR").unwrap())
-            .join("benchmark-canisters"),
-        PathBuf::new()
-            .join(env::var("CARGO_MANIFEST_DIR").unwrap())
-            .join("target")
-            .join("wasm32-unknown-unknown")
-            .join("release")
-            .join("benchmarks.wasm"),
-        args.pattern,
-        args.persist,
-        PathBuf::new()
-            .join(env::var("CARGO_MANIFEST_DIR").unwrap())
-            .join("benchmarks")
-            .join("results.yml"),
+    // Read and parse the configuration in `bench.yml` file.
+    let mut file = File::open("bench.yml").expect("bench.yml not found");
+    let mut config_str = String::new();
+    file.read_to_string(&mut config_str).unwrap();
+    let cfg: BTreeMap<String, String> = serde_yaml::from_str(&config_str).unwrap();
+
+    let wasm_path = PathBuf::from(
+        cfg.get("wasm_path")
+            .expect("`wasm_path` in bench.yml must be specified."),
     );
+
+    let results_path = PathBuf::from(
+        cfg.get("results_path")
+            .expect("`results_path` in the config must be specified."),
+    );
+
+    // Build the canister if a build command is specified.
+    if let Some(build_cmd) = cfg.get("build_cmd") {
+        assert!(
+            Command::new("bash")
+                .arg("-c")
+                .arg(build_cmd)
+                .status()
+                .unwrap()
+                .success(),
+            "failed to unwrap build command"
+        );
+    }
+
+    // Run the benchmarks.
+    profiler::run_benchmarks(wasm_path, args.pattern, args.persist, results_path);
 }

--- a/benchmarks/benchmark.rs
+++ b/benchmarks/benchmark.rs
@@ -51,5 +51,5 @@ fn main() {
     }
 
     // Run the benchmarks.
-    profiler::run_benchmarks(wasm_path, args.pattern, args.persist, results_path);
+    profiler::run_benchmarks(&wasm_path, args.pattern, args.persist, &results_path);
 }

--- a/profiler/src/benchmark.rs
+++ b/profiler/src/benchmark.rs
@@ -8,7 +8,7 @@ use std::{
     env,
     fs::File,
     io::{Read, Write},
-    path::{PathBuf, Path},
+    path::{Path, PathBuf},
     process::Command,
 };
 use wasmparser::Parser as WasmParser;


### PR DESCRIPTION
This PR is another step towards transforming our benchmarking logic into a general-purpose tool that others can use.

Rather than hard-coding everything in `benchmark.rs`, the configuration is moved into a config file called `bench.yml`.

The eventual goal is to evolve the current benchmarking work into a tool that works like this:

1. User defines a configuration file (e.g. `bench.yml`)
2. User installs our benchmarking tool (e.g. `cargo install canbench`)
3. User can now run benchmarks using cargo (e.g. `cargo canbench`)

Note that users won't need to write any code and the file `benchmark.rs` will soon be completely removed.