### PR TITLE
fix(ci): Sanitize PR title by using ENV

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -21,6 +21,8 @@ jobs:
   check:
     name: conventional-pr-title:required
     runs-on: ubuntu-latest
+    env:
+      TITLE: ${{ github.event.pull_request.title }}
     steps:
         # Conventional commit patterns:
         #   verb: description
@@ -31,7 +33,7 @@ jobs:
         # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
         # !: Indicates that the PR contains a breaking change.
       - run: |
-          if [[ "${{ github.event.pull_request.title }}" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
+          if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
               echo pass
           else
               echo "PR title does not match conventions"


### PR DESCRIPTION
As a follow up to #218 we need to further sanitize by using the intermediate step of using an environment variable to avoid possible script injection attack.