### PR TITLE
test: BTreeMap: add case for deallocating root node with overflows

### DIFF
--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -367,6 +367,11 @@ impl<K: Storable + Ord + Clone> Node<K> {
     }
 
     #[cfg(test)]
+    pub fn keys(&self) -> &[K] {
+        &self.keys
+    }
+
+    #[cfg(test)]
     pub fn overflows(&self) -> &[Address] {
         &self.overflows
     }


### PR DESCRIPTION
Adds a new test case to verify that deallocating the root node is done correctly, even when the root node contains overflow pages.

NOTE: The logic in `btreemap.remove` has been slightly modified to be more understandable, but the functionality remains equivalent.