### PR TITLE
fix: Fix Vec Iter::count() after next_back()

### DIFF
--- a/src/base_vec.rs
+++ b/src/base_vec.rs
@@ -379,11 +379,7 @@ where
     }
 
     fn count(self) -> usize {
-        let n = self.vec.len().saturating_sub(self.range.start);
-        if n > usize::MAX as u64 {
-            panic!("The number of items in the vec {n} does not fit into usize");
-        }
-        n as usize
+        self.range.count()
     }
 
     fn nth(&mut self, n: usize) -> Option<T> {

--- a/src/base_vec.rs
+++ b/src/base_vec.rs
@@ -379,7 +379,10 @@ where
     }
 
     fn count(self) -> usize {
-        self.range.count()
+        min(self.vec.len(), self.range.end)
+            .saturating_sub(self.range.start)
+            .try_into()
+            .expect("Cannot express count as usize")
     }
 
     fn nth(&mut self, n: usize) -> Option<T> {

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -227,6 +227,13 @@ fn test_iter() {
     assert_eq!(sv.iter().skip(3).count(), 0);
     assert_eq!(sv.iter().skip(4).count(), 0);
     assert_eq!(sv.iter().skip(usize::MAX).count(), 0);
+
+    {
+        assert_eq!(sv.len(), 3);
+        let mut iter = sv.iter();
+        iter.next_back();
+        assert_eq!(iter.count(), 2);
+    }
 }
 
 // A struct with a bugg implementation of storable where the max_size can

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -227,11 +227,25 @@ fn test_iter() {
     assert_eq!(sv.iter().skip(3).count(), 0);
     assert_eq!(sv.iter().skip(4).count(), 0);
     assert_eq!(sv.iter().skip(usize::MAX).count(), 0);
+}
 
+#[test]
+fn test_iter_count() {
+    let sv = StableVec::<u64, M>::new(M::default()).unwrap();
+    sv.push(&1).unwrap();
+    sv.push(&2).unwrap();
+    sv.push(&3).unwrap();
+    sv.push(&4).unwrap();
     {
-        assert_eq!(sv.len(), 3);
         let mut iter = sv.iter();
         iter.next_back();
+        assert_eq!(iter.count(), 3);
+    }
+    {
+        let mut iter = sv.iter();
+        iter.next_back();
+        sv.pop(); // this pops the element that we iterated through on the previous line
+        sv.pop();
         assert_eq!(iter.count(), 2);
     }
 }


### PR DESCRIPTION
There is a bug in the current implementation that returns the count until the end of the vector even if some elements have been taken from the iterator using `next_back()` (see the testcase in the PR).