### PR TITLE
perf: Add `into_bytes` to `Storable` to avoid cloning where possible

### DIFF
--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -353,7 +353,7 @@ where
     ///   key.to_bytes().len() <= max_size(Key)
     ///   value.to_bytes().len() <= max_size(Value)
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
-        let value = value.to_bytes_checked().into_owned();
+        let value = value.into_bytes_checked();
 
         let root = if self.root_addr == NULL {
             // No root present. Allocate one.


### PR DESCRIPTION
In OpenChat I have just introduced a `StableBTreeMap` where the values are `Vec<u8>`.
I saw that when calling `map.insert(..)` the bytes were being cloned because `Storable::to_bytes` take a reference to `self` so for `Vec<u8>` the response is `Cow::Borrowed(self)`, then when calling `into_owned` the bytes are cloned.

This PR adds an optional `into_bytes` method to the `Storable` trait which by default simply calls into `to_bytes`.
Implementing `into_bytes` allows for values to be inserted with cloning the bytes.

The downside is that I've had to add the `Sized` trait to `Storable` which is a breaking change and may not be desired. 