### PR TITLE
fix: don't print PR title in github workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -35,6 +35,5 @@ jobs:
               echo pass
           else
               echo "PR title does not match conventions"
-              echo "PR title: ${{ github.event.pull_request.title }}"
               exit 1
           fi


### PR DESCRIPTION
Printing the PR title can open the door for remote code execution, so this commit removes it to be on the safe side.