### PR TITLE
chore: bump version to 0.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "canbench-rs",
  "candid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-stable-structures"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 description = "A collection of data structures for fearless canister upgrades."
 homepage = "https://docs.rs/ic-stable-structures"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "ic_principal",
 ]


### PR DESCRIPTION
Prepares a new release to include a fix to `BaseVec`.