### PR TITLE
perf: Add new efficient API read_to_vec

### DIFF
--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -1,595 +1,595 @@
 benches:
   btreemap_get_blob_128_1024:
     total:
-      instructions: 879302205
+      instructions: 838312230
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_128_1024_v2:
     total:
-      instructions: 986234201
+      instructions: 925296023
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_16_1024:
     total:
-      instructions: 315520793
+      instructions: 312574719
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_16_1024_v2:
     total:
-      instructions: 424439334
+      instructions: 389362994
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_256_1024:
     total:
-      instructions: 1410478508
+      instructions: 1341541199
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_256_1024_v2:
     total:
-      instructions: 1515420842
+      instructions: 1429507585
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_32_1024:
     total:
-      instructions: 359080553
+      instructions: 341505178
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_32_1024_v2:
     total:
-      instructions: 467643018
+      instructions: 423414626
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_4_1024:
     total:
-      instructions: 205936205
+      instructions: 193370587
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_4_1024_v2:
     total:
-      instructions: 304383660
+      instructions: 282410069
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_512_1024:
     total:
-      instructions: 2465612866
+      instructions: 2350444203
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_512_1024_v2:
     total:
-      instructions: 2571792093
+      instructions: 2434729419
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_64_1024:
     total:
-      instructions: 611173672
+      instructions: 585778707
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_64_1024_v2:
     total:
-      instructions: 727594763
+      instructions: 675975370
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_8_1024:
     total:
-      instructions: 242798942
+      instructions: 221010598
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_8_1024_v2:
     total:
-      instructions: 337855918
+      instructions: 306866427
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_8_u64:
     total:
-      instructions: 215475284
+      instructions: 209052293
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_blob_8_u64_v2:
     total:
-      instructions: 326446044
+      instructions: 311218507
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_u64_blob_8:
     total:
-      instructions: 198160835
+      instructions: 195425083
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_u64_blob_8_v2:
     total:
-      instructions: 285194478
+      instructions: 273402279
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_u64_u64:
     total:
-      instructions: 199393722
+      instructions: 196248685
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_get_u64_u64_v2:
     total:
-      instructions: 291906450
+      instructions: 279730979
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_insert_10mib_values:
     total:
-      instructions: 143394599
+      instructions: 143827896
       heap_increase: 0
       stable_memory_increase: 32
     scopes: {}
   btreemap_insert_blob_1024_128:
     total:
-      instructions: 5103816812
+      instructions: 4925677406
       heap_increase: 0
       stable_memory_increase: 262
     scopes: {}
   btreemap_insert_blob_1024_128_v2:
     total:
-      instructions: 5223665926
+      instructions: 4991806550
       heap_increase: 0
       stable_memory_increase: 196
     scopes: {}
   btreemap_insert_blob_1024_16:
     total:
-      instructions: 5060658098
+      instructions: 4914079150
       heap_increase: 0
       stable_memory_increase: 241
     scopes: {}
   btreemap_insert_blob_1024_16_v2:
     total:
-      instructions: 5181580835
+      instructions: 4970969708
       heap_increase: 0
       stable_memory_increase: 181
     scopes: {}
   btreemap_insert_blob_1024_256:
     total:
-      instructions: 5130558722
+      instructions: 4940626209
       heap_increase: 0
       stable_memory_increase: 292
     scopes: {}
   btreemap_insert_blob_1024_256_v2:
     total:
-      instructions: 5249596386
+      instructions: 5019204178
       heap_increase: 0
       stable_memory_increase: 219
     scopes: {}
   btreemap_insert_blob_1024_32:
     total:
-      instructions: 5069315515
+      instructions: 4925709402
       heap_increase: 0
       stable_memory_increase: 239
     scopes: {}
   btreemap_insert_blob_1024_32_v2:
     total:
-      instructions: 5192319151
+      instructions: 4989040386
       heap_increase: 0
       stable_memory_increase: 180
     scopes: {}
   btreemap_insert_blob_1024_4:
     total:
-      instructions: 4959470000
+      instructions: 4815377680
       heap_increase: 0
       stable_memory_increase: 235
     scopes: {}
   btreemap_insert_blob_1024_4_v2:
     total:
-      instructions: 5080388188
+      instructions: 4867626129
       heap_increase: 0
       stable_memory_increase: 176
     scopes: {}
   btreemap_insert_blob_1024_512:
     total:
-      instructions: 5252901073
+      instructions: 5030249966
       heap_increase: 0
       stable_memory_increase: 348
     scopes: {}
   btreemap_insert_blob_1024_512_v2:
     total:
-      instructions: 5373023593
+      instructions: 5108265481
       heap_increase: 0
       stable_memory_increase: 261
     scopes: {}
   btreemap_insert_blob_1024_64:
     total:
-      instructions: 5101699743
+      instructions: 4932891575
       heap_increase: 0
       stable_memory_increase: 250
     scopes: {}
   btreemap_insert_blob_1024_64_v2:
     total:
-      instructions: 5223434507
+      instructions: 5009136666
       heap_increase: 0
       stable_memory_increase: 188
     scopes: {}
   btreemap_insert_blob_1024_8:
     total:
-      instructions: 5043314359
+      instructions: 4876604226
       heap_increase: 0
       stable_memory_increase: 237
     scopes: {}
   btreemap_insert_blob_1024_8_v2:
     total:
-      instructions: 5163637162
+      instructions: 4957027160
       heap_increase: 0
       stable_memory_increase: 178
     scopes: {}
   btreemap_insert_blob_128_1024:
     total:
-      instructions: 1458078497
+      instructions: 1293310594
       heap_increase: 0
       stable_memory_increase: 260
     scopes: {}
   btreemap_insert_blob_128_1024_v2:
     total:
-      instructions: 1570349058
+      instructions: 1394660688
       heap_increase: 0
       stable_memory_increase: 195
     scopes: {}
   btreemap_insert_blob_16_1024:
     total:
-      instructions: 839064490
+      instructions: 712605308
       heap_increase: 0
       stable_memory_increase: 215
     scopes: {}
   btreemap_insert_blob_16_1024_v2:
     total:
-      instructions: 955395829
+      instructions: 810604067
       heap_increase: 0
       stable_memory_increase: 161
     scopes: {}
   btreemap_insert_blob_256_1024:
     total:
-      instructions: 2028664457
+      instructions: 1848076307
       heap_increase: 0
       stable_memory_increase: 292
     scopes: {}
   btreemap_insert_blob_256_1024_v2:
     total:
-      instructions: 2144398075
+      instructions: 1945542031
       heap_increase: 0
       stable_memory_increase: 219
     scopes: {}
   btreemap_insert_blob_32_1024:
     total:
-      instructions: 890749049
+      instructions: 753237496
       heap_increase: 0
       stable_memory_increase: 230
     scopes: {}
   btreemap_insert_blob_32_1024_v2:
     total:
-      instructions: 1007248566
+      instructions: 851675269
       heap_increase: 0
       stable_memory_increase: 173
     scopes: {}
   btreemap_insert_blob_4_1024:
     total:
-      instructions: 633932227
+      instructions: 512874154
       heap_increase: 0
       stable_memory_increase: 123
     scopes: {}
   btreemap_insert_blob_4_1024_v2:
     total:
-      instructions: 738087270
+      instructions: 613160534
       heap_increase: 0
       stable_memory_increase: 92
     scopes: {}
   btreemap_insert_blob_512_1024:
     total:
-      instructions: 3161385472
+      instructions: 2938225827
       heap_increase: 0
       stable_memory_increase: 351
     scopes: {}
   btreemap_insert_blob_512_1024_v2:
     total:
-      instructions: 3275260995
+      instructions: 3026807564
       heap_increase: 0
       stable_memory_increase: 263
     scopes: {}
   btreemap_insert_blob_64_1024:
     total:
-      instructions: 1157359426
+      instructions: 1019745208
       heap_increase: 0
       stable_memory_increase: 245
     scopes: {}
   btreemap_insert_blob_64_1024_v2:
     total:
-      instructions: 1281618754
+      instructions: 1118379986
       heap_increase: 0
       stable_memory_increase: 183
     scopes: {}
   btreemap_insert_blob_8_1024:
     total:
-      instructions: 758180070
+      instructions: 623850523
       heap_increase: 0
       stable_memory_increase: 183
     scopes: {}
   btreemap_insert_blob_8_1024_v2:
     total:
-      instructions: 866287942
+      instructions: 729165343
       heap_increase: 0
       stable_memory_increase: 138
     scopes: {}
   btreemap_insert_blob_8_u64:
     total:
-      instructions: 353807315
+      instructions: 348869854
       heap_increase: 0
       stable_memory_increase: 6
     scopes: {}
   btreemap_insert_blob_8_u64_v2:
     total:
-      instructions: 473686702
+      instructions: 463558546
       heap_increase: 0
       stable_memory_increase: 4
     scopes: {}
   btreemap_insert_u64_blob_8:
     total:
-      instructions: 364631146
+      instructions: 366622921
       heap_increase: 0
       stable_memory_increase: 7
     scopes: {}
   btreemap_insert_u64_blob_8_v2:
     total:
-      instructions: 450222711
+      instructions: 447255789
       heap_increase: 0
       stable_memory_increase: 5
     scopes: {}
   btreemap_insert_u64_u64:
     total:
-      instructions: 374696730
+      instructions: 372742486
       heap_increase: 0
       stable_memory_increase: 7
     scopes: {}
   btreemap_insert_u64_u64_v2:
     total:
-      instructions: 462904999
+      instructions: 456250739
       heap_increase: 0
       stable_memory_increase: 6
     scopes: {}
   btreemap_iter_10mib_values:
     total:
-      instructions: 17116720
+      instructions: 17170053
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_iter_count_10mib_values:
     total:
-      instructions: 527176
+      instructions: 523050
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_iter_count_small_values:
     total:
-      instructions: 10158843
+      instructions: 9791185
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_iter_rev_10mib_values:
     total:
-      instructions: 17114625
+      instructions: 17168844
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_iter_rev_small_values:
     total:
-      instructions: 14524294
+      instructions: 15098598
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_iter_small_values:
     total:
-      instructions: 14527493
+      instructions: 15057793
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_keys_10mib_values:
     total:
-      instructions: 516764
+      instructions: 509518
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_keys_rev_10mib_values:
     total:
-      instructions: 519117
+      instructions: 511871
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_keys_rev_small_values:
     total:
-      instructions: 10530635
+      instructions: 10162977
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_keys_small_values:
     total:
-      instructions: 10294798
+      instructions: 9927140
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_read_every_third_value_from_range:
     total:
-      instructions: 113084618
+      instructions: 115746474
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_read_keys_from_range:
     total:
-      instructions: 113084618
+      instructions: 115746474
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_128_1024:
     total:
-      instructions: 1814329611
+      instructions: 1566318834
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_128_1024_v2:
     total:
-      instructions: 1982178501
+      instructions: 1713654716
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_16_1024:
     total:
-      instructions: 1046555128
+      instructions: 838510246
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_16_1024_v2:
     total:
-      instructions: 1207409244
+      instructions: 980295655
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_256_1024:
     total:
-      instructions: 2484528504
+      instructions: 2211967018
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_256_1024_v2:
     total:
-      instructions: 2645421668
+      instructions: 2350672812
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_32_1024:
     total:
-      instructions: 1125110448
+      instructions: 905595083
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_32_1024_v2:
     total:
-      instructions: 1290917923
+      instructions: 1048606229
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_4_1024:
     total:
-      instructions: 639953529
+      instructions: 506153912
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_4_1024_v2:
     total:
-      instructions: 763706218
+      instructions: 624714334
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_512_1024:
     total:
-      instructions: 3880456183
+      instructions: 3559688390
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_512_1024_v2:
     total:
-      instructions: 4043734433
+      instructions: 3688440154
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_64_1024:
     total:
-      instructions: 1458217613
+      instructions: 1234228088
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_64_1024_v2:
     total:
-      instructions: 1631937179
+      instructions: 1379393822
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_1024:
     total:
-      instructions: 843328385
+      instructions: 659759424
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_1024_v2:
     total:
-      instructions: 986540048
+      instructions: 797258545
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_u64:
     total:
-      instructions: 465951671
+      instructions: 461068699
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_u64_v2:
     total:
-      instructions: 626297968
+      instructions: 617031815
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_blob_8:
     total:
-      instructions: 516865037
+      instructions: 522411015
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_blob_8_v2:
     total:
-      instructions: 637827582
+      instructions: 639861748
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_u64:
     total:
-      instructions: 537895420
+      instructions: 536826185
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_u64_v2:
     total:
-      instructions: 668544917
+      instructions: 664966599
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_values_10mib_values:
     total:
-      instructions: 17140501
+      instructions: 17168641
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_values_rev_10mib_values:
     total:
-      instructions: 17139292
+      instructions: 17167432
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_values_rev_small_values:
     total:
-      instructions: 15756258
+      instructions: 15027936
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_values_small_values:
     total:
-      instructions: 15715453
+      instructions: 14987131
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -613,43 +613,43 @@ benches:
     scopes: {}
   vec_get_blob_128:
     total:
-      instructions: 21620835
+      instructions: 18894883
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   vec_get_blob_16:
     total:
-      instructions: 9954082
+      instructions: 8866778
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   vec_get_blob_32:
     total:
-      instructions: 10864853
+      instructions: 9512539
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   vec_get_blob_4:
     total:
-      instructions: 5894588
+      instructions: 5712959
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   vec_get_blob_64:
     total:
-      instructions: 15712671
+      instructions: 13894512
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   vec_get_blob_8:
     total:
-      instructions: 7151499
+      instructions: 6506141
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   vec_get_u64:
     total:
-      instructions: 6430307
+      instructions: 5870313
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/src/base_vec.rs
+++ b/src/base_vec.rs
@@ -245,11 +245,10 @@ impl<T: Storable, M: Memory> BaseVec<T, M> {
     }
 
     /// Reads the item at the specified index without any bound checks.
-    fn read_entry_to(&self, index: u64, buf: &mut std::vec::Vec<u8>) {
+    fn read_entry_to(&self, index: u64, buf: &mut Vec<u8>) {
         let offset = DATA_OFFSET + slot_size::<T>() as u64 * index;
         let (data_offset, data_size) = self.read_entry_size(offset);
-        buf.resize(data_size, 0);
-        self.memory.read(data_offset, &mut buf[..]);
+        self.memory.read_to_vec(data_offset, data_size, buf);
     }
 
     /// Sets the vector's length.

--- a/src/btreemap/node.rs
+++ b/src/btreemap/node.rs
@@ -200,8 +200,8 @@ impl<K: Storable + Ord + Clone> Node<K> {
         };
 
         let value_len = read_u32(&reader, Address::from(offset.get())) as usize;
-        let mut bytes = vec![0; value_len];
-        reader.read((offset + U32_SIZE).get(), &mut bytes);
+        let mut bytes = vec![];
+        reader.read_to_vec((offset + U32_SIZE).get(), value_len, &mut bytes);
 
         bytes
     }

--- a/src/btreemap/node/io.rs
+++ b/src/btreemap/node/io.rs
@@ -59,6 +59,18 @@ impl<'a, M: Memory> Memory for NodeReader<'a, M> {
         }
     }
 
+    fn read_to_vec(&self, offset: u64, len: usize, dst: &mut Vec<u8>) {
+        // If the read is only in the initial page, then read it directly in one go.
+        // This is a performance enhancement.
+        if (offset + len as u64) < self.page_size.get() as u64 {
+            self.memory
+                .read_to_vec(self.address.get() + offset, len, dst);
+        } else {
+            dst.resize(len, 0);
+            self.read(offset, &mut dst[..]);
+        }
+    }
+
     fn write(&self, _: u64, _: &[u8]) {
         unreachable!("NodeReader does not support write")
     }

--- a/src/btreemap/node/v1.rs
+++ b/src/btreemap/node/v1.rs
@@ -65,15 +65,14 @@ impl<K: Storable + Ord + Clone> Node<K> {
         // Load the entries.
         let mut keys_encoded_values = Vec::with_capacity(header.num_entries as usize);
         let mut offset = NodeHeader::size();
-        let mut buf = Vec::with_capacity(max_key_size.max(max_value_size) as usize);
+        let mut buf = vec![];
         for _ in 0..header.num_entries {
             // Read the key's size.
             let key_size = read_u32(memory, address + offset);
             offset += U32_SIZE;
 
             // Read the key.
-            buf.resize(key_size as usize, 0);
-            memory.read((address + offset).get(), &mut buf);
+            memory.read_to_vec((address + offset).get(), key_size as usize, &mut buf);
             offset += Bytes::from(max_key_size);
             let key = K::from_bytes(Cow::Borrowed(&buf));
             // Values are loaded lazily. Store a reference and skip loading it.

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -164,8 +164,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
             };
 
             // Load the key.
-            buf.resize(key_size as usize, 0);
-            reader.read(offset.get(), &mut buf);
+            reader.read_to_vec(offset.get(), key_size as usize, &mut buf);
             let key = K::from_bytes(Cow::Borrowed(&buf));
             offset += Bytes::from(key_size);
             keys_encoded_values.push((key, Value::by_ref(Bytes::from(0usize))));

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -132,8 +132,8 @@ impl<T: Storable, M: Memory> Cell<T, M> {
     ///
     /// PRECONDITION: memory is large enough to contain the value.
     fn read_value(memory: &M, len: u32) -> T {
-        let mut buf = vec![0; len as usize];
-        memory.read(HEADER_V1_SIZE, &mut buf);
+        let mut buf = vec![];
+        memory.read_to_vec(HEADER_V1_SIZE, len as usize, &mut buf);
         T::from_bytes(Cow::Owned(buf))
     }
 

--- a/src/ic0_memory.rs
+++ b/src/ic0_memory.rs
@@ -27,6 +27,18 @@ impl Memory for Ic0StableMemory {
         unsafe { stable64_read(dst.as_ptr() as u64, offset, dst.len() as u64) }
     }
 
+    fn read_to_vec(&self, offset: u64, len: usize, dst: &mut Vec<u8>) {
+        dst.clear();
+        dst.reserve(len);
+        unsafe {
+            // SAFETY: This is safe because of the ic0 api guarantees.
+            stable64_read(dst.as_ptr() as u64, offset, len as u64);
+            // SAFETY: This is safe because stable64_read guarantees that the first len bytes
+            // will be initialized.
+            dst.set_len(len);
+        }
+    }
+
     fn write(&self, offset: u64, src: &[u8]) {
         // SAFETY: This is safe because of the ic0 api guarantees.
         unsafe { stable64_write(offset, src.as_ptr() as u64, src.len() as u64) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,16 @@ pub trait Memory {
     /// and replaces the corresponding bytes in dst.
     fn read(&self, offset: u64, dst: &mut [u8]);
 
+    /// Copies len bytes of data starting from offset out of the stable memory into dst.
+    /// Implementations must not make any assumptions about dst (e.g. length, contents, capacity).
+    /// Callers are allowed to pass empty vectors. After the method returns, dst.len() == len.
+    /// This method is an alternative to read which does not require initializing a buffer and may
+    /// therefore be faster.
+    fn read_to_vec(&self, offset: u64, len: usize, dst: &mut std::vec::Vec<u8>) {
+        dst.resize(len, 0);
+        self.read(offset, &mut dst[..]);
+    }
+
     /// Copies the data referred to by src and replaces the
     /// corresponding segment starting at offset in the stable memory.
     fn write(&self, offset: u64, src: &[u8]);

--- a/src/log.rs
+++ b/src/log.rs
@@ -331,8 +331,8 @@ impl<T: Storable, INDEX: Memory, DATA: Memory> Log<T, INDEX, DATA> {
     /// ignores the result.
     pub fn read_entry(&self, idx: u64, buf: &mut Vec<u8>) -> Result<(), NoSuchEntry> {
         let (offset, len) = self.entry_meta(idx).ok_or(NoSuchEntry)?;
-        buf.resize(len, 0);
-        self.data_memory.read(HEADER_OFFSET + offset, buf);
+        self.data_memory
+            .read_to_vec(HEADER_OFFSET + offset, len, buf);
         Ok(())
     }
 

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -239,9 +239,9 @@ impl<M: Memory> MemoryManagerInner<M> {
         }
 
         // Check if the magic in the memory corresponds to this object.
-        let mut dst = vec![0; 3];
+        let mut dst = [0; 3];
         memory.read(0, &mut dst);
-        if dst != MAGIC {
+        if &dst != MAGIC {
             // No memory manager found. Create a new instance.
             MemoryManagerInner::new(memory, bucket_size_in_pages)
         } else {
@@ -277,8 +277,12 @@ impl<M: Memory> MemoryManagerInner<M> {
         assert_eq!(&header.magic, MAGIC, "Bad magic.");
         assert_eq!(header.version, LAYOUT_VERSION, "Unsupported version.");
 
-        let mut buckets = vec![0; MAX_NUM_BUCKETS as usize];
-        memory.read(bucket_allocations_address(BucketId(0)).get(), &mut buckets);
+        let mut buckets = vec![];
+        memory.read_to_vec(
+            bucket_allocations_address(BucketId(0)).get(),
+            MAX_NUM_BUCKETS as usize,
+            &mut buckets,
+        );
 
         let mut memory_buckets = BTreeMap::new();
         for (bucket_idx, memory) in buckets.into_iter().enumerate() {

--- a/src/vec_mem.rs
+++ b/src/vec_mem.rs
@@ -39,6 +39,16 @@ impl Memory for RefCell<Vec<u8>> {
         dst.copy_from_slice(&self.borrow()[offset as usize..n as usize]);
     }
 
+    fn read_to_vec(&self, offset: u64, len: usize, dst: &mut Vec<u8>) {
+        let n = offset.checked_add(len as u64).expect("read: out of bounds");
+
+        if n as usize > self.borrow().len() {
+            panic!("read: out of bounds");
+        }
+        dst.clear();
+        dst.extend_from_slice(&self.borrow()[offset as usize..n as usize]);
+    }
+
     fn write(&self, offset: u64, src: &[u8]) {
         let n = offset
             .checked_add(src.len() as u64)
@@ -60,6 +70,9 @@ impl<M: Memory> Memory for Rc<M> {
     }
     fn read(&self, offset: u64, dst: &mut [u8]) {
         self.deref().read(offset, dst)
+    }
+    fn read_to_vec(&self, offset: u64, len: usize, dst: &mut Vec<u8>) {
+        self.deref().read_to_vec(offset, len, dst)
     }
     fn write(&self, offset: u64, src: &[u8]) {
         self.deref().write(offset, src)


### PR DESCRIPTION
I found that a source of significant performance loss is the `read` method of `Memory`. The `read` method takes a mutable buffer which it fills with values read from the stable memory. According to Rust rules, the buffer passed to `read` must be initialized before it's passed to `read` (buffers containing uninitialized values are unsound and can cause UB).

The usual pattern is to create a properly sized `Vec`, eg. by using `vec![0; size]` or `vec.resize(size, 0)` and pass that to `read`. However, initializing the bytes with values that get overwritten by `read` is only necessary in order to be sound and requires significant number of instructions.

This PR introduces a new method `read_to_vec` which allows passing in a `Vec` with any size (most of the time an empty `Vec` will be used). Implementations can be more efficient by reading directly into the `Vec` and skipping initialization. This can lead to instruction reductions of up to 20%.