### PR TITLE
feat: Implement Storable for tuples with three elements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install DFX
         run: |
           wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-          DFX_VERSION=${DFX_VERSION:=0.14.3} bash install-dfx.sh <<(yes Y)
+          DFX_VERSION=${DFX_VERSION:=0.14.3} bash install-dfx.sh < <(yes Y)
           rm install-dfx.sh
           dfx cache install
           echo "$HOME/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install DFX
         run: |
           wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-          DFX_VERSION=${DFX_VERSION:=0.14.3} bash install-dfx.sh < <(yes Y)
+          DFX_VERSION=${DFX_VERSION:=0.14.3} bash install-dfx.sh <<(yes Y)
           rm install-dfx.sh
           dfx cache install
           echo "$HOME/bin" >> $GITHUB_PATH

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -502,6 +502,7 @@ where
         match Self::BOUND {
             Bound::Bounded { max_size, .. } => {
                 let mut bytes = vec![0; max_size as usize];
+
                 let a_bytes = self.0.to_bytes();
                 let a_bounds = bounds::<A>();
                 let a_max_size = a_bounds.max_size as usize;
@@ -515,10 +516,10 @@ where
                     &a_bounds,
                 );
 
-                let b_c_bytes = <(B, C)>::to_bytes(&(self.1, self.2));
+                let b_c_bytes = (self.1, self.2).to_bytes();
 
                 bytes[a_max_size + a_size_len..a_max_size + a_size_len + b_c_bytes.len()]
-                    .copy_from_slice(b_c_bytes.into_owned().as_slice());
+                    .copy_from_slice(b_c_bytes.borrow());
 
                 Cow::Owned(bytes)
             }

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -492,7 +492,7 @@ where
     };
 }
 
-fn get_size_len<T>() -> usize
+fn get_num_bytes_required_to_store_size<T>() -> usize
 where
     T: Storable,
 {
@@ -517,7 +517,7 @@ fn serialize_with_size<T>(entry_bytes: &[u8], bytes: &mut [u8], start: usize) ->
 where
     T: Storable,
 {
-    let size_len = get_size_len::<T>();
+    let size_len = get_num_bytes_required_to_store_size::<T>();
     let actual_size = entry_bytes.len();
 
     encode_size_universal::<T>(&mut bytes[start..start + size_len], actual_size);
@@ -535,7 +535,7 @@ fn deserialize_bounded_with_size<T>(bytes: &[u8], start: usize) -> (T, usize)
 where
     T: Storable,
 {
-    let size_len = get_size_len::<T>();
+    let size_len = get_num_bytes_required_to_store_size::<T>();
     let actual_size = decode_size_universal::<T>(&bytes[start..start + size_len]);
 
     let a = T::from_bytes(Cow::Borrowed(
@@ -557,11 +557,11 @@ where
         let c_bytes = self.2.to_bytes();
 
         let output_size = a_bytes.len()
-            + get_size_len::<A>()
+            + get_num_bytes_required_to_store_size::<A>()
             + b_bytes.len()
-            + get_size_len::<B>()
+            + get_num_bytes_required_to_store_size::<B>()
             + c_bytes.len()
-            + get_size_len::<C>();
+            + get_num_bytes_required_to_store_size::<C>();
 
         let mut bytes = vec![0; output_size];
 

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -497,10 +497,13 @@ where
     T: Storable,
 {
     match T::BOUND {
-        Bound::Bounded { .. } => {
-            let bounds = bounds::<T>();
-            bytes_to_store_size(&bounds) as usize
-        }
+        Bound::Bounded {
+            max_size,
+            is_fixed_size,
+        } => bytes_to_store_size(&Bounds {
+            max_size,
+            is_fixed_size,
+        }) as usize,
         Bound::Unbounded => 8,
     }
 }
@@ -710,8 +713,17 @@ where
     T: Storable,
 {
     match T::BOUND {
-        Bound::Bounded { max_size, .. } => {
-            let size = decode_size(src, &bounds::<T>());
+        Bound::Bounded {
+            max_size,
+            is_fixed_size,
+        } => {
+            let size = decode_size(
+                src,
+                &Bounds {
+                    max_size,
+                    is_fixed_size,
+                },
+            );
             debug_assert!(size <= max_size as usize);
             size
         }
@@ -726,9 +738,19 @@ where
     T: Storable,
 {
     match T::BOUND {
-        Bound::Bounded { max_size, .. } => {
+        Bound::Bounded {
+            max_size,
+            is_fixed_size,
+        } => {
             debug_assert!(n <= max_size as usize);
-            encode_size(dst, n, &bounds::<T>())
+            encode_size(
+                dst,
+                n,
+                &Bounds {
+                    max_size,
+                    is_fixed_size,
+                },
+            )
         }
         Bound::Unbounded => dst[0..8].copy_from_slice(&(n as u64).to_be_bytes()),
     }

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -504,8 +504,8 @@ where
     let bounds = bounds::<T>();
     let size_len = bytes_to_store_size(&bounds) as usize;
     let max_size = bounds.max_size as usize;
-    debug_assert!(entry_bytes.len() <= max_size);
     let actual_size = entry_bytes.len();
+    debug_assert!(actual_size <= max_size);
 
     encode_size(&mut bytes[start..start + size_len], actual_size, &bounds);
 

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -492,6 +492,11 @@ where
     };
 }
 
+/// Serializes `entry` into `bytes` starting from the index `start`
+/// in `bytes`.
+/// If serialized `entry` is saved in `bytes` on indices `[start, end)`
+/// the function will return index `end` - the first index after
+/// `start` that is not occupied with the serialization of `entry`.
 fn serialize_bounded_with_size<T>(entry: &T, bytes: &mut [u8], start: usize) -> usize
 where
     T: Storable,
@@ -514,6 +519,10 @@ where
     start + max_size + size_len
 }
 
+/// Deserialize the struct starting at index `start` in `bytes`.
+/// If serialized struct is saved in `bytes` on indices `[start, end)` the
+/// function will return deserialized struct and index `end` - the first index
+/// after `start` that is not occupied with the serialization of the struct.
 fn deserialize_bounded_with_size<T>(bytes: &[u8], start: usize) -> (T, usize)
 where
     T: Storable,

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -495,12 +495,12 @@ where
     };
 }
 
-// Serializes `entry` into `bytes` starting from the index `start`
-// in `bytes`.
-// When serialized `entry` is saved in `bytes` on indices `[start, end)`
+// Encodes `entry_bytes` size followed with `entry_bytes` into `bytes`
+// starting from the index `start`.
+// When encoding is saved in `bytes` on indices `[start, end)`
 // the function will return index `end` - the first index after
-// `start` that is not occupied with the serialization of `entry`.
-fn serialize_with_size<T>(entry_bytes: &[u8], bytes: &mut [u8], start: usize) -> usize
+// `start` that is not occupied with encoding.
+fn encode_with_size<T>(entry_bytes: &[u8], bytes: &mut [u8], start: usize) -> usize
 where
     T: Storable,
 {
@@ -552,9 +552,9 @@ where
 
         let mut bytes = vec![0; output_size];
 
-        let a_end = serialize_with_size::<A>(a_bytes.borrow(), &mut bytes, 0);
-        let b_end = serialize_with_size::<B>(b_bytes.borrow(), &mut bytes, a_end);
-        serialize_with_size::<C>(c_bytes.borrow(), &mut bytes, b_end);
+        let a_end = encode_with_size::<A>(a_bytes.borrow(), &mut bytes, 0);
+        let b_end = encode_with_size::<B>(b_bytes.borrow(), &mut bytes, a_end);
+        encode_with_size::<C>(c_bytes.borrow(), &mut bytes, b_end);
         Cow::Owned(bytes)
     }
 

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -519,10 +519,10 @@ where
     start + max_size + size_len
 }
 
-/// Deserialize the struct starting at index `start` in `bytes`.
-/// When serialized struct is saved in `bytes` on indices `[start, end)` the
-/// function will return deserialized struct and index `end` - the first index
-/// after `start` that is not occupied with the serialization of the struct.
+// Deserialize the struct starting at index `start` in `bytes`.
+// When serialized struct is saved in `bytes` on indices `[start, end)` the
+// function will return deserialized struct and index `end` - the first index
+// after `start` that is not occupied with the serialization of the struct.
 fn deserialize_bounded_with_size<T>(bytes: &[u8], start: usize) -> (T, usize)
 where
     T: Storable,

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -492,11 +492,11 @@ where
     };
 }
 
-/// Serializes `entry` into `bytes` starting from the index `start`
-/// in `bytes`.
-/// If serialized `entry` is saved in `bytes` on indices `[start, end)`
-/// the function will return index `end` - the first index after
-/// `start` that is not occupied with the serialization of `entry`.
+// Serializes `entry` into `bytes` starting from the index `start`
+// in `bytes`.
+// When serialized `entry` is saved in `bytes` on indices `[start, end)`
+// the function will return index `end` - the first index after
+// `start` that is not occupied with the serialization of `entry`.
 fn serialize_bounded_with_size<T>(entry: &T, bytes: &mut [u8], start: usize) -> usize
 where
     T: Storable,
@@ -520,7 +520,7 @@ where
 }
 
 /// Deserialize the struct starting at index `start` in `bytes`.
-/// If serialized struct is saved in `bytes` on indices `[start, end)` the
+/// When serialized struct is saved in `bytes` on indices `[start, end)` the
 /// function will return deserialized struct and index `end` - the first index
 /// after `start` that is not occupied with the serialization of the struct.
 fn deserialize_bounded_with_size<T>(bytes: &[u8], start: usize) -> (T, usize)

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -502,21 +502,27 @@ where
     T: Storable,
 {
     let bounds = bounds::<T>();
-    let size_len = bytes_to_store_size(&bounds) as usize;
     let max_size = bounds.max_size as usize;
+
     let entry_bytes = entry.to_bytes();
     debug_assert!(entry_bytes.len() <= max_size);
 
-    encode_size(
-        &mut bytes[start..start + size_len],
-        entry_bytes.len(),
-        &bounds,
-    );
+    let length_of_size_encoding = if bounds.is_fixed_size {
+        0
+    } else {
+        let length_of_size_encoding = bytes_to_store_size(&bounds) as usize;
+        encode_size(
+            &mut bytes[start..start + length_of_size_encoding],
+            entry_bytes.len(),
+            &bounds,
+        );
+        length_of_size_encoding
+    };
 
-    bytes[start + size_len..start + size_len + entry_bytes.len()]
+    bytes[start + length_of_size_encoding..start + length_of_size_encoding + entry_bytes.len()]
         .copy_from_slice(entry_bytes.borrow());
 
-    start + max_size + size_len
+    start + max_size + length_of_size_encoding
 }
 
 /// Deserialize the struct starting at index `start` in `bytes`.
@@ -529,13 +535,19 @@ where
 {
     let bounds = bounds::<T>();
     let max_size = bounds.max_size as usize;
-    let size_len = bytes_to_store_size(&bounds) as usize;
-    let len = decode_size(&bytes[start..start + size_len], &bounds);
+
+    let (length_of_size_encoding, actual_size) = if bounds.is_fixed_size {
+        (0, max_size)
+    } else {
+        let size_len = bytes_to_store_size(&bounds) as usize;
+        let len = decode_size(&bytes[start..start + size_len], &bounds);
+        (size_len, len)
+    };
 
     let a = T::from_bytes(Cow::Borrowed(
-        &bytes[start + size_len..start + size_len + len],
+        &bytes[start + length_of_size_encoding..start + length_of_size_encoding + actual_size],
     ));
-    (a, start + max_size + size_len)
+    (a, start + max_size + length_of_size_encoding)
 }
 
 impl<A, B, C> Storable for (A, B, C)

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -594,23 +594,14 @@ where
     const BOUND: Bound = {
         match (A::BOUND, B::BOUND, C::BOUND) {
             (Bound::Bounded { .. }, Bound::Bounded { .. }, Bound::Bounded { .. }) => {
-                let a_bounds = bounds::<A>();
-                let b_bounds = bounds::<B>();
+                let a_b_bounds = bounds::<(A, B)>();
                 let c_bounds = bounds::<C>();
 
-                let max_size = a_bounds.max_size
-                    + b_bounds.max_size
-                    + c_bounds.max_size
-                    + bytes_to_store_size(&a_bounds)
-                    + bytes_to_store_size(&b_bounds)
-                    + bytes_to_store_size(&c_bounds);
-
-                let is_fixed_size =
-                    a_bounds.is_fixed_size && b_bounds.is_fixed_size && c_bounds.is_fixed_size;
-
                 Bound::Bounded {
-                    max_size,
-                    is_fixed_size,
+                    max_size: a_b_bounds.max_size
+                        + c_bounds.max_size
+                        + bytes_to_store_size(&c_bounds),
+                    is_fixed_size: a_b_bounds.is_fixed_size && c_bounds.is_fixed_size,
                 }
             }
             _ => Bound::Unbounded,

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -682,7 +682,7 @@ pub(crate) const fn bytes_to_store_size(bounds: &Bounds) -> u32 {
     }
 }
 
-const NUM_BYTES_TO_STORE_SIZE_OF_UNBOUNDED_TYPE: usize = 8;
+const NUM_BYTES_TO_STORE_SIZE_OF_UNBOUNDED_TYPE: usize = 4;
 
 const fn get_num_bytes_required_to_store_size<T>() -> usize
 where
@@ -745,9 +745,7 @@ where
             debug_assert!(size <= max_size as usize);
             size
         }
-        Bound::Unbounded => u64::from_be_bytes([
-            src[0], src[1], src[2], src[3], src[4], src[5], src[6], src[7],
-        ]) as usize,
+        Bound::Unbounded => u32::from_be_bytes([src[0], src[1], src[2], src[3]]) as usize,
     }
 }
 
@@ -771,6 +769,6 @@ where
             )
         }
         Bound::Unbounded => dst[0..NUM_BYTES_TO_STORE_SIZE_OF_UNBOUNDED_TYPE]
-            .copy_from_slice(&(n as u64).to_be_bytes()),
+            .copy_from_slice(&(n as u32).to_be_bytes()),
     }
 }

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -551,6 +551,7 @@ where
     C: Storable,
 {
     fn to_bytes(&self) -> Cow<[u8]> {
+        // Serialize each of the tuple's elements
         let a_bytes = self.0.to_bytes();
         let b_bytes = self.1.to_bytes();
         let c_bytes = self.2.to_bytes();

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -531,7 +531,7 @@ where
 // When serialized struct is saved in `bytes` on indices `[start, end)` the
 // function will return deserialized struct and index `end` - the first index
 // after `start` that is not occupied with the serialization of the struct.
-fn deserialize_bounded_with_size<T>(bytes: &[u8], start: usize) -> (T, usize)
+fn deserialize_with_size<T>(bytes: &[u8], start: usize) -> (T, usize)
 where
     T: Storable,
 {
@@ -576,9 +576,9 @@ where
             assert!(bytes.len() <= max_size as usize);
         }
 
-        let (a, a_end) = deserialize_bounded_with_size::<A>(bytes.borrow(), 0);
-        let (b, b_end) = deserialize_bounded_with_size::<B>(bytes.borrow(), a_end);
-        let (c, _) = deserialize_bounded_with_size::<C>(bytes.borrow(), b_end);
+        let (a, a_end) = deserialize_with_size::<A>(bytes.borrow(), 0);
+        let (b, b_end) = deserialize_with_size::<B>(bytes.borrow(), a_end);
+        let (c, _) = deserialize_with_size::<C>(bytes.borrow(), b_end);
 
         (a, b, c)
     }

--- a/src/storable/tests.rs
+++ b/src/storable/tests.rs
@@ -14,6 +14,15 @@ proptest! {
     }
 
     #[test]
+    fn tuple_with_three_elements_roundtrip(x in any::<u64>(), y in uniform20(any::<u8>()), z in uniform20(any::<u8>())) {
+        let tuple = (x, y, z);
+        let bytes = tuple.to_bytes();
+        prop_assert_eq!(bytes.len(), 48);
+        prop_assert_eq!(tuple, Storable::from_bytes(bytes));
+    }
+
+
+    #[test]
     fn tuple_variable_width_u8_roundtrip(x in any::<u64>(), v in pvec(any::<u8>(), 0..40)) {
         let bytes = Blob::<48>::try_from(&v[..]).unwrap();
         let tuple = (x, bytes);
@@ -21,9 +30,26 @@ proptest! {
     }
 
     #[test]
+    fn tuple_with_three_elements_variable_width_u8_roundtrip(x in any::<u64>(), v1 in pvec(any::<u8>(), 0..40), v2 in pvec(any::<u8>(), 0..80)) {
+        let v1_bytes = Blob::<40>::try_from(&v1[..]).unwrap();
+        let v2_bytes = Blob::<80>::try_from(&v2[..]).unwrap();
+        let tuple = (x, v1_bytes, v2_bytes);
+        prop_assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes()));
+    }
+
+    #[test]
     fn tuple_variable_width_u16_roundtrip(x in any::<u64>(), v in pvec(any::<u8>(), 0..40)) {
         let bytes = Blob::<300>::try_from(&v[..]).unwrap();
         let tuple = (x, bytes);
+        prop_assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes()));
+    }
+
+    #[test]
+    fn tuple_with_three_elements_variable_width_u16_roundtrip(x in any::<u64>(), v1 in pvec(any::<u8>(), 0..40), v2 in pvec(any::<u8>(), 0..80)) {
+        let v1_bytes = Blob::<300>::try_from(&v1[..]).unwrap();
+        let v2_bytes = Blob::<300>::try_from(&v2[..]).unwrap();
+
+        let tuple = (x, v1_bytes, v2_bytes);
         prop_assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes()));
     }
 
@@ -53,8 +79,19 @@ proptest! {
     }
 
     #[test]
+    fn optional_tuple_with_three_elements_roundtrip(v in proptest::option::of((any::<u64>(), uniform20(any::<u8>()), uniform20(any::<u8>())))) {
+        prop_assert_eq!(v, Storable::from_bytes(v.to_bytes()));
+    }
+
+    #[test]
     fn optional_tuple_variable_width_u8_roundtrip(v in proptest::option::of((any::<u64>(), pvec(any::<u8>(), 0..40)))) {
         let v = v.map(|(n, bytes)| (n, Blob::<48>::try_from(&bytes[..]).unwrap()));
+        prop_assert_eq!(v, Storable::from_bytes(v.to_bytes()));
+    }
+
+    #[test]
+    fn optional_tuple_with_three_elements_variable_width_u8_roundtrip(v in proptest::option::of((any::<u64>(), pvec(any::<u8>(), 0..40), pvec(any::<u8>(), 0..80)))) {
+        let v = v.map(|(n, bytes_1, bytes_2)| (n, Blob::<40>::try_from(&bytes_1[..]).unwrap(), Blob::<80>::try_from(&bytes_2[..]).unwrap()));
         prop_assert_eq!(v, Storable::from_bytes(v.to_bytes()));
     }
 

--- a/src/storable/tests.rs
+++ b/src/storable/tests.rs
@@ -21,6 +21,18 @@ proptest! {
         prop_assert_eq!(tuple, Storable::from_bytes(bytes));
     }
 
+    #[test]
+    fn tuple_with_three_unbounded_elements_roundtrip(v1 in pvec(any::<u8>(), 0..4), v2 in pvec(any::<u8>(), 0..8), v3 in pvec(any::<u8>(), 0..12)) {
+        let tuple = (v1, v2, v3);
+        assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes()));
+    }
+
+    #[test]
+    fn tuple_with_three_elements_bounded_and_unbounded_roundtrip(v1 in pvec(any::<u8>(), 0..4), x in any::<u64>(), v2 in pvec(any::<u8>(), 0..12)) {
+        let tuple = (v1, x, v2);
+        assert_eq!(tuple, Storable::from_bytes(tuple.to_bytes()));
+    }
+
 
     #[test]
     fn tuple_variable_width_u8_roundtrip(x in any::<u64>(), v in pvec(any::<u8>(), 0..40)) {
@@ -84,6 +96,11 @@ proptest! {
     }
 
     #[test]
+    fn optional_tuple_with_three_unbounded_elements_roundtrip(v in proptest::option::of((pvec(any::<u8>(), 0..4), pvec(any::<u8>(), 0..8),  pvec(any::<u8>(), 0..12)))) {
+        prop_assert_eq!(v.clone(), Storable::from_bytes(v.to_bytes()));
+    }
+
+    #[test]
     fn optional_tuple_variable_width_u8_roundtrip(v in proptest::option::of((any::<u64>(), pvec(any::<u8>(), 0..40)))) {
         let v = v.map(|(n, bytes)| (n, Blob::<48>::try_from(&bytes[..]).unwrap()));
         prop_assert_eq!(v, Storable::from_bytes(v.to_bytes()));
@@ -93,6 +110,11 @@ proptest! {
     fn optional_tuple_with_three_elements_variable_width_u8_roundtrip(v in proptest::option::of((any::<u64>(), pvec(any::<u8>(), 0..40), pvec(any::<u8>(), 0..80)))) {
         let v = v.map(|(n, bytes_1, bytes_2)| (n, Blob::<40>::try_from(&bytes_1[..]).unwrap(), Blob::<80>::try_from(&bytes_2[..]).unwrap()));
         prop_assert_eq!(v, Storable::from_bytes(v.to_bytes()));
+    }
+
+    #[test]
+    fn optional_tuple_with_three_elements_bounded_and_unbounded_roundtrip(v in proptest::option::of((any::<u64>(), pvec(any::<u8>(), 0..40), pvec(any::<u8>(), 0..80)))) {
+        prop_assert_eq!(v.clone(), Storable::from_bytes(v.to_bytes()));
     }
 
     #[test]


### PR DESCRIPTION
Currently, Storable is implemented for two-element tuples (A, B), but not for three-element tuples (A, B, C). Adding support for three-element tuples would help with usability.