### PR TITLE
chore: Upgrade Rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ 1.73.0 ]
+        rust: [ 1.76.0 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.76.0"
 targets = ["wasm32-unknown-unknown"]

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -233,7 +233,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
 
         // Add a null overflow address.
         // This might get overwritten later in case the node does overflow.
-        writer.write_u64(offset, self.overflows.get(0).unwrap_or(&NULL).get());
+        writer.write_u64(offset, self.overflows.first().unwrap_or(&NULL).get());
         offset += Bytes::from(8u64);
 
         // Write the children

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,7 @@ impl Display for GrowFailed {
         write!(
             f,
             "Failed to grow memory: current size={}, delta={}",
-            self.current_size,
-            self.delta
+            self.current_size, self.delta
         )
     }
 }


### PR DESCRIPTION
Problem:
CI was failing because rust >= 1.74 was required.

Solution:
Upgrade the Rust version.