### PR TITLE
fix: permissions in benchmark CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      # To allow writing comments to the PR in forked repositorites.
+      # See https://github.com/thollander/actions-comment-pull-request/issues/181
+      pull-requests: write
+
     env:
       PROJECT_DIR: .
     steps:


### PR DESCRIPTION
The benchmark CI job is failing in the case of PRs from forked repositories such as #197 and #188 due to a permissions issue. This commit fixes the permissions issue.