### PR TITLE
ci: add emojis for visualization to top-level canbench summary

### DIFF
--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -34,13 +34,13 @@ fi
 pushd "$CANISTER_PATH"
 canbench --less-verbose > $CANBENCH_OUTPUT
 if grep -q "(regress\|(improved by \|(new)" "$CANBENCH_OUTPUT"; then
-  UPDATED_MSG="**\`$CANBENCH_RESULTS_FILE\` is not up to date ❌**
+  UPDATED_MSG="**❌ \`$CANBENCH_RESULTS_FILE\` is not up to date**
   If the performance change is expected, run \`canbench --persist\` to save the updated benchmark results.";
 
   # canbench results file not up to date. Fail the job.
   echo "EXIT_STATUS=1" >> "$GITHUB_ENV"
 else
-  UPDATED_MSG="**\`$CANBENCH_RESULTS_FILE\` is up to date ✅**";
+  UPDATED_MSG="**✅ \`$CANBENCH_RESULTS_FILE\` is up to date**";
 
   # canbench results file is up to date. The job succeeds.
   echo "EXIT_STATUS=0" >> "$GITHUB_ENV"
@@ -60,26 +60,27 @@ if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
   canbench --less-verbose > "$CANBENCH_OUTPUT"
   popd
 
-  if grep -q "(regress\|(improved by" "${CANBENCH_OUTPUT}"; then
-    echo "**Significant performance change detected! ⚠️**
-    " >> "$COMMENT_MESSAGE_PATH"
-  else
-    echo "**No significant performance changes detected ✅**
-    " >> "$COMMENT_MESSAGE_PATH"
-  fi
-fi
+  # Add emojis for visualization (as of December 2024, Github does not support colored text)
+  awk '
+  /\(improved / { print $0, "🟢"; next }
+  /\(regressed / { print $0, "🔴"; next }
+  /\(new\)/ { print $0, "🟡"; next }
+  { print }
+  ' "$CANBENCH_OUTPUT" > "${CANBENCH_OUTPUT}.tmp" && mv "${CANBENCH_OUTPUT}.tmp" "$CANBENCH_OUTPUT"
 
-# Add emojis for visualization (as of December 2024, Github does not support colored text)
-FORMATTED_CANBENCH_OUTPUT=$(cat "$CANBENCH_OUTPUT" \
-                            | sed -E 's/.*improved.*/\0 🟢/g' \
-                            | sed -E 's/.*regress.*/\0 🔴/g')
+  # Add a top-level summary of detected performance changes
+  MESSAGE=""
+  grep -q "(improved " "${CANBENCH_OUTPUT}" && MESSAGE+="**🟢 Performance improvements detected! 🎉**\n"
+  grep -q "(regressed " "${CANBENCH_OUTPUT}" && MESSAGE+="**🔴 Performance regressions detected! 😱**\n"
+  echo -e "${MESSAGE:-**ℹ️ No significant performance changes detected 👍**}" >> "$COMMENT_MESSAGE_PATH"
+fi
 
 ## Add the output of canbench to the file.
 {
   echo "$UPDATED_MSG"
   echo ""
   echo "\`\`\`"
-  echo "$FORMATTED_CANBENCH_OUTPUT"
+  echo "$CANBENCH_OUTPUT"
   echo "\`\`\`"
 } >> "$COMMENT_MESSAGE_PATH"
 

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -47,8 +47,12 @@ else
 fi
 popd
 
+# Get the latest commit hash
+commit_hash=$(git rev-parse HEAD)
+time=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
 
-echo "# \`canbench\` 🏋 (dir: $CANISTER_PATH)" > "$COMMENT_MESSAGE_PATH"
+# Print output with correct formatting
+echo "# \`canbench\` 🏋 (dir: $CANISTER_PATH) $commit_hash $time" > "$COMMENT_MESSAGE_PATH"
 
 # Detect if there are performance changes relative to the main branch.
 if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -84,7 +84,7 @@ fi
   echo "$UPDATED_MSG"
   echo ""
   echo "\`\`\`"
-  echo "$CANBENCH_OUTPUT"
+  cat "$CANBENCH_OUTPUT"
   echo "\`\`\`"
 } >> "$COMMENT_MESSAGE_PATH"
 

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -524,12 +524,7 @@ where
     /// Returns true if the key exists.
     pub fn contains_key(&self, key: &K) -> bool {
         // An empty closure returns Some(()) if the key is found.
-        self.root_addr != NULL
-            && self
-                .traverse(self.root_addr, key, |node, idx| {
-                    node.into_entry(idx, self.memory()).1 // TODO: remove debug code.
-                })
-                .is_some()
+        self.root_addr != NULL && self.traverse(self.root_addr, key, |_, _| ()).is_some()
     }
 
     /// Recursively traverses from `node_addr`, invoking `f` if `key` is found. Stops at a leaf if not.

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -524,7 +524,12 @@ where
     /// Returns true if the key exists.
     pub fn contains_key(&self, key: &K) -> bool {
         // An empty closure returns Some(()) if the key is found.
-        self.root_addr != NULL && self.traverse(self.root_addr, key, |_, _| ()).is_some()
+        self.root_addr != NULL
+            && self
+                .traverse(self.root_addr, key, |node, idx| {
+                    node.into_entry(idx, self.memory()).1 // TODO: remove debug code.
+                })
+                .is_some()
     }
 
     /// Recursively traverses from `node_addr`, invoking `f` if `key` is found. Stops at a leaf if not.


### PR DESCRIPTION
This PR adds emojis to top-level canbench summary the same way it's done in [bitcoin-canister](https://github.com/dfinity/bitcoin-canister/blob/164a18241db834f49770e423d9cccfc4deb45cf5/scripts/canbench_ci_run_benchmark.sh#L77) repo.

It also adds to canbench report a commit hash & time of the benchmark run.

Testing [example log](https://github.com/dfinity/stable-structures/actions/runs/14329924031/job/40163575581#step:6:391).