### PR TITLE
fix: canbench post comment in CI from forked repos (part 1)

### DIFF
--- a/.github/workflows/canbench-post-comment.yml
+++ b/.github/workflows/canbench-post-comment.yml
@@ -1,0 +1,38 @@
+name: Post Canbench results
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  download-results:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-benchmarks.outputs.matrix }}
+      pr_number: ${{ steps.set-benchmarks.outputs.pr_number }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - id: set-benchmarks
+        run: bash ./scripts/ci_download_canbench_artifacts.sh
+
+  post-comment:
+    runs-on: ubuntu-latest
+    needs: [download-results]
+    strategy:
+      matrix: ${{fromJSON(needs.download-results.outputs.matrix)}}
+    steps:
+      - name: Post comment
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            ${{ matrix.benchmark.result }}
+          comment_tag: ${{ matrix.benchmark.title }}
+          pr_number: ${{ needs.download-results.outputs.pr_number }}
+

--- a/.github/workflows/canbench_ci_download_artifacts.sh
+++ b/.github/workflows/canbench_ci_download_artifacts.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eexuo pipefail
+
+# Identifies the benchmarks provided in the artifacts and outputs them.
+
+json_array="["
+# Loop through each file with prefix "canbench_result_" in the current directory
+for file in canbench_result_*; do
+if [ -e "$file" ]; then  # Check if the file exists.
+  # Read the content of the file, escaping double quotes and adding escaped newlines
+  content=$(<"$file/$file" sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}' | sed '$ s/\\n$//')
+
+  # Construct a JSON object for the current file with "title" and "result" keys
+  json_object="{\"title\":\"$file\",\"result\":\"$content\"},"
+
+  # Append the JSON object to the array string
+  json_array+="$json_object"
+fi
+done
+
+# Remove the trailing comma from the JSON array string
+json_array=${json_array%,}
+
+# Close the JSON array string
+json_array+="]"
+
+# Output the benchmarks and PR number to be used by the next job.
+echo "matrix={\"benchmark\": $json_array}" >> "$GITHUB_OUTPUT"
+echo "pr_number=$(cat ./pr_number/pr_number)" >> "$GITHUB_OUTPUT"
+


### PR DESCRIPTION
Due to the way Github Actions are setup for security reasons, canbench comments weren't working for PRs from forked repositories.

Rather than commenting directly from CI, we now add a separate workflow that will be triggered once CI is complete, and that workflow will post the comment.

In a followup PR, the CI itself will be updated to use the workflow we're adding here. It cannot be added in the same PR.