### PR TITLE
Draft: POC [EXC-2017] Cache the first and the last key-value pair in StableBTreeMap

### DIFF
--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -1,13 +1,13 @@
 benches:
   btreemap_contains_key_blob_4_1024:
     total:
-      instructions: 166001914
+      instructions: 166051908
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_contains_key_blob_4_1024_v2:
     total:
-      instructions: 246601950
+      instructions: 246651944
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -175,6 +175,7 @@ benches:
     scopes: {}
   btreemap_insert_10mib_values:
     total:
+      instructions: 5239412459
       heap_increase: 0
       stable_memory_increase: 3613
     scopes: {}
@@ -414,7 +415,7 @@ benches:
     scopes: {}
   btreemap_insert_u64_u64_v2_mem_manager:
     total:
-      instructions: 558130823
+      instructions: 558306919
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -25,7 +25,7 @@ benches:
     scopes: {}
   btreemap_first_key_value_pop_first_blob1024:
     total:
-      instructions: 647858734
+      instructions: 652265736
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -505,7 +505,7 @@ benches:
     scopes: {}
   btreemap_last_key_value_pop_last_blob1024:
     total:
-      instructions: 656992168
+      instructions: 661401864
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -19,25 +19,25 @@ benches:
     scopes: {}
   btreemap_first_key_value_pop_first:
     total:
-      instructions: 521197111
+      instructions: 266668587
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_first_key_value_pop_first_blob1024:
     total:
-      instructions: 652265736
+      instructions: 285627234
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_first_key_value_pop_first_once_blob1024:
     total:
-      instructions: 509852684
+      instructions: 514563065
       heap_increase: 0
       stable_memory_increase: 10
     scopes: {}
   btreemap_first_key_value_pop_last:
     total:
-      instructions: 372452012
+      instructions: 262126391
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -187,247 +187,247 @@ benches:
     scopes: {}
   btreemap_insert_10mib_values:
     total:
-      instructions: 5239412459
+      instructions: 5239412439
       heap_increase: 0
       stable_memory_increase: 3613
     scopes: {}
   btreemap_insert_blob_1024_128:
     total:
-      instructions: 5110804101
+      instructions: 5110784101
       heap_increase: 0
       stable_memory_increase: 262
     scopes: {}
   btreemap_insert_blob_1024_128_v2:
     total:
-      instructions: 5202076582
+      instructions: 5202056582
       heap_increase: 0
       stable_memory_increase: 196
     scopes: {}
   btreemap_insert_blob_1024_16:
     total:
-      instructions: 5113412660
+      instructions: 5113392660
       heap_increase: 0
       stable_memory_increase: 241
     scopes: {}
   btreemap_insert_blob_1024_16_v2:
     total:
-      instructions: 5200300649
+      instructions: 5200280649
       heap_increase: 0
       stable_memory_increase: 181
     scopes: {}
   btreemap_insert_blob_1024_256:
     total:
-      instructions: 5132146019
+      instructions: 5132126019
       heap_increase: 0
       stable_memory_increase: 292
     scopes: {}
   btreemap_insert_blob_1024_256_v2:
     total:
-      instructions: 5225856019
+      instructions: 5225836019
       heap_increase: 0
       stable_memory_increase: 219
     scopes: {}
   btreemap_insert_blob_1024_32:
     total:
-      instructions: 5096650160
+      instructions: 5096630160
       heap_increase: 0
       stable_memory_increase: 239
     scopes: {}
   btreemap_insert_blob_1024_32_v2:
     total:
-      instructions: 5194876210
+      instructions: 5194856210
       heap_increase: 0
       stable_memory_increase: 180
     scopes: {}
   btreemap_insert_blob_1024_4:
     total:
-      instructions: 5019450618
+      instructions: 5019430618
       heap_increase: 0
       stable_memory_increase: 235
     scopes: {}
   btreemap_insert_blob_1024_4_v2:
     total:
-      instructions: 5098362305
+      instructions: 5098342305
       heap_increase: 0
       stable_memory_increase: 176
     scopes: {}
   btreemap_insert_blob_1024_512:
     total:
-      instructions: 5206463531
+      instructions: 5206443531
       heap_increase: 0
       stable_memory_increase: 348
     scopes: {}
   btreemap_insert_blob_1024_512_v2:
     total:
-      instructions: 5306007254
+      instructions: 5305987254
       heap_increase: 0
       stable_memory_increase: 261
     scopes: {}
   btreemap_insert_blob_1024_512_v2_mem_manager:
     total:
-      instructions: 5475083990
+      instructions: 5475063990
       heap_increase: 0
       stable_memory_increase: 256
     scopes: {}
   btreemap_insert_blob_1024_64:
     total:
-      instructions: 5150315789
+      instructions: 5150295789
       heap_increase: 0
       stable_memory_increase: 250
     scopes: {}
   btreemap_insert_blob_1024_64_v2:
     total:
-      instructions: 5249245297
+      instructions: 5249225297
       heap_increase: 0
       stable_memory_increase: 188
     scopes: {}
   btreemap_insert_blob_1024_8:
     total:
-      instructions: 5085488900
+      instructions: 5085468900
       heap_increase: 0
       stable_memory_increase: 237
     scopes: {}
   btreemap_insert_blob_1024_8_v2:
     total:
-      instructions: 5187698037
+      instructions: 5187678037
       heap_increase: 0
       stable_memory_increase: 178
     scopes: {}
   btreemap_insert_blob_128_1024:
     total:
-      instructions: 1273367463
+      instructions: 1273347463
       heap_increase: 0
       stable_memory_increase: 260
     scopes: {}
   btreemap_insert_blob_128_1024_v2:
     total:
-      instructions: 1373453309
+      instructions: 1373433309
       heap_increase: 0
       stable_memory_increase: 195
     scopes: {}
   btreemap_insert_blob_16_1024:
     total:
-      instructions: 637945470
+      instructions: 637925470
       heap_increase: 0
       stable_memory_increase: 215
     scopes: {}
   btreemap_insert_blob_16_1024_v2:
     total:
-      instructions: 732595990
+      instructions: 732575990
       heap_increase: 0
       stable_memory_increase: 161
     scopes: {}
   btreemap_insert_blob_256_1024:
     total:
-      instructions: 1859980193
+      instructions: 1859960193
       heap_increase: 0
       stable_memory_increase: 292
     scopes: {}
   btreemap_insert_blob_256_1024_v2:
     total:
-      instructions: 1957995803
+      instructions: 1957975803
       heap_increase: 0
       stable_memory_increase: 219
     scopes: {}
   btreemap_insert_blob_32_1024:
     total:
-      instructions: 673010979
+      instructions: 672990979
       heap_increase: 0
       stable_memory_increase: 230
     scopes: {}
   btreemap_insert_blob_32_1024_v2:
     total:
-      instructions: 770304792
+      instructions: 770284792
       heap_increase: 0
       stable_memory_increase: 173
     scopes: {}
   btreemap_insert_blob_4_1024:
     total:
-      instructions: 497401412
+      instructions: 497381412
       heap_increase: 0
       stable_memory_increase: 123
     scopes: {}
   btreemap_insert_blob_4_1024_v2:
     total:
-      instructions: 593973800
+      instructions: 593953800
       heap_increase: 0
       stable_memory_increase: 92
     scopes: {}
   btreemap_insert_blob_512_1024:
     total:
-      instructions: 3010935691
+      instructions: 3010915691
       heap_increase: 0
       stable_memory_increase: 351
     scopes: {}
   btreemap_insert_blob_512_1024_v2:
     total:
-      instructions: 3104836455
+      instructions: 3104816455
       heap_increase: 0
       stable_memory_increase: 263
     scopes: {}
   btreemap_insert_blob_64_1024:
     total:
-      instructions: 920075850
+      instructions: 920055850
       heap_increase: 0
       stable_memory_increase: 245
     scopes: {}
   btreemap_insert_blob_64_1024_v2:
     total:
-      instructions: 1016043332
+      instructions: 1016023332
       heap_increase: 0
       stable_memory_increase: 183
     scopes: {}
   btreemap_insert_blob_8_1024:
     total:
-      instructions: 607946777
+      instructions: 607926777
       heap_increase: 0
       stable_memory_increase: 183
     scopes: {}
   btreemap_insert_blob_8_1024_v2:
     total:
-      instructions: 709670767
+      instructions: 709650767
       heap_increase: 0
       stable_memory_increase: 138
     scopes: {}
   btreemap_insert_blob_8_u64:
     total:
-      instructions: 330440136
+      instructions: 330420136
       heap_increase: 0
       stable_memory_increase: 6
     scopes: {}
   btreemap_insert_blob_8_u64_v2:
     total:
-      instructions: 441269700
+      instructions: 441249700
       heap_increase: 0
       stable_memory_increase: 4
     scopes: {}
   btreemap_insert_u64_blob_8:
     total:
-      instructions: 340059034
+      instructions: 340049034
       heap_increase: 0
       stable_memory_increase: 7
     scopes: {}
   btreemap_insert_u64_blob_8_v2:
     total:
-      instructions: 420458618
+      instructions: 420448618
       heap_increase: 0
       stable_memory_increase: 5
     scopes: {}
   btreemap_insert_u64_u64:
     total:
-      instructions: 345600000
+      instructions: 345580000
       heap_increase: 0
       stable_memory_increase: 7
     scopes: {}
   btreemap_insert_u64_u64_v2:
     total:
-      instructions: 429035247
+      instructions: 429015247
       heap_increase: 0
       stable_memory_increase: 6
     scopes: {}
   btreemap_insert_u64_u64_v2_mem_manager:
     total:
-      instructions: 558306919
+      instructions: 558286919
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -499,25 +499,25 @@ benches:
     scopes: {}
   btreemap_last_key_value_pop_first:
     total:
-      instructions: 705264570
+      instructions: 509651413
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_last_key_value_pop_last:
     total:
-      instructions: 969597964
+      instructions: 500351283
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_last_key_value_pop_last_blob1024:
     total:
-      instructions: 661401864
+      instructions: 280631454
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_last_key_value_pop_last_once_blob1024:
     total:
-      instructions: 478691110
+      instructions: 483401222
       heap_increase: 0
       stable_memory_increase: 10
     scopes: {}
@@ -535,133 +535,133 @@ benches:
     scopes: {}
   btreemap_remove_blob_128_1024:
     total:
-      instructions: 1574815940
+      instructions: 1574745325
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_128_1024_v2:
     total:
-      instructions: 1717824218
+      instructions: 1717753603
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_16_1024:
     total:
-      instructions: 758276944
+      instructions: 758199770
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_16_1024_v2:
     total:
-      instructions: 896125762
+      instructions: 896048588
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_256_1024:
     total:
-      instructions: 2279303553
+      instructions: 2279233169
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_256_1024_v2:
     total:
-      instructions: 2418045594
+      instructions: 2417975210
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_32_1024:
     total:
-      instructions: 827739093
+      instructions: 827665965
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_32_1024_v2:
     total:
-      instructions: 966897633
+      instructions: 966824505
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_4_1024:
     total:
-      instructions: 486647796
+      instructions: 486539431
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_4_1024_v2:
     total:
-      instructions: 600271963
+      instructions: 600163604
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_512_1024:
     total:
-      instructions: 3749133388
+      instructions: 3749063298
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_512_1024_v2:
     total:
-      instructions: 3878381779
+      instructions: 3878311689
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_64_1024:
     total:
-      instructions: 1141148090
+      instructions: 1141076866
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_64_1024_v2:
     total:
-      instructions: 1281060638
+      instructions: 1280989414
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_1024:
     total:
-      instructions: 644875138
+      instructions: 644789494
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_1024_v2:
     total:
-      instructions: 776908069
+      instructions: 776822427
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_u64:
     total:
-      instructions: 435496043
+      instructions: 435087262
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_u64_v2:
     total:
-      instructions: 584546455
+      instructions: 584107775
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_blob_8:
     total:
-      instructions: 485888982
+      instructions: 485818997
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_blob_8_v2:
     total:
-      instructions: 601152747
+      instructions: 601082762
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_u64:
     total:
-      instructions: 499404278
+      instructions: 499004307
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_u64_v2:
     total:
-      instructions: 623995810
+      instructions: 623565839
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -31,7 +31,7 @@ benches:
     scopes: {}
   btreemap_first_key_value_pop_first_once_blob1024:
     total:
-      instructions: 509829791
+      instructions: 509852684
       heap_increase: 0
       stable_memory_increase: 10
     scopes: {}
@@ -517,7 +517,7 @@ benches:
     scopes: {}
   btreemap_last_key_value_pop_last_once_blob1024:
     total:
-      instructions: 478668212
+      instructions: 478691110
       heap_increase: 0
       stable_memory_increase: 10
     scopes: {}

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -1,19 +1,19 @@
 benches:
   btreemap_first_key_value_insert:
     total:
-      instructions: 611925884
+      instructions: 499983469
       heap_increase: 0
       stable_memory_increase: 31
     scopes: {}
   btreemap_first_key_value_insert_and_pop_first:
     total:
-      instructions: 1013842556
+      instructions: 1016202556
       heap_increase: 0
       stable_memory_increase: 31
     scopes: {}
   btreemap_first_key_value_insert_and_pop_last:
     total:
-      instructions: 978061717
+      instructions: 867457457
       heap_increase: 0
       stable_memory_increase: 31
     scopes: {}
@@ -163,247 +163,247 @@ benches:
     scopes: {}
   btreemap_insert_10mib_values:
     total:
-      instructions: 5239421355
+      instructions: 5239421635
       heap_increase: 0
       stable_memory_increase: 3613
     scopes: {}
   btreemap_insert_blob_1024_128:
     total:
-      instructions: 5110664101
+      instructions: 5110804101
       heap_increase: 0
       stable_memory_increase: 262
     scopes: {}
   btreemap_insert_blob_1024_128_v2:
     total:
-      instructions: 5201936582
+      instructions: 5202076582
       heap_increase: 0
       stable_memory_increase: 196
     scopes: {}
   btreemap_insert_blob_1024_16:
     total:
-      instructions: 5113272660
+      instructions: 5113412660
       heap_increase: 0
       stable_memory_increase: 241
     scopes: {}
   btreemap_insert_blob_1024_16_v2:
     total:
-      instructions: 5200160649
+      instructions: 5200300649
       heap_increase: 0
       stable_memory_increase: 181
     scopes: {}
   btreemap_insert_blob_1024_256:
     total:
-      instructions: 5132006019
+      instructions: 5132146019
       heap_increase: 0
       stable_memory_increase: 292
     scopes: {}
   btreemap_insert_blob_1024_256_v2:
     total:
-      instructions: 5225716019
+      instructions: 5225856019
       heap_increase: 0
       stable_memory_increase: 219
     scopes: {}
   btreemap_insert_blob_1024_32:
     total:
-      instructions: 5096510160
+      instructions: 5096650160
       heap_increase: 0
       stable_memory_increase: 239
     scopes: {}
   btreemap_insert_blob_1024_32_v2:
     total:
-      instructions: 5194736210
+      instructions: 5194876210
       heap_increase: 0
       stable_memory_increase: 180
     scopes: {}
   btreemap_insert_blob_1024_4:
     total:
-      instructions: 5019310618
+      instructions: 5019450618
       heap_increase: 0
       stable_memory_increase: 235
     scopes: {}
   btreemap_insert_blob_1024_4_v2:
     total:
-      instructions: 5098222305
+      instructions: 5098362305
       heap_increase: 0
       stable_memory_increase: 176
     scopes: {}
   btreemap_insert_blob_1024_512:
     total:
-      instructions: 5206323531
+      instructions: 5206463531
       heap_increase: 0
       stable_memory_increase: 348
     scopes: {}
   btreemap_insert_blob_1024_512_v2:
     total:
-      instructions: 5305867254
+      instructions: 5306007254
       heap_increase: 0
       stable_memory_increase: 261
     scopes: {}
   btreemap_insert_blob_1024_512_v2_mem_manager:
     total:
-      instructions: 5474908000
+      instructions: 5475083990
       heap_increase: 0
       stable_memory_increase: 256
     scopes: {}
   btreemap_insert_blob_1024_64:
     total:
-      instructions: 5150175789
+      instructions: 5150315789
       heap_increase: 0
       stable_memory_increase: 250
     scopes: {}
   btreemap_insert_blob_1024_64_v2:
     total:
-      instructions: 5249105297
+      instructions: 5249245297
       heap_increase: 0
       stable_memory_increase: 188
     scopes: {}
   btreemap_insert_blob_1024_8:
     total:
-      instructions: 5085348900
+      instructions: 5085488900
       heap_increase: 0
       stable_memory_increase: 237
     scopes: {}
   btreemap_insert_blob_1024_8_v2:
     total:
-      instructions: 5187558037
+      instructions: 5187698037
       heap_increase: 0
       stable_memory_increase: 178
     scopes: {}
   btreemap_insert_blob_128_1024:
     total:
-      instructions: 1273227463
+      instructions: 1273367463
       heap_increase: 0
       stable_memory_increase: 260
     scopes: {}
   btreemap_insert_blob_128_1024_v2:
     total:
-      instructions: 1373313309
+      instructions: 1373453309
       heap_increase: 0
       stable_memory_increase: 195
     scopes: {}
   btreemap_insert_blob_16_1024:
     total:
-      instructions: 637805470
+      instructions: 637945470
       heap_increase: 0
       stable_memory_increase: 215
     scopes: {}
   btreemap_insert_blob_16_1024_v2:
     total:
-      instructions: 732455990
+      instructions: 732595990
       heap_increase: 0
       stable_memory_increase: 161
     scopes: {}
   btreemap_insert_blob_256_1024:
     total:
-      instructions: 1859840193
+      instructions: 1859980193
       heap_increase: 0
       stable_memory_increase: 292
     scopes: {}
   btreemap_insert_blob_256_1024_v2:
     total:
-      instructions: 1957855803
+      instructions: 1957995803
       heap_increase: 0
       stable_memory_increase: 219
     scopes: {}
   btreemap_insert_blob_32_1024:
     total:
-      instructions: 672870979
+      instructions: 673010979
       heap_increase: 0
       stable_memory_increase: 230
     scopes: {}
   btreemap_insert_blob_32_1024_v2:
     total:
-      instructions: 770164792
+      instructions: 770304792
       heap_increase: 0
       stable_memory_increase: 173
     scopes: {}
   btreemap_insert_blob_4_1024:
     total:
-      instructions: 497280451
+      instructions: 497401412
       heap_increase: 0
       stable_memory_increase: 123
     scopes: {}
   btreemap_insert_blob_4_1024_v2:
     total:
-      instructions: 593852839
+      instructions: 593973800
       heap_increase: 0
       stable_memory_increase: 92
     scopes: {}
   btreemap_insert_blob_512_1024:
     total:
-      instructions: 3010795691
+      instructions: 3010935691
       heap_increase: 0
       stable_memory_increase: 351
     scopes: {}
   btreemap_insert_blob_512_1024_v2:
     total:
-      instructions: 3104696455
+      instructions: 3104836455
       heap_increase: 0
       stable_memory_increase: 263
     scopes: {}
   btreemap_insert_blob_64_1024:
     total:
-      instructions: 919935850
+      instructions: 920075850
       heap_increase: 0
       stable_memory_increase: 245
     scopes: {}
   btreemap_insert_blob_64_1024_v2:
     total:
-      instructions: 1015903332
+      instructions: 1016043332
       heap_increase: 0
       stable_memory_increase: 183
     scopes: {}
   btreemap_insert_blob_8_1024:
     total:
-      instructions: 607806777
+      instructions: 607946777
       heap_increase: 0
       stable_memory_increase: 183
     scopes: {}
   btreemap_insert_blob_8_1024_v2:
     total:
-      instructions: 709530767
+      instructions: 709670767
       heap_increase: 0
       stable_memory_increase: 138
     scopes: {}
   btreemap_insert_blob_8_u64:
     total:
-      instructions: 330300136
+      instructions: 330440136
       heap_increase: 0
       stable_memory_increase: 6
     scopes: {}
   btreemap_insert_blob_8_u64_v2:
     total:
-      instructions: 441129700
+      instructions: 441269700
       heap_increase: 0
       stable_memory_increase: 4
     scopes: {}
   btreemap_insert_u64_blob_8:
     total:
-      instructions: 339919034
+      instructions: 340059034
       heap_increase: 0
       stable_memory_increase: 7
     scopes: {}
   btreemap_insert_u64_blob_8_v2:
     total:
-      instructions: 420318618
+      instructions: 420458618
       heap_increase: 0
       stable_memory_increase: 5
     scopes: {}
   btreemap_insert_u64_u64:
     total:
-      instructions: 345460000
+      instructions: 345600000
       heap_increase: 0
       stable_memory_increase: 7
     scopes: {}
   btreemap_insert_u64_u64_mem_manager:
     total:
-      instructions: 558130823
+      instructions: 558306919
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_insert_u64_u64_v2:
     total:
-      instructions: 428895247
+      instructions: 429035247
       heap_increase: 0
       stable_memory_increase: 6
     scopes: {}
@@ -469,19 +469,19 @@ benches:
     scopes: {}
   btreemap_last_key_value_insert:
     total:
-      instructions: 799866043
+      instructions: 504925553
       heap_increase: 0
       stable_memory_increase: 31
     scopes: {}
   btreemap_last_key_value_insert_pop_first:
     total:
-      instructions: 1467470443
+      instructions: 1200250013
       heap_increase: 0
       stable_memory_increase: 31
     scopes: {}
   btreemap_last_key_value_insert_pop_last:
     total:
-      instructions: 1460003347
+      instructions: 1464583407
       heap_increase: 0
       stable_memory_increase: 31
     scopes: {}
@@ -499,133 +499,133 @@ benches:
     scopes: {}
   btreemap_remove_blob_128_1024:
     total:
-      instructions: 1574675940
+      instructions: 1574815940
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_128_1024_v2:
     total:
-      instructions: 1717684218
+      instructions: 1717824218
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_16_1024:
     total:
-      instructions: 758136944
+      instructions: 758276944
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_16_1024_v2:
     total:
-      instructions: 895985762
+      instructions: 896125762
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_256_1024:
     total:
-      instructions: 2279163553
+      instructions: 2279303553
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_256_1024_v2:
     total:
-      instructions: 2417905594
+      instructions: 2418045594
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_32_1024:
     total:
-      instructions: 827599093
+      instructions: 827739093
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_32_1024_v2:
     total:
-      instructions: 966757633
+      instructions: 966897633
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_4_1024:
     total:
-      instructions: 486469240
+      instructions: 486647796
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_4_1024_v2:
     total:
-      instructions: 600093407
+      instructions: 600271963
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_512_1024:
     total:
-      instructions: 3748993388
+      instructions: 3749133388
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_512_1024_v2:
     total:
-      instructions: 3878241779
+      instructions: 3878381779
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_64_1024:
     total:
-      instructions: 1141008090
+      instructions: 1141148090
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_64_1024_v2:
     total:
-      instructions: 1280920638
+      instructions: 1281060638
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_1024:
     total:
-      instructions: 644735138
+      instructions: 644875138
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_1024_v2:
     total:
-      instructions: 776768069
+      instructions: 776908069
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_u64:
     total:
-      instructions: 435032682
+      instructions: 435496043
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_blob_8_u64_v2:
     total:
-      instructions: 584053097
+      instructions: 584546455
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_blob_8:
     total:
-      instructions: 485748982
+      instructions: 485888982
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_blob_8_v2:
     total:
-      instructions: 601012747
+      instructions: 601152747
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_u64:
     total:
-      instructions: 498934285
+      instructions: 499404278
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_remove_u64_u64_v2:
     total:
-      instructions: 623495817
+      instructions: 623995810
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -13,19 +13,19 @@ benches:
     scopes: {}
   btreemap_first_key_value:
     total:
-      instructions: 117060439
+      instructions: 4978024
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_first_key_value_pop_first:
     total:
-      instructions: 518977111
+      instructions: 521197111
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_first_key_value_pop_last:
     total:
-      instructions: 483196272
+      instructions: 372452012
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -481,19 +481,19 @@ benches:
     scopes: {}
   btreemap_last_key_value:
     total:
-      instructions: 305020600
+      instructions: 9940110
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_last_key_value_pop_first:
     total:
-      instructions: 972625000
+      instructions: 705264570
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_last_key_value_pop_last:
     total:
-      instructions: 965157904
+      instructions: 969597964
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -103,10 +103,10 @@ where
     // The number of elements in the map.
     length: u64,
 
-    // Saved first (K, V) pair in tree.
+    // Caches the first (K, V) pair in the tree for quick access.
     first_key_value: Option<(K, Vec<u8>)>,
 
-    // Saved last (K, V) pair in tree.
+    // Caches the last (K, V) pair in the tree for quick access.
     last_key_value: Option<(K, Vec<u8>)>,
 
     // A marker to communicate to the Rust compiler that we own these types.
@@ -219,9 +219,9 @@ where
             ),
             version: Version::V2(page_size),
             length: 0,
-            _phantom: PhantomData,
             first_key_value: None,
             last_key_value: None,
+            _phantom: PhantomData,
         };
 
         btree.save();
@@ -248,9 +248,9 @@ where
                 max_value_size,
             }),
             length: 0,
-            _phantom: PhantomData,
             first_key_value: None,
             last_key_value: None,
+            _phantom: PhantomData,
         };
 
         btree.save();
@@ -299,9 +299,9 @@ where
             allocator: Allocator::load(memory, allocator_addr),
             version,
             length: header.length,
-            _phantom: PhantomData,
             first_key_value: None,
             last_key_value: None,
+            _phantom: PhantomData,
         }
     }
 


### PR DESCRIPTION
This PR adds caching for the first and last key-value pairs, which should speed up `fn first_key_value` and `fn last_key_value`. The only downside is that these functions will now require a mutable reference on `StableBTreeMap`, since caching can mutate `StableBTreeMap`.

Canbench results:
---------------------------------------------------
---------------------------------------------------

Benchmark: btreemap_first_key_value
  total:
    instructions: 4.98 M (improved by 95.75%)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

Benchmark: btreemap_first_key_value_pop_first
  total:
    instructions: 266.67 M (improved by 48.62%)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

Benchmark: btreemap_first_key_value_pop_last
  total:
    instructions: 262.13 M (improved by 45.75%)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

Benchmark: btreemap_first_key_value_pop_first_blob1024
  total:
    instructions: 285.63 M (improved by 55.91%)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

Benchmark: btreemap_first_key_value_pop_first_once_blob1024
  total:
    instructions: 514.56 M (0.93%) (change within noise threshold)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 10 pages (no change)

---------------------------------------------------

Benchmark: btreemap_last_key_value
  total:
    instructions: 9.94 M (improved by 96.74%)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

Benchmark: btreemap_last_key_value_pop_first
  total:
    instructions: 509.65 M (improved by 47.60%)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

Benchmark: btreemap_last_key_value_pop_last
  total:
    instructions: 500.35 M (improved by 48.16%)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

Benchmark: btreemap_last_key_value_pop_last_blob1024
  total:
    instructions: 280.63 M (improved by 57.29%)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

Benchmark: btreemap_last_key_value_pop_last_once_blob1024
  total:
    instructions: 483.40 M (0.99%) (change within noise threshold)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 10 pages (no change)

---------------------------------------------------