### PR TITLE
test: add multi‑type key/value support to BTreeMap tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@
 .vscode/
 .idea/
 **/*~
-
-tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .vscode/
 .idea/
 **/*~
+
+tmp/

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1236,16 +1236,6 @@ mod test {
         }
     }
 
-    type MonotonicString32 = String;
-    impl Builder for MonotonicString32 {
-        fn build(i: u32) -> Self {
-            format!("{i:0>32}")
-        }
-        fn empty() -> Self {
-            String::new()
-        }
-    }
-
     type MonotonicVec32 = Vec<u8>;
     impl Builder for MonotonicVec32 {
         fn build(i: u32) -> Self {
@@ -1253,6 +1243,16 @@ mod test {
         }
         fn empty() -> Self {
             Vec::new()
+        }
+    }
+
+    type MonotonicString32 = String;
+    impl Builder for MonotonicString32 {
+        fn build(i: u32) -> Self {
+            format!("{i:0>32}")
+        }
+        fn empty() -> Self {
+            String::new()
         }
     }
 
@@ -1324,14 +1324,14 @@ mod test {
                 // Set.
                 verify_and_run!($runner, u32, ());
                 verify_and_run!($runner, Blob<10>, ());
-                verify_and_run!($runner, MonotonicString32, ());
                 verify_and_run!($runner, MonotonicVec32, ());
+                verify_and_run!($runner, MonotonicString32, ());
 
                 // Map.
                 verify_and_run!($runner, u32, Blob<20>);
                 verify_and_run!($runner, Blob<10>, Blob<20>);
-                verify_and_run!($runner, MonotonicString32, Blob<20>);
                 verify_and_run!($runner, MonotonicVec32, Blob<20>);
+                verify_and_run!($runner, MonotonicString32, Blob<20>);
             }
         };
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2060,77 +2060,40 @@ mod test {
         remove_case_3b_merge_into_left
     );
 
-    // #[test]
-    // fn many_insertions<K: TestKey, V: TestValue>() {
-    //     let mem = make_memory();
-    //     let mut btree = BTreeMap::new(mem.clone());
+    fn many_insertions<K: TestKey, V: TestValue>(ids: &[u32]) {
+        let (key, value) = (|i| K::make(i), |i| V::make(i));
+        run_btree_test(|mut btree| {
+            for &i in ids {
+                assert_eq!(btree.insert(key(i), value(i)), None);
+            }
+            for &i in ids {
+                assert_eq!(btree.get(&key(i)), Some(value(i)));
+            }
 
-    //     for j in 0..=10 {
-    //         for i in 0..=255 {
-    //             assert_eq!(btree.insert(b(&[i, j]), b(&[i, j])), None);
-    //         }
-    //     }
+            let mut btree = BTreeMap::<K, V, _>::load(btree.into_memory());
+            for &i in ids {
+                assert_eq!(btree.remove(&key(i)), Some(value(i)));
+            }
+            for &i in ids {
+                assert_eq!(btree.get(&key(i)), None);
+            }
 
-    //     for j in 0..=10 {
-    //         for i in 0..=255 {
-    //             assert_eq!(btree.get(&b(&[i, j])), Some(b(&[i, j])));
-    //         }
-    //     }
+            // We've deallocated everything.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 0);
+        });
+    }
 
-    //     let mut btree = BTreeMap::load(mem);
+    fn many_insertions_ascending<K: TestKey, V: TestValue>() {
+        let n = 10_000;
+        many_insertions::<K, V>(&(0..n).collect::<Vec<_>>());
+    }
+    btree_test!(test_many_insertions_ascending, many_insertions_ascending);
 
-    //     for j in 0..=10 {
-    //         for i in 0..=255 {
-    //             assert_eq!(btree.remove(&b(&[i, j])), Some(b(&[i, j])));
-    //         }
-    //     }
-
-    //     for j in 0..=10 {
-    //         for i in 0..=255 {
-    //             assert_eq!(btree.get(&b(&[i, j])), None);
-    //         }
-    //     }
-
-    //     // We've deallocated everything.
-    //     assert_eq!(btree.allocator.num_allocated_chunks(), 0);
-    // }
-    // btree_test!(test_, );
-
-    // #[test]
-    // fn many_insertions_2<K: TestKey, V: TestValue>() {
-    //     let mem = make_memory();
-    //     let mut btree = BTreeMap::new(mem.clone());
-
-    //     for j in (0..=10).rev() {
-    //         for i in (0..=255).rev() {
-    //             assert_eq!(btree.insert(b(&[i, j]), b(&[i, j])), None);
-    //         }
-    //     }
-
-    //     for j in 0..=10 {
-    //         for i in 0..=255 {
-    //             assert_eq!(btree.get(&b(&[i, j])), Some(b(&[i, j])));
-    //         }
-    //     }
-
-    //     let mut btree = BTreeMap::load(mem);
-
-    //     for j in (0..=10).rev() {
-    //         for i in (0..=255).rev() {
-    //             assert_eq!(btree.remove(&b(&[i, j])), Some(b(&[i, j])));
-    //         }
-    //     }
-
-    //     for j in 0..=10 {
-    //         for i in 0..=255 {
-    //             assert_eq!(btree.get(&b(&[i, j])), None);
-    //         }
-    //     }
-
-    //     // We've deallocated everything.
-    //     assert_eq!(btree.allocator.num_allocated_chunks(), 0);
-    // }
-    // btree_test!(test_, );
+    fn many_insertions_descending<K: TestKey, V: TestValue>() {
+        let n = 10_000;
+        many_insertions::<K, V>(&(0..n).rev().collect::<Vec<_>>());
+    }
+    btree_test!(test_many_insertions_descending, many_insertions_descending);
 
     // #[test]
     // fn pop_first_many_entries<K: TestKey, V: TestValue>() {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1279,11 +1279,15 @@ mod test {
         };
     }
 
-    fn init_preserves_data<K, V>()
-    where
-        K: Storable + Ord + Clone + Make,
-        V: Storable + Make + std::fmt::Debug + PartialEq,
-    {
+    // Define a trait for keys that need the full set of bounds.
+    trait TestKey: Storable + Ord + Clone + Make + std::fmt::Debug {}
+    impl<T> TestKey for T where T: Storable + Ord + Clone + Make + std::fmt::Debug {}
+
+    // Define a trait for values that need the full set of bounds.
+    trait TestValue: Storable + Make + std::fmt::Debug + PartialEq {}
+    impl<T> TestValue for T where T: Storable + Make + std::fmt::Debug + PartialEq {}
+
+    fn init_preserves_data<K: TestKey, V: TestValue>() {
         run_btree_test(|mut btree| {
             assert_eq!(btree.insert(K::make(1), V::make(20)), None);
             assert_eq!(btree.get(&K::make(1)), Some(V::make(20)));
@@ -1296,11 +1300,7 @@ mod test {
 
     btree_test!(test_init_preserves_data, init_preserves_data);
 
-    fn insert_get<K, V>()
-    where
-        K: Storable + Ord + Clone + Make + std::fmt::Debug,
-        V: Storable + Make + std::fmt::Debug + PartialEq,
-    {
+    fn insert_get<K: TestKey, V: TestValue>() {
         run_btree_test(|mut btree| {
             assert_eq!(btree.insert(K::make(1), V::make(20)), None);
             assert_eq!(btree.get(&K::make(1)), Some(V::make(20)));
@@ -1309,11 +1309,7 @@ mod test {
 
     btree_test!(test_insert_get, insert_get);
 
-    fn insert_overwrites_previous_value<K, V>()
-    where
-        K: Storable + Ord + Clone + Make + std::fmt::Debug,
-        V: Storable + Make + std::fmt::Debug + PartialEq,
-    {
+    fn insert_overwrites_previous_value<K: TestKey, V: TestValue>() {
         run_btree_test(|mut btree| {
             assert_eq!(btree.insert(K::make(1), V::make(20)), None);
             assert_eq!(btree.insert(K::make(1), V::make(30)), Some(V::make(20)));
@@ -1326,11 +1322,7 @@ mod test {
         insert_overwrites_previous_value
     );
 
-    fn insert_get_multiple_entries<K, V>()
-    where
-        K: Storable + Ord + Clone + Make + std::fmt::Debug,
-        V: Storable + Make + std::fmt::Debug + PartialEq,
-    {
+    fn insert_get_multiple_entries<K: TestKey, V: TestValue>() {
         run_btree_test(|mut btree| {
             assert_eq!(btree.insert(K::make(1), V::make(10)), None);
             assert_eq!(btree.insert(K::make(2), V::make(20)), None);
@@ -1346,11 +1338,7 @@ mod test {
         insert_get_multiple_entries
     );
 
-    fn insert_overwrite_median_key_in_full_child_node<K, V>()
-    where
-        K: Storable + Ord + Clone + Make + std::fmt::Debug,
-        V: Storable + Make + std::fmt::Debug + PartialEq,
-    {
+    fn insert_overwrite_median_key_in_full_child_node<K: TestKey, V: TestValue>() {
         run_btree_test(|mut btree| {
             for i in 1..=17 {
                 assert_eq!(btree.insert(K::make(i), V::default()), None);

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1506,13 +1506,13 @@ mod test {
         let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             for i in 1..=11 {
-                assert_eq!(btree.insert(key(i), value(10)), None);
+                assert_eq!(btree.insert(key(i), value(i)), None);
             }
 
             // Should now split a node.
             let root = btree.load_node(btree.root_addr);
             assert!(root.is_full());
-            assert_eq!(btree.insert(key(12), value(10)), None);
+            assert_eq!(btree.insert(key(12), value(12)), None);
 
             // The result should look like this:
             //                [6]
@@ -1520,7 +1520,7 @@ mod test {
             // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
             for i in 1..=12 {
-                assert_eq!(btree.get(&key(i)), Some(value(10)));
+                assert_eq!(btree.get(&key(i)), Some(value(i)));
             }
         });
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2589,130 +2589,127 @@ mod test {
         range_various_prefixes_with_offset_2
     );
 
-    // #[should_panic(expected = "max_key_size must be <= 4")]
-    // fn v1_rejects_increases_in_max_key_size<K: TestKey, V: TestValue>() {
-    //     let mem = make_memory();
-    //     let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init_v1(mem);
-    //     let _btree: BTreeMap<Blob<5>, Blob<3>, _> = BTreeMap::init_v1(btree.into_memory());
-    // }
-    // btree_test!(test_, );
+    #[test]
+    #[should_panic(expected = "max_key_size must be <= 4")]
+    fn v1_rejects_increases_in_max_key_size() {
+        let mem = make_memory();
+        let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init_v1(mem);
+        let _btree: BTreeMap<Blob<5>, Blob<3>, _> = BTreeMap::init_v1(btree.into_memory());
+    }
 
-    // fn v2_handles_increases_in_max_key_size_and_max_value_size<K: TestKey, V: TestValue>() {
-    //     let mem = make_memory();
-    //     let mut btree: BTreeMap<Blob<4>, Blob<4>, _> = BTreeMap::init(mem);
-    //     btree.insert(
-    //         [1u8; 4].as_slice().try_into().unwrap(),
-    //         [1u8; 4].as_slice().try_into().unwrap(),
-    //     );
+    #[test]
+    fn v2_handles_increases_in_max_key_size_and_max_value_size() {
+        let mem = make_memory();
+        let mut btree: BTreeMap<Blob<4>, Blob<4>, _> = BTreeMap::init(mem);
+        btree.insert(
+            [1u8; 4].as_slice().try_into().unwrap(),
+            [1u8; 4].as_slice().try_into().unwrap(),
+        );
 
-    //     // Reinitialize the BTree with larger keys and value sizes.
-    //     let mut btree: BTreeMap<Blob<5>, Blob<5>, _> = BTreeMap::init(btree.into_memory());
-    //     btree.insert(
-    //         [2u8; 5].as_slice().try_into().unwrap(),
-    //         [2u8; 5].as_slice().try_into().unwrap(),
-    //     );
+        // Reinitialize the BTree with larger keys and value sizes.
+        let mut btree: BTreeMap<Blob<5>, Blob<5>, _> = BTreeMap::init(btree.into_memory());
+        btree.insert(
+            [2u8; 5].as_slice().try_into().unwrap(),
+            [2u8; 5].as_slice().try_into().unwrap(),
+        );
 
-    //     // Still able to retrieve all the entries inserted.
-    //     assert_eq!(
-    //         btree.get(&([1u8; 4].as_slice().try_into().unwrap())),
-    //         Some([1u8; 4].as_slice().try_into().unwrap())
-    //     );
+        // Still able to retrieve all the entries inserted.
+        assert_eq!(
+            btree.get(&([1u8; 4].as_slice().try_into().unwrap())),
+            Some([1u8; 4].as_slice().try_into().unwrap())
+        );
 
-    //     assert_eq!(
-    //         btree.get(&([2u8; 5].as_slice().try_into().unwrap())),
-    //         Some([2u8; 5].as_slice().try_into().unwrap())
-    //     );
-    // }
-    // btree_test!(test_, );
+        assert_eq!(
+            btree.get(&([2u8; 5].as_slice().try_into().unwrap())),
+            Some([2u8; 5].as_slice().try_into().unwrap())
+        );
+    }
 
-    // fn accepts_small_or_equal_key_sizes<K: TestKey, V: TestValue>() {
-    //     let mem = make_memory();
-    //     let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(mem);
-    //     // Smaller key size
-    //     let btree: BTreeMap<Blob<3>, Blob<3>, _> = BTreeMap::init(btree.into_memory());
-    //     // Equal key size
-    //     let _btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(btree.into_memory());
-    // }
-    // btree_test!(test_, );
+    #[test]
+    fn accepts_small_or_equal_key_sizes() {
+        let mem = make_memory();
+        let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(mem);
+        // Smaller key size
+        let btree: BTreeMap<Blob<3>, Blob<3>, _> = BTreeMap::init(btree.into_memory());
+        // Equal key size
+        let _btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(btree.into_memory());
+    }
 
-    // #[should_panic(expected = "max_value_size must be <= 3")]
-    // fn v1_rejects_larger_value_sizes<K: TestKey, V: TestValue>() {
-    //     let mem = make_memory();
-    //     let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init_v1(mem);
-    //     let _btree: BTreeMap<Blob<4>, Blob<4>, _> = BTreeMap::init_v1(btree.into_memory());
-    // }
-    // btree_test!(test_, );
+    #[test]
+    #[should_panic(expected = "max_value_size must be <= 3")]
+    fn v1_rejects_larger_value_sizes() {
+        let mem = make_memory();
+        let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init_v1(mem);
+        let _btree: BTreeMap<Blob<4>, Blob<4>, _> = BTreeMap::init_v1(btree.into_memory());
+    }
 
-    // fn accepts_small_or_equal_value_sizes<K: TestKey, V: TestValue>() {
-    //     let mem = make_memory();
-    //     let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(mem);
-    //     // Smaller key size
-    //     let btree: BTreeMap<Blob<4>, Blob<2>, _> = BTreeMap::init(btree.into_memory());
-    //     // Equal key size
-    //     let _btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(btree.into_memory());
-    // }
-    // btree_test!(test_, );
+    #[test]
+    fn accepts_small_or_equal_value_sizes() {
+        let mem = make_memory();
+        let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(mem);
+        // Smaller key size
+        let btree: BTreeMap<Blob<4>, Blob<2>, _> = BTreeMap::init(btree.into_memory());
+        // Equal key size
+        let _btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(btree.into_memory());
+    }
 
-    // fn bruteforce_range_search<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut stable_map| {
-    //         use std::collections::BTreeMap;
-    //         const NKEYS: u64 = 60;
-    //         let mut std_map = BTreeMap::new();
+    fn bruteforce_range_search<K: TestKey, V: TestValue>() {
+        let (key, value) = (|i| K::make(i), |i| V::make(i));
 
-    //         for k in 0..NKEYS {
-    //             std_map.insert(k, k);
-    //             stable_map.insert(k, k);
-    //         }
+        fn collect_kv<'a, K: Clone + 'a, V: Clone + 'a>(
+            iter: impl Iterator<Item = (&'a K, &'a V)>,
+        ) -> Vec<(K, V)> {
+            iter.map(|(k, v)| (k.clone(), v.clone())).collect()
+        }
 
-    //         assert_eq!(
-    //             std_map.range(..).map(|(k, v)| (*k, *v)).collect::<Vec<_>>(),
-    //             stable_map.range(..).collect::<Vec<_>>()
-    //         );
+        fn collect<K: Clone, V: Clone>(it: impl Iterator<Item = (K, V)>) -> Vec<(K, V)> {
+            it.collect()
+        }
 
-    //         for l in 0..=NKEYS {
-    //             assert_eq!(
-    //                 std_map
-    //                     .range(l..)
-    //                     .map(|(k, v)| (*k, *v))
-    //                     .collect::<Vec<_>>(),
-    //                 stable_map.range(l..).collect::<Vec<_>>()
-    //             );
+        run_btree_test(|mut stable_map| {
+            use std::collections::BTreeMap;
+            const NKEYS: u32 = 60;
+            let mut std_map = BTreeMap::new();
 
-    //             assert_eq!(
-    //                 std_map
-    //                     .range(..l)
-    //                     .map(|(k, v)| (*k, *v))
-    //                     .collect::<Vec<_>>(),
-    //                 stable_map.range(..l).collect::<Vec<_>>()
-    //             );
+            for i in 0..NKEYS {
+                std_map.insert(key(i), value(i));
+                stable_map.insert(key(i), value(i));
+            }
 
-    //             assert_eq!(
-    //                 std_map
-    //                     .range(..=l)
-    //                     .map(|(k, v)| (*k, *v))
-    //                     .collect::<Vec<_>>(),
-    //                 stable_map.range(..=l).collect::<Vec<_>>()
-    //             );
+            assert_eq!(collect_kv(std_map.range(..)), collect(stable_map.range(..)));
 
-    //             for r in l + 1..=NKEYS {
-    //                 for lbound in [Bound::Included(l), Bound::Excluded(l)] {
-    //                     for rbound in [Bound::Included(r), Bound::Excluded(r)] {
-    //                         let range = (lbound, rbound);
-    //                         assert_eq!(
-    //                             std_map
-    //                                 .range(range)
-    //                                 .map(|(k, v)| (*k, *v))
-    //                                 .collect::<Vec<_>>(),
-    //                             stable_map.range(range).collect::<Vec<_>>(),
-    //                             "range: {range:?}"
-    //                         );
-    //                     }
-    //                 }
-    //             }
-    //         }
-    //     });
-    // }
-    // btree_test!(test_, );
+            for l in 0..=NKEYS {
+                assert_eq!(
+                    collect_kv(std_map.range(key(l)..)),
+                    collect(stable_map.range(key(l)..))
+                );
+
+                assert_eq!(
+                    collect_kv(std_map.range(..key(l))),
+                    collect(stable_map.range(..key(l)))
+                );
+
+                assert_eq!(
+                    collect_kv(std_map.range(..=key(l))),
+                    collect(stable_map.range(..=key(l)))
+                );
+
+                for r in l + 1..=NKEYS {
+                    for lbound in [Bound::Included(key(l)), Bound::Excluded(key(l))] {
+                        for rbound in [Bound::Included(key(r)), Bound::Excluded(key(r))] {
+                            let range = (lbound.clone(), rbound);
+                            assert_eq!(
+                                collect_kv(std_map.range(range.clone())),
+                                collect(stable_map.range(range.clone())),
+                                "range: {range:?}"
+                            );
+                        }
+                    }
+                }
+            }
+        });
+    }
+    btree_test!(test_bruteforce_range_search, bruteforce_range_search);
 
     // fn test_iter_upper_bound<K: TestKey, V: TestValue>() {
     //     run_btree_test(|mut btree| {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2503,10 +2503,10 @@ mod test {
     fn range_various_prefixes_with_offset_2<K: TestKey, V: TestValue>() {
         let (key, value) = (|i| K::make(i), |i| V::make(i));
         run_btree_test(|mut btree| {
-            btree.insert(key(01), value(0));
-            btree.insert(key(02), value(0));
-            btree.insert(key(03), value(0));
-            btree.insert(key(04), value(0));
+            btree.insert(key(1), value(0));
+            btree.insert(key(2), value(0));
+            btree.insert(key(3), value(0));
+            btree.insert(key(4), value(0));
             btree.insert(key(12), value(0));
             btree.insert(key(14), value(0));
             btree.insert(key(16), value(0));

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1160,7 +1160,6 @@ mod test {
         storable::{Blob, Bound as StorableBound, Storable},
         VectorMemory,
     };
-    use core::panic;
     use std::borrow::Cow;
     use std::cell::RefCell;
     use std::convert::TryFrom;
@@ -1204,19 +1203,6 @@ mod test {
         object.to_bytes_checked().into_owned()
     }
 
-    /// Decodes a byte vector into an object.
-    fn decode<T: Storable>(bytes: Vec<u8>) -> T {
-        T::from_bytes(Cow::Owned(bytes))
-    }
-
-    // // TODO: remove obsolete code.
-    // /// A helper method to succinctly create an entry.
-    // fn e(x: u8) -> (Blob<10>, Vec<u8>) {
-    //     (b(&[x]), vec![])
-    // }
-    // btree_test!(test_, );
-
-    // TODO: remove obsolete code.
     /// A helper method to succinctly create a blob.
     pub(crate) fn b(x: &[u8]) -> Blob<10> {
         Blob::<10>::try_from(x).unwrap()
@@ -1260,42 +1246,23 @@ mod test {
         }
     }
 
-    macro_rules! btree_test_body {
-        ($runner_fn:ident) => {{
-            // first key/value combo
-            {
-                type K = u32;
-                type V = Blob<20>;
-                verify_monotonic::<K>();
-                $runner_fn::<K, V>();
-            }
-            // second key/value combo
-            {
-                type K = Blob<10>;
-                type V = Blob<20>;
-                verify_monotonic::<K>();
-                $runner_fn::<K, V>();
-            }
-        }};
-    }
-
     /// Macro to apply a test function to a predefined grid of key/value types.
     macro_rules! btree_test {
         ($name:ident, $runner_fn:ident) => {
             #[test]
             fn $name() {
-                btree_test_body!($runner_fn);
-            }
-        };
-    }
-
-    /// Macro to apply a test function to a predefined grid of key/value types.
-    macro_rules! btree_test_ignored {
-        ($name:ident, $runner_fn:ident) => {
-            #[test]
-            #[ignore]
-            fn $name() {
-                btree_test_body!($runner_fn);
+                {
+                    type K = u32;
+                    type V = Blob<20>;
+                    verify_monotonic::<K>();
+                    $runner_fn::<K, V>();
+                }
+                {
+                    type K = Blob<10>;
+                    type V = Blob<20>;
+                    verify_monotonic::<K>();
+                    $runner_fn::<K, V>();
+                }
             }
         };
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1248,7 +1248,7 @@ mod test {
     }
 
     #[test]
-    fn insert_and_get() {
+    fn insert_get() {
         run_btree_test(|mut btree| {
             assert_eq!(btree.insert(k(1), v(20)), None);
             assert_eq!(btree.get(&k(1)), Some(v(20)));

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1735,318 +1735,331 @@ mod test {
     }
     btree_test!(test_remove_case_2a_and_2c, remove_case_2a_and_2c);
 
-    // #[test]
-    // fn remove_case_2b<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut btree| {
-    //         for i in 1..=11 {
-    //             assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-    //         }
-    //         // Should now split a node.
-    //         assert_eq!(btree.insert(b(&[12]), b(&[])), None);
+    fn remove_case_2b<K: TestKey, V: TestValue>() {
+        let (key, value) = (|i| K::make(i), |i| V::make(i));
+        let e = |i: u32| (key(i), encode(V::empty()));
+        run_btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(key(i), V::empty()), None);
+            }
+            // Should now split a node.
+            assert_eq!(btree.insert(key(12), V::empty()), None);
 
-    //         // The result should look like this:
-    //         //                [6]
-    //         //               /   \
-    //         // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-    //         for i in 1..=12 {
-    //             assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
-    //         }
+            for i in 1..=12 {
+                assert_eq!(btree.get(&key(i)), Some(V::empty()));
+            }
 
-    //         // Remove node 6. Triggers case 2.b
-    //         assert_eq!(btree.remove(&b(&[6])), Some(b(&[])));
+            // Remove node 6. Triggers case 2.b
+            assert_eq!(btree.remove(&key(6)), Some(V::empty()));
 
-    //         // The result should look like this:
-    //         //                [7]
-    //         //               /   \
-    //         // [1, 2, 3, 4, 5]   [8, 9, 10, 11, 12]
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Internal);
-    //         assert_eq!(root.entries(btree.memory()), vec![e(7)]);
-    //         assert_eq!(root.children_len(), 2);
+            // The result should look like this:
+            //                [7]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(7)]);
+            assert_eq!(root.children_len(), 2);
 
-    //         let child_0 = btree.load_node(root.child(0));
-    //         assert_eq!(child_0.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_0.entries(btree.memory()),
-    //             vec![e(1), e(2), e(3), e(4), e(5)]
-    //         );
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(1), e(2), e(3), e(4), e(5)]
+            );
 
-    //         let child_1 = btree.load_node(root.child(1));
-    //         assert_eq!(child_1.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_1.entries(btree.memory()),
-    //             vec![e(8), e(9), e(10), e(11), e(12)]
-    //         );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(8), e(9), e(10), e(11), e(12)]
+            );
 
-    //         // Remove node 7. Triggers case 2.c
-    //         assert_eq!(btree.remove(&b(&[7])), Some(b(&[])));
-    //         // The result should look like this:
-    //         //
-    //         // [1, 2, 3, 4, 5, 8, 9, 10, 11, 12]
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             root.entries(btree.memory()),
-    //             vec![
-    //                 e(1),
-    //                 e(2),
-    //                 e(3),
-    //                 e(4),
-    //                 e(5),
-    //                 e(8),
-    //                 e(9),
-    //                 e(10),
-    //                 e(11),
-    //                 e(12)
-    //             ]
-    //         );
-    //     });
-    // }
-    // btree_test!(test_, );
+            // Remove node 7. Triggers case 2.c
+            assert_eq!(btree.remove(&key(7)), Some(V::empty()));
+            // The result should look like this:
+            //
+            // [1, 2, 3, 4, 5, 8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Leaf);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![
+                    e(1),
+                    e(2),
+                    e(3),
+                    e(4),
+                    e(5),
+                    e(8),
+                    e(9),
+                    e(10),
+                    e(11),
+                    e(12)
+                ]
+            );
 
-    // #[test]
-    // fn remove_case_3a_right<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut btree| {
-    //         for i in 1..=11 {
-    //             assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-    //         }
+            assert_eq!(btree.allocator.num_allocated_chunks(), 1);
+        });
+    }
+    btree_test!(test_remove_case_2b, remove_case_2b);
 
-    //         // Should now split a node.
-    //         assert_eq!(btree.insert(b(&[12]), b(&[])), None);
+    fn remove_case_3a_right<K: TestKey, V: TestValue>() {
+        let (key, _value) = (|i| K::make(i), |i| V::make(i));
+        let e = |i: u32| (key(i), encode(V::empty()));
+        run_btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(key(i), V::empty()), None);
+            }
 
-    //         // The result should look like this:
-    //         //                [6]
-    //         //               /   \
-    //         // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
+            // Should now split a node.
+            assert_eq!(btree.insert(key(12), V::empty()), None);
 
-    //         // Remove node 3. Triggers case 3.a
-    //         assert_eq!(btree.remove(&b(&[3])), Some(b(&[])));
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-    //         // The result should look like this:
-    //         //                [7]
-    //         //               /   \
-    //         // [1, 2, 4, 5, 6]   [8, 9, 10, 11, 12]
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Internal);
-    //         assert_eq!(root.entries(btree.memory()), vec![e(7)]);
-    //         assert_eq!(root.children_len(), 2);
+            // Remove node 3. Triggers case 3.a
+            assert_eq!(btree.remove(&key(3)), Some(V::empty()));
 
-    //         let child_0 = btree.load_node(root.child(0));
-    //         assert_eq!(child_0.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_0.entries(btree.memory()),
-    //             vec![e(1), e(2), e(4), e(5), e(6)]
-    //         );
+            // The result should look like this:
+            //                [7]
+            //               /   \
+            // [1, 2, 4, 5, 6]   [8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(7)]);
+            assert_eq!(root.children_len(), 2);
 
-    //         let child_1 = btree.load_node(root.child(1));
-    //         assert_eq!(child_1.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_1.entries(btree.memory()),
-    //             vec![e(8), e(9), e(10), e(11), e(12)]
-    //         );
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(1), e(2), e(4), e(5), e(6)]
+            );
 
-    //         // There are three allocated nodes.
-    //         assert_eq!(btree.allocator.num_allocated_chunks(), 3);
-    //     });
-    // }
-    // btree_test!(test_, );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(8), e(9), e(10), e(11), e(12)]
+            );
 
-    // #[test]
-    // fn remove_case_3a_left<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut btree| {
-    //         for i in 1..=11 {
-    //             assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-    //         }
-    //         // Should now split a node.
-    //         assert_eq!(btree.insert(b(&[0]), b(&[])), None);
+            // There are three allocated nodes.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+        });
+    }
+    btree_test!(test_remove_case_3a_right, remove_case_3a_right);
 
-    //         // The result should look like this:
-    //         //                   [6]
-    //         //                  /   \
-    //         // [0, 1, 2, 3, 4, 5]   [7, 8, 9, 10, 11]
+    fn remove_case_3a_left<K: TestKey, V: TestValue>() {
+        let (key, _value) = (|i| K::make(i), |i| V::make(i));
+        let e = |i: u32| (key(i), encode(V::empty()));
+        run_btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(key(i), V::empty()), None);
+            }
+            // Should now split a node.
+            assert_eq!(btree.insert(key(0), V::empty()), None);
 
-    //         // Remove node 8. Triggers case 3.a left
-    //         assert_eq!(btree.remove(&b(&[8])), Some(b(&[])));
+            // The result should look like this:
+            //                   [6]
+            //                  /   \
+            // [0, 1, 2, 3, 4, 5]   [7, 8, 9, 10, 11]
 
-    //         // The result should look like this:
-    //         //                [5]
-    //         //               /   \
-    //         // [0, 1, 2, 3, 4]   [6, 7, 9, 10, 11]
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Internal);
-    //         assert_eq!(root.entries(btree.memory()), vec![e(5)]);
-    //         assert_eq!(root.children_len(), 2);
+            // Remove node 8. Triggers case 3.a left
+            assert_eq!(btree.remove(&key(8)), Some(V::empty()));
 
-    //         let child_0 = btree.load_node(root.child(0));
-    //         assert_eq!(child_0.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_0.entries(btree.memory()),
-    //             vec![e(0), e(1), e(2), e(3), e(4)]
-    //         );
+            // The result should look like this:
+            //                [5]
+            //               /   \
+            // [0, 1, 2, 3, 4]   [6, 7, 9, 10, 11]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(5)]);
+            assert_eq!(root.children_len(), 2);
 
-    //         let child_1 = btree.load_node(root.child(1));
-    //         assert_eq!(child_1.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_1.entries(btree.memory()),
-    //             vec![e(6), e(7), e(9), e(10), e(11)]
-    //         );
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(0), e(1), e(2), e(3), e(4)]
+            );
 
-    //         // There are three allocated nodes.
-    //         assert_eq!(btree.allocator.num_allocated_chunks(), 3);
-    //     });
-    // }
-    // btree_test!(test_, );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(6), e(7), e(9), e(10), e(11)]
+            );
 
-    // #[test]
-    // fn remove_case_3b_merge_into_right<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut btree| {
-    //         for i in 1..=11 {
-    //             assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-    //         }
-    //         // Should now split a node.
-    //         assert_eq!(btree.insert(b(&[12]), b(&[])), None);
+            // There are three allocated nodes.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+        });
+    }
+    btree_test!(test_remove_case_3a_left, remove_case_3a_left);
 
-    //         // The result should look like this:
-    //         //                [6]
-    //         //               /   \
-    //         // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
+    fn remove_case_3b_merge_into_right<K: TestKey, V: TestValue>() {
+        let (key, _value) = (|i| K::make(i), |i| V::make(i));
+        let e = |i: u32| (key(i), encode(V::empty()));
+        run_btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(key(i), V::empty()), None);
+            }
+            // Should now split a node.
+            assert_eq!(btree.insert(key(12), V::empty()), None);
 
-    //         for i in 1..=12 {
-    //             assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
-    //         }
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-    //         // Remove node 6. Triggers case 2.b
-    //         assert_eq!(btree.remove(&b(&[6])), Some(b(&[])));
-    //         // The result should look like this:
-    //         //                [7]
-    //         //               /   \
-    //         // [1, 2, 3, 4, 5]   [8, 9, 10, 11, 12]
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Internal);
-    //         assert_eq!(root.entries(btree.memory()), vec![e(7)]);
-    //         assert_eq!(root.children_len(), 2);
+            for i in 1..=12 {
+                assert_eq!(btree.get(&key(i)), Some(V::empty()));
+            }
 
-    //         let child_0 = btree.load_node(root.child(0));
-    //         assert_eq!(child_0.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_0.entries(btree.memory()),
-    //             vec![e(1), e(2), e(3), e(4), e(5)]
-    //         );
+            // Remove node 6. Triggers case 2.b
+            assert_eq!(btree.remove(&key(6)), Some(V::empty()));
+            // The result should look like this:
+            //                [7]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(7)]);
+            assert_eq!(root.children_len(), 2);
 
-    //         let child_1 = btree.load_node(root.child(1));
-    //         assert_eq!(child_1.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_1.entries(btree.memory()),
-    //             vec![e(8), e(9), e(10), e(11), e(12)]
-    //         );
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(1), e(2), e(3), e(4), e(5)]
+            );
 
-    //         // There are three allocated nodes.
-    //         assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(8), e(9), e(10), e(11), e(12)]
+            );
 
-    //         // Remove node 3. Triggers case 3.b
-    //         assert_eq!(btree.remove(&b(&[3])), Some(b(&[])));
+            // There are three allocated nodes.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 3);
 
-    //         // Reload the btree to verify that we saved it correctly.
-    //         let btree = BTreeMap::<Blob<10>, Blob<10>, _>::load(btree.into_memory());
+            // Remove node 3. Triggers case 3.b
+            assert_eq!(btree.remove(&key(3)), Some(V::empty()));
 
-    //         // The result should look like this:
-    //         //
-    //         // [1, 2, 4, 5, 7, 8, 9, 10, 11, 12]
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             root.entries(btree.memory()),
-    //             vec![
-    //                 e(1),
-    //                 e(2),
-    //                 e(4),
-    //                 e(5),
-    //                 e(7),
-    //                 e(8),
-    //                 e(9),
-    //                 e(10),
-    //                 e(11),
-    //                 e(12)
-    //             ]
-    //         );
+            // Reload the btree to verify that we saved it correctly.
+            let btree = BTreeMap::<K, V, _>::load(btree.into_memory());
 
-    //         // There is only one allocated node remaining.
-    //         assert_eq!(btree.allocator.num_allocated_chunks(), 1);
-    //     });
-    // }
-    // btree_test!(test_, );
+            // The result should look like this:
+            //
+            // [1, 2, 4, 5, 7, 8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Leaf);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![
+                    e(1),
+                    e(2),
+                    e(4),
+                    e(5),
+                    e(7),
+                    e(8),
+                    e(9),
+                    e(10),
+                    e(11),
+                    e(12)
+                ]
+            );
 
-    // #[test]
-    // fn remove_case_3b_merge_into_left<K: TestKey, V: TestValue>() {
-    //     let mem = make_memory();
-    //     let mut btree = BTreeMap::new(mem.clone());
+            // There is only one allocated node remaining.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 1);
+        });
+    }
+    btree_test!(
+        test_remove_case_3b_merge_into_right,
+        remove_case_3b_merge_into_right
+    );
 
-    //     for i in 1..=11 {
-    //         assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-    //     }
+    fn remove_case_3b_merge_into_left<K: TestKey, V: TestValue>() {
+        let (key, _value) = (|i| K::make(i), |i| V::make(i));
+        let e = |i: u32| (key(i), encode(V::empty()));
 
-    //     // Should now split a node.
-    //     assert_eq!(btree.insert(b(&[12]), b(&[])), None);
+        run_btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(key(i), V::empty()), None);
+            }
 
-    //     // The result should look like this:
-    //     //                [6]
-    //     //               /   \
-    //     // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
+            // Should now split a node.
+            assert_eq!(btree.insert(key(12), V::empty()), None);
 
-    //     for i in 1..=12 {
-    //         assert_eq!(btree.get(&b(&[i])), Some(b(&[])));
-    //     }
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-    //     // Remove node 6. Triggers case 2.b
-    //     assert_eq!(btree.remove(&b(&[6])), Some(b(&[])));
+            for i in 1..=12 {
+                assert_eq!(btree.get(&key(i)), Some(V::empty()));
+            }
 
-    //     // The result should look like this:
-    //     //                [7]
-    //     //               /   \
-    //     // [1, 2, 3, 4, 5]   [8, 9, 10, 11, 12]
-    //     let root = btree.load_node(btree.root_addr);
-    //     assert_eq!(root.node_type(), NodeType::Internal);
-    //     assert_eq!(root.entries(btree.memory()), vec![e(7)]);
-    //     assert_eq!(root.children_len(), 2);
+            // Remove node 6. Triggers case 2.b
+            assert_eq!(btree.remove(&key(6)), Some(V::empty()));
 
-    //     let child_0 = btree.load_node(root.child(0));
-    //     assert_eq!(child_0.node_type(), NodeType::Leaf);
-    //     assert_eq!(
-    //         child_0.entries(btree.memory()),
-    //         vec![e(1), e(2), e(3), e(4), e(5)]
-    //     );
+            // The result should look like this:
+            //                [7]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [8, 9, 10, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(root.entries(btree.memory()), vec![e(7)]);
+            assert_eq!(root.children_len(), 2);
 
-    //     let child_1 = btree.load_node(root.child(1));
-    //     assert_eq!(child_1.node_type(), NodeType::Leaf);
-    //     assert_eq!(
-    //         child_1.entries(btree.memory()),
-    //         vec![e(8), e(9), e(10), e(11), e(12)]
-    //     );
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![e(1), e(2), e(3), e(4), e(5)]
+            );
 
-    //     // There are three allocated nodes.
-    //     assert_eq!(btree.allocator.num_allocated_chunks(), 3);
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![e(8), e(9), e(10), e(11), e(12)]
+            );
 
-    //     // Remove node 10. Triggers case 3.b where we merge the right into the left.
-    //     assert_eq!(btree.remove(&b(&[10])), Some(b(&[])));
+            // There are three allocated nodes.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 3);
 
-    //     // Reload the btree to verify that we saved it correctly.
-    //     let btree = BTreeMap::<Blob<10>, Blob<10>, _>::load(mem);
+            // Remove node 10. Triggers case 3.b where we merge the right into the left.
+            assert_eq!(btree.remove(&key(10)), Some(V::empty()));
 
-    //     // The result should look like this:
-    //     //
-    //     // [1, 2, 3, 4, 5, 7, 8, 9, 11, 12]
-    //     let root = btree.load_node(btree.root_addr);
-    //     assert_eq!(root.node_type(), NodeType::Leaf);
-    //     assert_eq!(
-    //         root.entries(btree.memory()),
-    //         vec![e(1), e(2), e(3), e(4), e(5), e(7), e(8), e(9), e(11), e(12)]
-    //     );
+            // Reload the btree to verify that we saved it correctly.
+            let btree = BTreeMap::<K, V, _>::load(btree.into_memory());
 
-    //     // There is only one allocated node remaining.
-    //     assert_eq!(btree.allocator.num_allocated_chunks(), 1);
-    // }
-    // btree_test!(test_, );
+            // The result should look like this:
+            //
+            // [1, 2, 3, 4, 5, 7, 8, 9, 11, 12]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Leaf);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![e(1), e(2), e(3), e(4), e(5), e(7), e(8), e(9), e(11), e(12)]
+            );
+
+            // There is only one allocated node remaining.
+            assert_eq!(btree.allocator.num_allocated_chunks(), 1);
+        });
+    }
+    btree_test!(
+        test_remove_case_3b_merge_into_left,
+        remove_case_3b_merge_into_left
+    );
 
     // #[test]
     // fn many_insertions<K: TestKey, V: TestValue>() {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1322,23 +1322,37 @@ mod test {
         ($name:ident, $runner:ident) => {
             #[test]
             fn $name() {
-                // Set, empty value.
-                verify_and_run!($runner, u32, ());
-                verify_and_run!($runner, Blob<10>, ());
-                verify_and_run!($runner, MonotonicVec32, ());
-                verify_and_run!($runner, MonotonicString32, ());
+                use StorableBound::Unbounded;
+
+                // Set, empty value, bounded.
+                {
+                    type Value = ();
+                    assert_ne!(<Value>::BOUND, Unbounded, "Must be Bounded");
+                    verify_and_run!($runner, u32, Value);
+                    verify_and_run!($runner, Blob<10>, Value);
+                    verify_and_run!($runner, MonotonicVec32, Value);
+                    verify_and_run!($runner, MonotonicString32, Value);
+                }
 
                 // Map, bounded value.
-                verify_and_run!($runner, u32, u32);
-                verify_and_run!($runner, Blob<10>, u32);
-                verify_and_run!($runner, MonotonicVec32, u32);
-                verify_and_run!($runner, MonotonicString32, u32);
+                {
+                    type Value = u32;
+                    assert_ne!(Value::BOUND, Unbounded, "Must be Bounded");
+                    verify_and_run!($runner, u32, Value);
+                    verify_and_run!($runner, Blob<10>, Value);
+                    verify_and_run!($runner, MonotonicVec32, Value);
+                    verify_and_run!($runner, MonotonicString32, Value);
+                }
 
                 // Map, unbounded value.
-                verify_and_run!($runner, u32, MonotonicVec32);
-                verify_and_run!($runner, Blob<10>, MonotonicVec32);
-                verify_and_run!($runner, MonotonicVec32, MonotonicVec32);
-                verify_and_run!($runner, MonotonicString32, MonotonicVec32);
+                {
+                    type Value = MonotonicVec32;
+                    assert_eq!(Value::BOUND, Unbounded, "Must be Unbounded");
+                    verify_and_run!($runner, u32, Value);
+                    verify_and_run!($runner, Blob<10>, Value);
+                    verify_and_run!($runner, MonotonicVec32, Value);
+                    verify_and_run!($runner, MonotonicString32, Value);
+                }
             }
         };
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1298,7 +1298,7 @@ mod test {
 
     fn insert_get<K, V>()
     where
-        K: Storable + Ord + Clone + Make,
+        K: Storable + Ord + Clone + Make + std::fmt::Debug,
         V: Storable + Make + std::fmt::Debug + PartialEq,
     {
         run_btree_test(|mut btree| {
@@ -1311,7 +1311,7 @@ mod test {
 
     fn insert_overwrites_previous_value<K, V>()
     where
-        K: Storable + Ord + Clone + Make,
+        K: Storable + Ord + Clone + Make + std::fmt::Debug,
         V: Storable + Make + std::fmt::Debug + PartialEq,
     {
         run_btree_test(|mut btree| {
@@ -1328,7 +1328,7 @@ mod test {
 
     fn insert_get_multiple_entries<K, V>()
     where
-        K: Storable + Ord + Clone + Make,
+        K: Storable + Ord + Clone + Make + std::fmt::Debug,
         V: Storable + Make + std::fmt::Debug + PartialEq,
     {
         run_btree_test(|mut btree| {
@@ -1346,40 +1346,54 @@ mod test {
         insert_get_multiple_entries
     );
 
-    // #[test]
-    // fn insert_overwrite_median_key_in_full_child_node() {
-    //     run_btree_test(|mut btree| {
-    //         for i in 1..=17 {
-    //             assert_eq!(btree.insert(K::make(i), V::make(0)), None);
-    //         }
+    fn insert_overwrite_median_key_in_full_child_node<K, V>()
+    where
+        K: Storable + Ord + Clone + Make + std::fmt::Debug,
+        V: Storable + Make + std::fmt::Debug + PartialEq,
+    {
+        run_btree_test(|mut btree| {
+            for i in 1..=17 {
+                assert_eq!(btree.insert(K::make(i), V::default()), None);
+            }
 
-    //         // The result should look like this:
-    //         //                [6]
-    //         //               /   \
-    //         // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, (12), 13, 14, 15, 16, 17]
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, (12), 13, 14, 15, 16, 17]
 
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Internal);
-    //         assert_eq!(root.entries(btree.memory()), vec![(K::make(6), encode(V::make(0)))]);
-    //         assert_eq!(root.children_len(), 2);
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![(K::make(6), encode(V::default()))]
+            );
+            assert_eq!(root.children_len(), 2);
 
-    //         // The right child should now be full, with the median key being "12"
-    //         let right_child = btree.load_node(root.child(1));
-    //         assert!(right_child.is_full());
-    //         let median_index = right_child.entries_len() / 2;
-    //         let expected_median_key = K::make(12);
-    //         assert_eq!(right_child.key(median_index), &expected_median_key);
+            // The right child should now be full, with the median key being "12"
+            let right_child = btree.load_node(root.child(1));
+            assert!(right_child.is_full());
+            let median_index = right_child.entries_len() / 2;
+            let expected_median_key = K::make(12);
+            assert_eq!(right_child.key(median_index), &expected_median_key);
 
-    //         // Overwrite the value of the median key.
-    //         assert_eq!(btree.insert(expected_median_key, V::make(100)), Some(V::make(0)));
-    //         assert_eq!(btree.get(&expected_median_key), Some(V::make(100)));
+            // Overwrite the value of the median key.
+            assert_eq!(
+                btree.insert(expected_median_key.clone(), V::make(123)),
+                Some(V::default())
+            );
+            assert_eq!(btree.get(&expected_median_key), Some(V::make(123)));
 
-    //         // The child has not been split and is still full.
-    //         let right_child = btree.load_node(root.child(1));
-    //         assert_eq!(right_child.node_type(), NodeType::Leaf);
-    //         assert!(right_child.is_full());
-    //     });
-    // }
+            // The child has not been split and is still full.
+            let right_child = btree.load_node(root.child(1));
+            assert_eq!(right_child.node_type(), NodeType::Leaf);
+            assert!(right_child.is_full());
+        });
+    }
+
+    btree_test!(
+        test_insert_overwrite_median_key_in_full_child_node,
+        insert_overwrite_median_key_in_full_child_node
+    );
 
     // #[test]
     // fn insert_overwrite_key_in_full_root_node() {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1329,10 +1329,10 @@ mod test {
                 verify_and_run!($runner, MonotonicString32, ());
 
                 // Map, bounded value.
-                verify_and_run!($runner, u32, Blob<20>);
-                verify_and_run!($runner, Blob<10>, Blob<20>);
-                verify_and_run!($runner, MonotonicVec32, Blob<20>);
-                verify_and_run!($runner, MonotonicString32, Blob<20>);
+                verify_and_run!($runner, u32, u32);
+                verify_and_run!($runner, Blob<10>, u32);
+                verify_and_run!($runner, MonotonicVec32, u32);
+                verify_and_run!($runner, MonotonicString32, u32);
 
                 // Map, unbounded value.
                 verify_and_run!($runner, u32, MonotonicVec32);

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2220,9 +2220,9 @@ mod test {
             btree.insert(key(24), value(1_200));
 
             // The result should look like this:
-            //                [12]
-            //               /   \
-            // [1, 2, 3, 4, 11]   [13, 14, 21, 22, 23, 24]
+            //                 [12]
+            //                /    \
+            // [1, 2, 3, 4, 11]    [13, 14, 21, 22, 23, 24]
 
             let root = btree.load_node(btree.root_addr);
             assert_eq!(root.node_type(), NodeType::Internal);
@@ -2291,11 +2291,11 @@ mod test {
             btree.insert(key(29), value(1800));
 
             // The result should look like this:
-            //                  [14, 23]
-            //                 /    |   \
-            // [1, 2, 3, 4, 12]     |    [24, 25, 26, 27, 28, 29]
-            //                      |
-            //              [16, 18, 19, 21, 22]
+            //                 [14, 23]
+            //                /    |   \
+            // [1, 2, 3, 4, 12]    |   [24, 25, 26, 27, 28, 29]
+            //                     |
+            //           [16, 18, 19, 21, 22]
             let root = btree.load_node(btree.root_addr);
             assert_eq!(root.node_type(), NodeType::Internal);
             assert_eq!(
@@ -2444,9 +2444,9 @@ mod test {
             btree.insert(key(24), value(1200));
 
             // The result should look like this:
-            //                  [12]
-            //                 /    \
-            // [1, 2, 3, 4, 11]      [13, 14, 21, 22, 23, 24]
+            //                 [12]
+            //                /    \
+            // [1, 2, 3, 4, 11]    [13, 14, 21, 22, 23, 24]
 
             let root = btree.load_node(btree.root_addr);
             assert_eq!(root.node_type(), NodeType::Internal);
@@ -2504,11 +2504,11 @@ mod test {
             btree.insert(key(29), value(0));
 
             // The result should look like this:
-            //                  [14, 23]
-            //                 /    |   \
-            // [1, 2, 3, 4, 12]     |    [24, 25, 26, 27, 28, 29]
-            //                      |
-            //            [16, 18, 19, 21, 22]
+            //                 [14, 23]
+            //                /    |   \
+            // [1, 2, 3, 4, 12]    |   [24, 25, 26, 27, 28, 29]
+            //                     |
+            //           [16, 18, 19, 21, 22]
             let root = btree.load_node(btree.root_addr);
             assert_eq!(root.node_type(), NodeType::Internal);
             assert_eq!(

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1189,18 +1189,12 @@ mod test {
     }
 
     /// Encodes an object into a byte vector.
-    fn encode<T>(object: T) -> Vec<u8>
-    where
-        T: Storable,
-    {
+    fn encode<T: Storable>(object: T) -> Vec<u8> {
         object.to_bytes_checked().into_owned()
     }
 
     /// Decodes a byte vector into an object.
-    fn decode<T>(bytes: Vec<u8>) -> T
-    where
-        T: Storable,
-    {
+    fn decode<T: Storable>(bytes: Vec<u8>) -> T {
         T::from_bytes(Cow::Owned(bytes))
     }
 

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1165,7 +1165,7 @@ mod test {
     use std::rc::Rc;
 
     /// Returns a fixed‑size buffer for the given u32.
-    fn make_buffer<const N: usize>(i: u32) -> [u8; N] {
+    fn make_monotonic_buffer<const N: usize>(i: u32) -> [u8; N] {
         let mut buf = [0u8; N];
         let bytes = i.to_be_bytes();
         buf[N - bytes.len()..].copy_from_slice(&bytes);
@@ -1189,7 +1189,7 @@ mod test {
 
     impl<const N: usize> Make for Blob<N> {
         fn make(i: u32) -> Self {
-            Blob::try_from(&make_buffer::<N>(i)[..]).unwrap()
+            Blob::try_from(&make_monotonic_buffer::<N>(i)[..]).unwrap()
         }
         fn empty() -> Self {
             let x: &[u8] = &[];

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2711,27 +2711,28 @@ mod test {
     }
     btree_test!(test_bruteforce_range_search, bruteforce_range_search);
 
-    // fn test_iter_upper_bound<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut btree| {
-    //         for k in 0..100u64 {
-    //             btree.insert(k, ());
-    //             for i in 0..=k {
-    //                 assert_eq!(
-    //                     Some((i, ())),
-    //                     btree.iter_upper_bound(&(i + 1)).next(),
-    //                     "failed to get an upper bound for key {}",
-    //                     i + 1
-    //                 );
-    //             }
-    //             assert_eq!(
-    //                 None,
-    //                 btree.iter_upper_bound(&0).next(),
-    //                 "key 0 must not have an upper bound"
-    //             );
-    //         }
-    //     });
-    // }
-    // btree_test!(test_, );
+    fn test_iter_upper_bound<K: TestKey, V: TestValue>() {
+        let (key, value) = (|i| K::make(i), |i| V::make(i));
+        run_btree_test(|mut btree| {
+            for j in 0..100 {
+                btree.insert(key(j), value(j));
+                for i in 0..=j {
+                    assert_eq!(
+                        btree.iter_upper_bound(&key(i + 1)).next(),
+                        Some((key(i), value(i))),
+                        "failed to get an upper bound for key({})",
+                        i + 1
+                    );
+                }
+                assert_eq!(
+                    btree.iter_upper_bound(&key(0)).next(),
+                    None,
+                    "key(0) must not have an upper bound"
+                );
+            }
+        });
+    }
+    btree_test!(test_test_iter_upper_bound, test_iter_upper_bound);
 
     // // A buggy implementation of storable where the max_size is smaller than the serialized size.
     // #[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2135,22 +2135,21 @@ mod test {
     }
     btree_test!(test_len, len);
 
-    // #[test]
-    // fn contains_key<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut btree| {
-    //         // Insert even numbers from 0 to 1000.
-    //         for i in (0..1000u32).step_by(2) {
-    //             assert_eq!(btree.insert(b(&i.to_le_bytes()), b(&[])), None);
-    //         }
+    fn contains_key<K: TestKey, V: TestValue>() {
+        let (key, value) = (|i| K::make(i), |i| V::make(i));
+        run_btree_test(|mut btree| {
+            let n = 1_000;
+            for i in (0..n).step_by(2) {
+                assert_eq!(btree.insert(key(i), value(i)), None);
+            }
 
-    //         // Contains key should return true on all the even numbers and false on all the odd
-    //         // numbers.
-    //         for i in 0..1000u32 {
-    //             assert_eq!(btree.contains_key(&b(&i.to_le_bytes())), i % 2 == 0);
-    //         }
-    //     });
-    // }
-    // btree_test!(test_, );
+            // Only even keys should be present.
+            for i in 0..n {
+                assert_eq!(btree.contains_key(&key(i)), i % 2 == 0);
+            }
+        });
+    }
+    btree_test!(test_contains_key, contains_key);
 
     // #[test]
     // fn range_empty<K: TestKey, V: TestValue>() {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1183,17 +1183,25 @@ mod test {
     /// A trait to construct a value from a u32.
     trait Make {
         fn make(i: u32) -> Self;
+        fn default() -> Self;
     }
 
     impl Make for u32 {
         fn make(i: u32) -> Self {
             i
         }
+        fn default() -> Self {
+            0
+        }
     }
 
     impl<const N: usize> Make for Blob<N> {
         fn make(i: u32) -> Self {
             Blob::try_from(&make_buffer::<N>(i)[..]).unwrap()
+        }
+        fn default() -> Self {
+            let x: &[u8] = &[];
+            Blob::try_from(x).unwrap()
         }
     }
 
@@ -1318,17 +1326,25 @@ mod test {
         insert_overwrites_previous_value
     );
 
-    // #[test]
-    // fn insert_get_multiple_entries() {
-    //     run_btree_test(|mut btree| {
-    //         assert_eq!(btree.insert(K::make(1), V::make(10)), None);
-    //         assert_eq!(btree.insert(K::make(2), V::make(20)), None);
-    //         assert_eq!(btree.insert(b(&[]), V::make(30)), None);
-    //         assert_eq!(btree.get(&K::make(1)), Some(V::make(10)));
-    //         assert_eq!(btree.get(&K::make(2)), Some(V::make(20)));
-    //         assert_eq!(btree.get(&b(&[])), Some(V::make(30)));
-    //     });
-    // }
+    fn insert_get_multiple_entries<K, V>()
+    where
+        K: Storable + Ord + Clone + Make,
+        V: Storable + Make + std::fmt::Debug + PartialEq,
+    {
+        run_btree_test(|mut btree| {
+            assert_eq!(btree.insert(K::make(1), V::make(10)), None);
+            assert_eq!(btree.insert(K::make(2), V::make(20)), None);
+            assert_eq!(btree.insert(K::default(), V::make(30)), None);
+            assert_eq!(btree.get(&K::make(1)), Some(V::make(10)));
+            assert_eq!(btree.get(&K::make(2)), Some(V::make(20)));
+            assert_eq!(btree.get(&K::default()), Some(V::make(30)));
+        });
+    }
+
+    btree_test!(
+        test_insert_get_multiple_entries,
+        insert_get_multiple_entries
+    );
 
     // #[test]
     // fn insert_overwrite_median_key_in_full_child_node() {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1157,7 +1157,7 @@ where
 mod test {
     use super::*;
     use crate::{
-        storable::{Blob, Bound as StorableBound, Storable},
+        storable::{Blob, Bound as StorableBound},
         VectorMemory,
     };
     use std::cell::RefCell;

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1220,7 +1220,7 @@ mod test {
     }
 
     #[test]
-    fn test_init_preserves_data() {
+    fn init_preserves_data() {
         run_btree_test(|mut btree| {
             assert_eq!(btree.insert(k(1), v(2)), None);
             assert_eq!(btree.get(&k(1)), Some(v(2)));
@@ -1232,7 +1232,7 @@ mod test {
     }
 
     #[test]
-    fn test_insert_and_get() {
+    fn insert_and_get() {
         run_btree_test(|mut btree| {
             assert_eq!(btree.insert(k(1), v(2)), None);
             assert_eq!(btree.get(&k(1)), Some(v(2)));
@@ -1240,7 +1240,7 @@ mod test {
     }
 
     #[test]
-    fn test_insert_overwrites_previous_value() {
+    fn insert_overwrites_previous_value() {
         run_btree_test(|mut btree| {
             assert_eq!(btree.insert(k(1), v(2)), None);
             assert_eq!(btree.insert(k(1), v(3)), Some(v(2)));
@@ -1249,7 +1249,7 @@ mod test {
     }
 
     #[test]
-    fn test_insert_get_multiple_entries() {
+    fn insert_get_multiple_entries() {
         run_btree_test(|mut btree| {
             assert_eq!(btree.insert(k(1), v(10)), None);
             assert_eq!(btree.insert(k(2), v(20)), None);

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1185,6 +1185,22 @@ mod test {
         Blob::<10>::try_from(&make_buffer::<10>(i)[..]).unwrap()
     }
 
+    /// Encodes an object into a byte vector.
+    fn encode<T>(object: T) -> Vec<u8>
+    where
+        T: Storable,
+    {
+        object.to_bytes_checked().into_owned()
+    }
+
+    /// Decodes a byte vector into an object.
+    fn decode<T>(bytes: Vec<u8>) -> T
+    where
+        T: Storable,
+    {
+        T::from_bytes(Cow::Owned(bytes))
+    }
+
     /// A helper method to succinctly create an entry.
     fn e(x: u8) -> (Blob<10>, Vec<u8>) {
         (b(&[x]), vec![])
@@ -1274,10 +1290,7 @@ mod test {
 
             let root = btree.load_node(btree.root_addr);
             assert_eq!(root.node_type(), NodeType::Internal);
-            assert_eq!(
-                root.entries(btree.memory()),
-                vec![(k(6), v(0).as_slice().to_vec())]
-            );
+            assert_eq!(root.entries(btree.memory()), vec![(k(6), encode(v(0)))]);
             assert_eq!(root.children_len(), 2);
 
             // The right child should now be full, with the median key being "12"

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2427,54 +2427,61 @@ mod test {
     }
     btree_test!(test_range_large, range_large);
 
-    // fn range_various_prefixes_with_offset() {
-    //     run_btree_test(|mut btree| {
-    //         btree.insert(b(&[0, 1]), b(&[]));
-    //         btree.insert(b(&[0, 2]), b(&[]));
-    //         btree.insert(b(&[0, 3]), b(&[]));
-    //         btree.insert(b(&[0, 4]), b(&[]));
-    //         btree.insert(b(&[1, 1]), b(&[]));
-    //         btree.insert(b(&[1, 2]), b(&[]));
-    //         btree.insert(b(&[1, 3]), b(&[]));
-    //         btree.insert(b(&[1, 4]), b(&[]));
-    //         btree.insert(b(&[2, 1]), b(&[]));
-    //         btree.insert(b(&[2, 2]), b(&[]));
-    //         btree.insert(b(&[2, 3]), b(&[]));
-    //         btree.insert(b(&[2, 4]), b(&[]));
+    fn range_various_prefixes_with_offset<K: TestKey, V: TestValue>() {
+        let (key, value) = (|i| K::make(i), |i| V::make(i));
+        run_btree_test(|mut btree| {
+            btree.insert(key(1), value(100));
+            btree.insert(key(2), value(200));
+            btree.insert(key(3), value(300));
+            btree.insert(key(4), value(400));
+            btree.insert(key(11), value(500));
+            btree.insert(key(12), value(600));
+            btree.insert(key(13), value(700));
+            btree.insert(key(14), value(800));
+            btree.insert(key(21), value(900));
+            btree.insert(key(22), value(1000));
+            btree.insert(key(23), value(1100));
+            btree.insert(key(24), value(1200));
 
-    //         // The result should look like this:
-    //         //                                         [(1, 2)]
-    //         //                                         /     \
-    //         // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 1)]       [(1, 3), (1, 4), (2, 1), (2, 2), (2, 3), (2, 4)]
+            // The result should look like this:
+            //                  [12]
+            //                 /    \
+            // [1, 2, 3, 4, 11]      [13, 14, 21, 22, 23, 24]
 
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Internal);
-    //         assert_eq!(root.entries(btree.memory()), vec![(b(&[1, 2]), vec![])]);
-    //         assert_eq!(root.children_len(), 2);
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![(key(12), encode(value(600)))]
+            );
+            assert_eq!(root.children_len(), 2);
 
-    //         assert_eq!(
-    //             btree.range(b(&[0])..b(&[1])).collect::<Vec<_>>(),
-    //             vec![
-    //                 (b(&[0, 1]), b(&[])),
-    //                 (b(&[0, 2]), b(&[])),
-    //                 (b(&[0, 3]), b(&[])),
-    //                 (b(&[0, 4]), b(&[])),
-    //             ]
-    //         );
+            assert_eq!(
+                btree.range(key(0)..key(10)).collect::<Vec<_>>(),
+                vec![
+                    (key(1), value(100)),
+                    (key(2), value(200)),
+                    (key(3), value(300)),
+                    (key(4), value(400)),
+                ]
+            );
 
-    //         // Tests an offset that has a keys somewhere in the range of keys of an internal node.
-    //         assert_eq!(
-    //             btree.range(b(&[1, 3])..b(&[2])).collect::<Vec<_>>(),
-    //             vec![(b(&[1, 3]), b(&[])), (b(&[1, 4]), b(&[])),]
-    //         );
+            // Tests an offset that has a keys somewhere in the range of keys of an internal node.
+            assert_eq!(
+                btree.range(key(13)..key(20)).collect::<Vec<_>>(),
+                vec![(key(13), value(700)), (key(14), value(800))]
+            );
 
-    //         // Tests an offset that's larger than the key in the internal node.
-    //         assert_eq!(btree.range(b(&[2, 5])..).collect::<Vec<_>>(), vec![]);
-    //     });
-    // }
-    // btree_test!(test_, );
+            // Tests an offset that's larger than the key in the internal node.
+            assert_eq!(btree.range(key(25)..).collect::<Vec<_>>(), vec![]);
+        });
+    }
+    btree_test!(
+        test_range_various_prefixes_with_offset,
+        range_various_prefixes_with_offset
+    );
 
-    // fn range_various_prefixes_with_offset_2() {
+    // fn range_various_prefixes_with_offset_2<K: TestKey, V: TestValue>() {
     //     run_btree_test(|mut btree| {
     //         btree.insert(b(&[0, 1]), b(&[]));
     //         btree.insert(b(&[0, 2]), b(&[]));
@@ -2579,14 +2586,14 @@ mod test {
     // btree_test!(test_, );
 
     // #[should_panic(expected = "max_key_size must be <= 4")]
-    // fn v1_rejects_increases_in_max_key_size() {
+    // fn v1_rejects_increases_in_max_key_size<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init_v1(mem);
     //     let _btree: BTreeMap<Blob<5>, Blob<3>, _> = BTreeMap::init_v1(btree.into_memory());
     // }
     // btree_test!(test_, );
 
-    // fn v2_handles_increases_in_max_key_size_and_max_value_size() {
+    // fn v2_handles_increases_in_max_key_size_and_max_value_size<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<Blob<4>, Blob<4>, _> = BTreeMap::init(mem);
     //     btree.insert(
@@ -2614,7 +2621,7 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // fn accepts_small_or_equal_key_sizes() {
+    // fn accepts_small_or_equal_key_sizes<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(mem);
     //     // Smaller key size
@@ -2625,14 +2632,14 @@ mod test {
     // btree_test!(test_, );
 
     // #[should_panic(expected = "max_value_size must be <= 3")]
-    // fn v1_rejects_larger_value_sizes() {
+    // fn v1_rejects_larger_value_sizes<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init_v1(mem);
     //     let _btree: BTreeMap<Blob<4>, Blob<4>, _> = BTreeMap::init_v1(btree.into_memory());
     // }
     // btree_test!(test_, );
 
-    // fn accepts_small_or_equal_value_sizes() {
+    // fn accepts_small_or_equal_value_sizes<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(mem);
     //     // Smaller key size
@@ -2642,7 +2649,7 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // fn bruteforce_range_search() {
+    // fn bruteforce_range_search<K: TestKey, V: TestValue>() {
     //     run_btree_test(|mut stable_map| {
     //         use std::collections::BTreeMap;
     //         const NKEYS: u64 = 60;
@@ -2703,7 +2710,7 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // fn test_iter_upper_bound() {
+    // fn test_iter_upper_bound<K: TestKey, V: TestValue>() {
     //     run_btree_test(|mut btree| {
     //         for k in 0..100u64 {
     //             btree.insert(k, ());
@@ -2745,28 +2752,28 @@ mod test {
     // btree_test!(test_, );
 
     // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
-    // fn v1_panics_if_key_is_bigger_than_max_size() {
+    // fn v1_panics_if_key_is_bigger_than_max_size<K: TestKey, V: TestValue>() {
     //     let mut btree = BTreeMap::init_v1(make_memory());
     //     btree.insert(BuggyStruct, ());
     // }
     // btree_test!(test_, );
 
     // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
-    // fn v2_panics_if_key_is_bigger_than_max_size() {
+    // fn v2_panics_if_key_is_bigger_than_max_size<K: TestKey, V: TestValue>() {
     //     let mut btree = BTreeMap::init(make_memory());
     //     btree.insert(BuggyStruct, ());
     // }
     // btree_test!(test_, );
 
     // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
-    // fn v1_panics_if_value_is_bigger_than_max_size() {
+    // fn v1_panics_if_value_is_bigger_than_max_size<K: TestKey, V: TestValue>() {
     //     let mut btree = BTreeMap::init(make_memory());
     //     btree.insert((), BuggyStruct);
     // }
     // btree_test!(test_, );
 
     // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
-    // fn v2_panics_if_value_is_bigger_than_max_size() {
+    // fn v2_panics_if_value_is_bigger_than_max_size<K: TestKey, V: TestValue>() {
     //     let mut btree = BTreeMap::init(make_memory());
     //     btree.insert((), BuggyStruct);
     // }
@@ -2775,7 +2782,7 @@ mod test {
     // // To generate the memory dump file for the current version:
     // //   cargo test create_btreemap_dump_file -- --include-ignored
     // #[ignore]
-    // fn create_btreemap_dump_file() {
+    // fn create_btreemap_dump_file<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let mut btree = BTreeMap::init_v1(mem.clone());
     //     assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
@@ -2788,7 +2795,7 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // fn produces_layout_identical_to_layout_version_1_with_packed_headers() {
+    // fn produces_layout_identical_to_layout_version_1_with_packed_headers<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let mut btree = BTreeMap::init_v1(mem.clone());
     //     assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
@@ -2799,7 +2806,7 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // fn read_write_header_is_identical_to_read_write_struct() {
+    // fn read_write_header_is_identical_to_read_write_struct<K: TestKey, V: TestValue>() {
     //     #[repr(C, packed)]
     //     struct BTreePackedHeader {
     //         magic: [u8; 3],
@@ -2857,7 +2864,7 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // fn migrate_from_bounded_to_unbounded_and_back() {
+    // fn migrate_from_bounded_to_unbounded_and_back<K: TestKey, V: TestValue>() {
     //     // A type that is bounded.
     //     #[derive(PartialOrd, Ord, Clone, Eq, PartialEq, Debug)]
     //     struct T;
@@ -2912,7 +2919,7 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // fn test_clear_new_bounded_type() {
+    // fn test_clear_new_bounded_type<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<Blob<4>, Blob<4>, _> = BTreeMap::new(mem.clone());
 
@@ -2937,7 +2944,7 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // fn test_clear_new_unbounded_type() {
+    // fn test_clear_new_unbounded_type<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<String, String, _> = BTreeMap::new(mem.clone());
     //     btree.insert("asd".into(), "bce".into());
@@ -2958,7 +2965,7 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // fn deallocating_node_with_overflows() {
+    // fn deallocating_node_with_overflows<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<Vec<u8>, Vec<u8>, _> = BTreeMap::new(mem.clone());
 
@@ -2978,7 +2985,7 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // fn repeatedly_deallocating_nodes_with_overflows() {
+    // fn repeatedly_deallocating_nodes_with_overflows<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<Vec<u8>, Vec<u8>, _> = BTreeMap::new(mem.clone());
 
@@ -3000,7 +3007,7 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // fn deallocating_root_does_not_leak_memory() {
+    // fn deallocating_root_does_not_leak_memory<K: TestKey, V: TestValue>() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<Vec<u8>, _, _> = BTreeMap::new(mem.clone());
 

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2291,10 +2291,10 @@ mod test {
             btree.insert(key(29), value(1800));
 
             // The result should look like this:
-            //                    [14, 23]
-            //                 /      |     \
-            // [1, 2, 3, 4, 12]       |      [24, 25, 26, 27, 28, 29]
-            //                        |
+            //                  [14, 23]
+            //                 /    |   \
+            // [1, 2, 3, 4, 12]     |    [24, 25, 26, 27, 28, 29]
+            //                      |
             //              [16, 18, 19, 21, 22]
             let root = btree.load_node(btree.root_addr);
             assert_eq!(root.node_type(), NodeType::Internal);
@@ -2481,109 +2481,113 @@ mod test {
         range_various_prefixes_with_offset
     );
 
-    // fn range_various_prefixes_with_offset_2<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut btree| {
-    //         btree.insert(b(&[0, 1]), b(&[]));
-    //         btree.insert(b(&[0, 2]), b(&[]));
-    //         btree.insert(b(&[0, 3]), b(&[]));
-    //         btree.insert(b(&[0, 4]), b(&[]));
-    //         btree.insert(b(&[1, 2]), b(&[]));
-    //         btree.insert(b(&[1, 4]), b(&[]));
-    //         btree.insert(b(&[1, 6]), b(&[]));
-    //         btree.insert(b(&[1, 8]), b(&[]));
-    //         btree.insert(b(&[1, 10]), b(&[]));
-    //         btree.insert(b(&[2, 1]), b(&[]));
-    //         btree.insert(b(&[2, 2]), b(&[]));
-    //         btree.insert(b(&[2, 3]), b(&[]));
-    //         btree.insert(b(&[2, 4]), b(&[]));
-    //         btree.insert(b(&[2, 5]), b(&[]));
-    //         btree.insert(b(&[2, 6]), b(&[]));
-    //         btree.insert(b(&[2, 7]), b(&[]));
-    //         btree.insert(b(&[2, 8]), b(&[]));
-    //         btree.insert(b(&[2, 9]), b(&[]));
+    fn range_various_prefixes_with_offset_2<K: TestKey, V: TestValue>() {
+        let (key, value) = (|i| K::make(i), |i| V::make(i));
+        run_btree_test(|mut btree| {
+            btree.insert(key(01), value(0));
+            btree.insert(key(02), value(0));
+            btree.insert(key(03), value(0));
+            btree.insert(key(04), value(0));
+            btree.insert(key(12), value(0));
+            btree.insert(key(14), value(0));
+            btree.insert(key(16), value(0));
+            btree.insert(key(18), value(0));
+            btree.insert(key(19), value(0));
+            btree.insert(key(21), value(0));
+            btree.insert(key(22), value(0));
+            btree.insert(key(23), value(0));
+            btree.insert(key(24), value(0));
+            btree.insert(key(25), value(0));
+            btree.insert(key(26), value(0));
+            btree.insert(key(27), value(0));
+            btree.insert(key(28), value(0));
+            btree.insert(key(29), value(0));
 
-    //         // The result should look like this:
-    //         //                                         [(1, 4), (2, 3)]
-    //         //                                         /      |       \
-    //         // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2)]       |        [(2, 4), (2, 5), (2, 6), (2, 7), (2, 8), (2, 9)]
-    //         //                                                |
-    //         //                             [(1, 6), (1, 8), (1, 10), (2, 1), (2, 2)]
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Internal);
-    //         assert_eq!(
-    //             root.entries(btree.memory()),
-    //             vec![(b(&[1, 4]), vec![]), (b(&[2, 3]), vec![])]
-    //         );
-    //         assert_eq!(root.children_len(), 3);
+            // The result should look like this:
+            //                  [14, 23]
+            //                 /    |   \
+            // [1, 2, 3, 4, 12]     |    [24, 25, 26, 27, 28, 29]
+            //                      |
+            //            [16, 18, 19, 21, 22]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![(key(14), encode(value(0))), (key(23), encode(value(0)))]
+            );
+            assert_eq!(root.children_len(), 3);
 
-    //         let child_0 = btree.load_node(root.child(0));
-    //         assert_eq!(child_0.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_0.entries(btree.memory()),
-    //             vec![
-    //                 (b(&[0, 1]), vec![]),
-    //                 (b(&[0, 2]), vec![]),
-    //                 (b(&[0, 3]), vec![]),
-    //                 (b(&[0, 4]), vec![]),
-    //                 (b(&[1, 2]), vec![]),
-    //             ]
-    //         );
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![
+                    (key(1), encode(value(0))),
+                    (key(2), encode(value(0))),
+                    (key(3), encode(value(0))),
+                    (key(4), encode(value(0))),
+                    (key(12), encode(value(0))),
+                ]
+            );
 
-    //         let child_1 = btree.load_node(root.child(1));
-    //         assert_eq!(child_1.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_1.entries(btree.memory()),
-    //             vec![
-    //                 (b(&[1, 6]), vec![]),
-    //                 (b(&[1, 8]), vec![]),
-    //                 (b(&[1, 10]), vec![]),
-    //                 (b(&[2, 1]), vec![]),
-    //                 (b(&[2, 2]), vec![]),
-    //             ]
-    //         );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![
+                    (key(16), encode(value(0))),
+                    (key(18), encode(value(0))),
+                    (key(19), encode(value(0))),
+                    (key(21), encode(value(0))),
+                    (key(22), encode(value(0))),
+                ]
+            );
 
-    //         let child_2 = btree.load_node(root.child(2));
-    //         assert_eq!(
-    //             child_2.entries(btree.memory()),
-    //             vec![
-    //                 (b(&[2, 4]), vec![]),
-    //                 (b(&[2, 5]), vec![]),
-    //                 (b(&[2, 6]), vec![]),
-    //                 (b(&[2, 7]), vec![]),
-    //                 (b(&[2, 8]), vec![]),
-    //                 (b(&[2, 9]), vec![]),
-    //             ]
-    //         );
+            let child_2 = btree.load_node(root.child(2));
+            assert_eq!(
+                child_2.entries(btree.memory()),
+                vec![
+                    (key(24), encode(value(0))),
+                    (key(25), encode(value(0))),
+                    (key(26), encode(value(0))),
+                    (key(27), encode(value(0))),
+                    (key(28), encode(value(0))),
+                    (key(29), encode(value(0))),
+                ]
+            );
 
-    //         // Tests a offset that crosses several nodes.
-    //         assert_eq!(
-    //             btree.range(b(&[1, 4])..b(&[2])).collect::<Vec<_>>(),
-    //             vec![
-    //                 (b(&[1, 4]), b(&[])),
-    //                 (b(&[1, 6]), b(&[])),
-    //                 (b(&[1, 8]), b(&[])),
-    //                 (b(&[1, 10]), b(&[])),
-    //             ]
-    //         );
+            // Tests a offset that crosses several nodes.
+            assert_eq!(
+                btree.range(key(14)..key(20)).collect::<Vec<_>>(),
+                vec![
+                    (key(14), value(0)),
+                    (key(16), value(0)),
+                    (key(18), value(0)),
+                    (key(19), value(0)),
+                ]
+            );
 
-    //         // Tests a offset that starts from a leaf node, then iterates through the root and right
-    //         // sibling.
-    //         assert_eq!(
-    //             btree.range(b(&[2, 2])..b(&[3])).collect::<Vec<_>>(),
-    //             vec![
-    //                 (b(&[2, 2]), b(&[])),
-    //                 (b(&[2, 3]), b(&[])),
-    //                 (b(&[2, 4]), b(&[])),
-    //                 (b(&[2, 5]), b(&[])),
-    //                 (b(&[2, 6]), b(&[])),
-    //                 (b(&[2, 7]), b(&[])),
-    //                 (b(&[2, 8]), b(&[])),
-    //                 (b(&[2, 9]), b(&[])),
-    //             ]
-    //         );
-    //     });
-    // }
-    // btree_test!(test_, );
+            // Tests a offset that starts from a leaf node, then iterates through the root and right
+            // sibling.
+            assert_eq!(
+                btree.range(key(22)..key(30)).collect::<Vec<_>>(),
+                vec![
+                    (key(22), value(0)),
+                    (key(23), value(0)),
+                    (key(24), value(0)),
+                    (key(25), value(0)),
+                    (key(26), value(0)),
+                    (key(27), value(0)),
+                    (key(28), value(0)),
+                    (key(29), value(0)),
+                ]
+            );
+        });
+    }
+    btree_test!(
+        test_range_various_prefixes_with_offset_2,
+        range_various_prefixes_with_offset_2
+    );
 
     // #[should_panic(expected = "max_key_size must be <= 4")]
     // fn v1_rejects_increases_in_max_key_size<K: TestKey, V: TestValue>() {

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1180,12 +1180,12 @@ mod test {
 
     /// Creates a key from a u32.
     fn k(i: u32) -> Key {
-        Blob::<10>::try_from(&make_buffer::<10>(i)[..]).unwrap()
+        Key::try_from(&make_buffer::<10>(i)[..]).unwrap()
     }
 
     /// Creates a value from a u32.
     fn v(i: u32) -> Value {
-        Blob::<20>::try_from(&make_buffer::<20>(i)[..]).unwrap()
+        Value::try_from(&make_buffer::<20>(i)[..]).unwrap()
     }
 
     /// Encodes an object into a byte vector.

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1260,21 +1260,23 @@ mod test {
         f(tree_v2);
     }
 
-    /// Macro that verifies the monotonicity for a given key type and then runs the test function.
-    macro_rules! verify_and_run {
-        ($Key:ty, $Value:ty, $runner_fn:ident) => {{
-            verify_monotonic_keys::<$Key>();
-            $runner_fn::<$Key, $Value>();
-        }};
-    }
-
     /// Macro to apply a test function to a predefined grid of key/value types.
     macro_rules! btree_test {
         ($name:ident, $runner_fn:ident) => {
             #[test]
             fn $name() {
-                verify_and_run!(u32, Blob<20>, $runner_fn);
-                verify_and_run!(Blob<10>, Blob<20>, $runner_fn);
+                {
+                    type K = u32;
+                    type V = Blob<20>;
+                    verify_monotonic_keys::<K>();
+                    $runner_fn::<K, V>();
+                }
+                {
+                    type K = Blob<10>;
+                    type V = Blob<20>;
+                    verify_monotonic_keys::<K>();
+                    $runner_fn::<K, V>();
+                }
             }
         };
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2801,35 +2801,36 @@ mod test {
 
     // To generate the memory dump file for the current version:
     //   cargo test create_btreemap_dump_file -- --include-ignored
-    fn create_btreemap_dump_file<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::make(i), |i| V::make(i));
-
+    #[test]
+    #[ignore]
+    fn create_btreemap_dump_file() {
         let mem = make_memory();
         let mut btree = BTreeMap::init_v1(mem.clone());
-        assert_eq!(btree.insert(key(1), value(1)), None);
-        assert_eq!(btree.get(&key(1)), Some(value(1)));
 
-        let key_type = std::any::type_name::<K>();
-        let value_type = std::any::type_name::<V>();
+        let key = b(&[1, 2, 3]);
+        let value = b(&[4, 5, 6]);
+        assert_eq!(btree.insert(key, value), None);
+        assert_eq!(btree.get(&key), Some(value));
+
         use std::io::prelude::*;
-        let mut file = std::fs::File::create(format!(
-            "dumps/btreemap_v{LAYOUT_VERSION}_{key_type}_{value_type}.dump"
-        ))
-        .unwrap();
+        let mut file =
+            std::fs::File::create(format!("dumps/btreemap_v{LAYOUT_VERSION}.dump")).unwrap();
         file.write_all(&mem.borrow()).unwrap();
     }
-    btree_test_ignored!(test_create_btreemap_dump_file, create_btreemap_dump_file);
 
-    // fn produces_layout_identical_to_layout_version_1_with_packed_headers<K: TestKey, V: TestValue>() {
-    //     let mem = make_memory();
-    //     let mut btree = BTreeMap::init_v1(mem.clone());
-    //     assert_eq!(btree.insert(b(&[1, 2, 3]), b(&[4, 5, 6])), None);
-    //     assert_eq!(btree.get(&b(&[1, 2, 3])), Some(b(&[4, 5, 6])));
+    #[test]
+    fn produces_layout_identical_to_layout_version_1_with_packed_headers() {
+        let mem = make_memory();
+        let mut btree = BTreeMap::init_v1(mem.clone());
 
-    //     let btreemap_v1 = include_bytes!("../dumps/btreemap_v1_packed_headers.dump");
-    //     assert_eq!(*mem.borrow(), btreemap_v1);
-    // }
-    // btree_test!(test_, );
+        let key = b(&[1, 2, 3]);
+        let value = b(&[4, 5, 6]);
+        assert_eq!(btree.insert(key, value), None);
+        assert_eq!(btree.get(&key), Some(value));
+
+        let btreemap_v1 = include_bytes!("../dumps/btreemap_v1_packed_headers.dump");
+        assert_eq!(*mem.borrow(), btreemap_v1);
+    }
 
     // fn read_write_header_is_identical_to_read_write_struct<K: TestKey, V: TestValue>() {
     //     #[repr(C, packed)]

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1160,7 +1160,6 @@ mod test {
         storable::{Blob, Bound as StorableBound, Storable},
         VectorMemory,
     };
-    use std::borrow::Cow;
     use std::cell::RefCell;
     use std::convert::TryFrom;
     use std::rc::Rc;

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2216,7 +2216,7 @@ mod test {
             btree.insert(key(0), value(0));
 
             // Test a prefix that's larger than the value in the leaf node. Should be empty.
-            assert_eq!(btree.range(key(1)..).collect::<Vec<_>>(), vec![]);
+            assert_eq!(collect(btree.range(key(1)..)), vec![]);
         });
     }
     btree_test!(

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1164,12 +1164,14 @@ mod test {
     use std::convert::TryFrom;
     use std::rc::Rc;
 
+    /// A helper function to clone and collect borrowed key/value pairs into a `Vec`.
     fn collect_kv<'a, K: Clone + 'a, V: Clone + 'a>(
         iter: impl Iterator<Item = (&'a K, &'a V)>,
     ) -> Vec<(K, V)> {
         iter.map(|(k, v)| (k.clone(), v.clone())).collect()
     }
 
+    /// A helper function to collect owned key/value pairs into a `Vec`.
     fn collect<K: Clone, V: Clone>(it: impl Iterator<Item = (K, V)>) -> Vec<(K, V)> {
         it.collect()
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1173,17 +1173,17 @@ mod test {
     }
 
     /// A trait to construct a value from a u32.
-    trait Make {
+    trait FromId {
         fn make(i: u32) -> Self;
         fn empty() -> Self;
     }
 
-    impl Make for () {
+    impl FromId for () {
         fn make(_i: u32) -> Self {}
         fn empty() -> Self {}
     }
 
-    impl Make for u32 {
+    impl FromId for u32 {
         fn make(i: u32) -> Self {
             i
         }
@@ -1192,7 +1192,7 @@ mod test {
         }
     }
 
-    impl<const N: usize> Make for Blob<N> {
+    impl<const N: usize> FromId for Blob<N> {
         fn make(i: u32) -> Self {
             Blob::try_from(&make_monotonic_buffer::<N>(i)[..]).unwrap()
         }
@@ -1203,7 +1203,7 @@ mod test {
     }
 
     type MonotonicString32 = String;
-    impl Make for MonotonicString32 {
+    impl FromId for MonotonicString32 {
         fn make(i: u32) -> Self {
             format!("{i:0>32}")
         }
@@ -1213,7 +1213,7 @@ mod test {
     }
 
     type MonotonicVec32 = Vec<u8>;
-    impl Make for MonotonicVec32 {
+    impl FromId for MonotonicVec32 {
         fn make(i: u32) -> Self {
             make_monotonic_buffer::<32>(i).to_vec()
         }
@@ -1265,7 +1265,7 @@ mod test {
 
     /// Checks that objects from boundary u32 values are strictly increasing.
     /// This ensures multi-byte conversions preserve order.
-    fn verify_monotonic<T: Make + PartialOrd>() {
+    fn verify_monotonic<T: FromId + PartialOrd>() {
         for shift_bits in [8, 16, 24] {
             let i = (1 << shift_bits) - 1;
             assert!(T::make(i) < T::make(i + 1), "Monotonicity failed at i: {i}",);
@@ -1300,12 +1300,12 @@ mod test {
     }
 
     // Define a trait for keys that need the full set of bounds.
-    trait TestKey: Storable + Ord + Clone + Make + std::fmt::Debug {}
-    impl<T> TestKey for T where T: Storable + Ord + Clone + Make + std::fmt::Debug {}
+    trait TestKey: Storable + Ord + Clone + FromId + std::fmt::Debug {}
+    impl<T> TestKey for T where T: Storable + Ord + Clone + FromId + std::fmt::Debug {}
 
     // Define a trait for values that need the full set of bounds.
-    trait TestValue: Storable + Clone + Make + std::fmt::Debug + PartialEq {}
-    impl<T> TestValue for T where T: Storable + Clone + Make + std::fmt::Debug + PartialEq {}
+    trait TestValue: Storable + Clone + FromId + std::fmt::Debug + PartialEq {}
+    impl<T> TestValue for T where T: Storable + Clone + FromId + std::fmt::Debug + PartialEq {}
 
     fn insert_get_init_preserves_data<K: TestKey, V: TestValue>() {
         let (key, value) = (|i| K::make(i), |i| V::make(i));

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1285,7 +1285,7 @@ mod test {
             // The result should look like this:
             //                [6]
             //               /   \
-            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, (12), 13, 14, 15, 16, 17]
 
             let root = btree.load_node(btree.root_addr);
             assert_eq!(root.node_type(), NodeType::Internal);
@@ -1296,11 +1296,12 @@ mod test {
             let right_child = btree.load_node(root.child(1));
             assert!(right_child.is_full());
             let median_index = right_child.entries_len() / 2;
-            assert_eq!(right_child.key(median_index), &k(12));
+            let expected_median_key = k(12);
+            assert_eq!(right_child.key(median_index), &expected_median_key);
 
             // Overwrite the value of the median key.
-            assert_eq!(btree.insert(k(12), v(100)), Some(v(0)));
-            assert_eq!(btree.get(&k(12)), Some(v(100)));
+            assert_eq!(btree.insert(expected_median_key, v(100)), Some(v(0)));
+            assert_eq!(btree.get(&expected_median_key), Some(v(100)));
 
             // The child has not been split and is still full.
             let right_child = btree.load_node(root.child(1));

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1175,14 +1175,17 @@ mod test {
         buf
     }
 
+    type Key = Blob<10>;
+    type Value = Blob<20>;
+
     /// Creates a key from a u32.
-    fn k(i: u32) -> Blob<10> {
+    fn k(i: u32) -> Key {
         Blob::<10>::try_from(&make_buffer::<10>(i)[..]).unwrap()
     }
 
     /// Creates a value from a u32.
-    fn v(i: u32) -> Blob<10> {
-        Blob::<10>::try_from(&make_buffer::<10>(i)[..]).unwrap()
+    fn v(i: u32) -> Value {
+        Blob::<20>::try_from(&make_buffer::<20>(i)[..]).unwrap()
     }
 
     /// Encodes an object into a byte vector.
@@ -1201,11 +1204,13 @@ mod test {
         T::from_bytes(Cow::Owned(bytes))
     }
 
+    // TODO: remove obsolete code.
     /// A helper method to succinctly create an entry.
     fn e(x: u8) -> (Blob<10>, Vec<u8>) {
         (b(&[x]), vec![])
     }
 
+    // TODO: remove obsolete code.
     /// A helper method to succinctly create a blob.
     pub(crate) fn b(x: &[u8]) -> Blob<10> {
         Blob::<10>::try_from(x).unwrap()
@@ -1241,7 +1246,7 @@ mod test {
             assert_eq!(btree.insert(k(1), v(20)), None);
             assert_eq!(btree.get(&k(1)), Some(v(20)));
 
-            // Reload the btree, verfiy data still exists.
+            // Reload the btree, verify data still exists.
             let btree = BTreeMap::init(btree.into_memory());
             assert_eq!(btree.get(&k(1)), Some(v(20)));
         });

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2734,52 +2734,51 @@ mod test {
     }
     btree_test!(test_test_iter_upper_bound, test_iter_upper_bound);
 
-    // // A buggy implementation of storable where the max_size is smaller than the serialized size.
-    // #[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
-    // struct BuggyStruct;
-    // impl crate::Storable for BuggyStruct {
-    //     fn to_bytes(&self) -> Cow<[u8]> {
-    //         Cow::Borrowed(&[1, 2, 3, 4])
-    //     }
+    // A buggy implementation of storable where the max_size is smaller than the serialized size.
+    #[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
+    struct BuggyStruct;
+    impl crate::Storable for BuggyStruct {
+        fn to_bytes(&self) -> Cow<[u8]> {
+            Cow::Borrowed(&[1, 2, 3, 4])
+        }
 
-    //     fn from_bytes(_: Cow<[u8]>) -> Self {
-    //         unimplemented!();
-    //     }
+        fn from_bytes(_: Cow<[u8]>) -> Self {
+            unimplemented!();
+        }
 
-    //     const BOUND: StorableBound = StorableBound::Bounded {
-    //         max_size: 1,
-    //         is_fixed_size: false,
-    //     };
-    // }
-    // btree_test!(test_, );
+        const BOUND: StorableBound = StorableBound::Bounded {
+            max_size: 1,
+            is_fixed_size: false,
+        };
+    }
 
-    // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
-    // fn v1_panics_if_key_is_bigger_than_max_size<K: TestKey, V: TestValue>() {
-    //     let mut btree = BTreeMap::init_v1(make_memory());
-    //     btree.insert(BuggyStruct, ());
-    // }
-    // btree_test!(test_, );
+    #[test]
+    #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
+    fn v1_panics_if_key_is_bigger_than_max_size() {
+        let mut btree = BTreeMap::init_v1(make_memory());
+        btree.insert(BuggyStruct, ());
+    }
 
-    // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
-    // fn v2_panics_if_key_is_bigger_than_max_size<K: TestKey, V: TestValue>() {
-    //     let mut btree = BTreeMap::init(make_memory());
-    //     btree.insert(BuggyStruct, ());
-    // }
-    // btree_test!(test_, );
+    #[test]
+    #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
+    fn v2_panics_if_key_is_bigger_than_max_size() {
+        let mut btree = BTreeMap::init(make_memory());
+        btree.insert(BuggyStruct, ());
+    }
 
-    // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
-    // fn v1_panics_if_value_is_bigger_than_max_size<K: TestKey, V: TestValue>() {
-    //     let mut btree = BTreeMap::init(make_memory());
-    //     btree.insert((), BuggyStruct);
-    // }
-    // btree_test!(test_, );
+    #[test]
+    #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
+    fn v1_panics_if_value_is_bigger_than_max_size() {
+        let mut btree = BTreeMap::init(make_memory());
+        btree.insert((), BuggyStruct);
+    }
 
-    // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
-    // fn v2_panics_if_value_is_bigger_than_max_size<K: TestKey, V: TestValue>() {
-    //     let mut btree = BTreeMap::init(make_memory());
-    //     btree.insert((), BuggyStruct);
-    // }
-    // btree_test!(test_, );
+    #[test]
+    #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
+    fn v2_panics_if_value_is_bigger_than_max_size() {
+        let mut btree = BTreeMap::init(make_memory());
+        btree.insert((), BuggyStruct);
+    }
 
     // // To generate the memory dump file for the current version:
     // //   cargo test create_btreemap_dump_file -- --include-ignored

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1214,6 +1214,7 @@ mod test {
     // fn e(x: u8) -> (Blob<10>, Vec<u8>) {
     //     (b(&[x]), vec![])
     // }
+    // btree_test!(test_, );
 
     // TODO: remove obsolete code.
     /// A helper method to succinctly create a blob.
@@ -2151,244 +2152,250 @@ mod test {
     }
     btree_test!(test_contains_key, contains_key);
 
-    // #[test]
-    // fn range_empty<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|btree| {
-    //         // Test prefixes that don't exist in the map.
-    //         assert_eq!(
-    //             btree
-    //                 .range(b(&[0])..)
-    //                 .collect::<Vec<(Blob<10>, Blob<10>)>>(),
-    //             vec![]
-    //         );
-    //         assert_eq!(btree.range(b(&[1, 2, 3, 4])..).collect::<Vec<_>>(), vec![]);
-    //     });
-    // }
+    fn range_empty<K: TestKey, V: TestValue>() {
+        let key = |i| K::make(i);
+        run_btree_test(|btree| {
+            // Test prefixes that don't exist in the map.
+            assert_eq!(btree.range(key(0)..).collect::<Vec<(K, V)>>(), vec![]);
+            assert_eq!(btree.range(key(10)..).collect::<Vec<(K, V)>>(), vec![]);
+            assert_eq!(btree.range(key(100)..).collect::<Vec<(K, V)>>(), vec![]);
+        });
+    }
+    btree_test!(test_range_empty, range_empty);
 
-    // // Tests the case where the prefix is larger than all the entries in a leaf node.
-    // #[test]
-    // fn range_leaf_prefix_greater_than_all_entries<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut btree| {
-    //         btree.insert(b(&[0]), b(&[]));
+    // Tests the case where the prefix is larger than all the entries in a leaf node.
+    fn range_leaf_prefix_greater_than_all_entries<K: TestKey, V: TestValue>() {
+        let (key, value) = (|i| K::make(i), |i| V::make(i));
+        run_btree_test(|mut btree| {
+            btree.insert(key(0), value(0));
 
-    //         // Test a prefix that's larger than the value in the leaf node. Should be empty.
-    //         assert_eq!(btree.range(b(&[1])..).collect::<Vec<_>>(), vec![]);
-    //     });
-    // }
+            // Test a prefix that's larger than the value in the leaf node. Should be empty.
+            assert_eq!(btree.range(key(1)..).collect::<Vec<_>>(), vec![]);
+        });
+    }
+    btree_test!(
+        test_range_leaf_prefix_greater_than_all_entries,
+        range_leaf_prefix_greater_than_all_entries
+    );
 
-    // // Tests the case where the prefix is larger than all the entries in an internal node.
-    // #[test]
-    // fn range_internal_prefix_greater_than_all_entries<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut btree| {
-    //         for i in 1..=12 {
-    //             assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-    //         }
+    // Tests the case where the prefix is larger than all the entries in an internal node.
+    fn range_internal_prefix_greater_than_all_entries<K: TestKey, V: TestValue>() {
+        let (key, value) = (|i| K::make(i), |i| V::make(i));
+        run_btree_test(|mut btree| {
+            for i in 1..=12 {
+                assert_eq!(btree.insert(key(i), value(i)), None);
+            }
 
-    //         // The result should look like this:
-    //         //                [6]
-    //         //               /   \
-    //         // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
+            // The result should look like this:
+            //                [6]
+            //               /   \
+            // [1, 2, 3, 4, 5]   [7, 8, 9, 10, 11, 12]
 
-    //         // Test a prefix that's larger than the key in the internal node.
-    //         assert_eq!(
-    //             btree.range(b(&[7])..b(&[8])).collect::<Vec<_>>(),
-    //             vec![(b(&[7]), b(&[]))]
-    //         );
-    //     });
-    // }
-    // btree_test!(test_, );
+            // Test a prefix that's larger than the key in the internal node.
+            assert_eq!(
+                btree.range(key(7)..key(8)).collect::<Vec<_>>(),
+                vec![(key(7), value(7))]
+            );
+        });
+    }
+    btree_test!(
+        test_range_internal_prefix_greater_than_all_entries,
+        range_internal_prefix_greater_than_all_entries
+    );
 
-    // #[test]
-    // fn range_various_prefixes<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut btree| {
-    //         btree.insert(b(&[0, 1]), b(&[]));
-    //         btree.insert(b(&[0, 2]), b(&[]));
-    //         btree.insert(b(&[0, 3]), b(&[]));
-    //         btree.insert(b(&[0, 4]), b(&[]));
-    //         btree.insert(b(&[1, 1]), b(&[]));
-    //         btree.insert(b(&[1, 2]), b(&[]));
-    //         btree.insert(b(&[1, 3]), b(&[]));
-    //         btree.insert(b(&[1, 4]), b(&[]));
-    //         btree.insert(b(&[2, 1]), b(&[]));
-    //         btree.insert(b(&[2, 2]), b(&[]));
-    //         btree.insert(b(&[2, 3]), b(&[]));
-    //         btree.insert(b(&[2, 4]), b(&[]));
+    fn range_various_prefixes<K: TestKey, V: TestValue>() {
+        let (key, value) = (|i| K::make(i), |i| V::make(i));
+        run_btree_test(|mut btree| {
+            btree.insert(key(1), value(100));
+            btree.insert(key(2), value(200));
+            btree.insert(key(3), value(300));
+            btree.insert(key(4), value(400));
+            btree.insert(key(11), value(500));
+            btree.insert(key(12), value(600));
+            btree.insert(key(13), value(700));
+            btree.insert(key(14), value(800));
+            btree.insert(key(21), value(900));
+            btree.insert(key(22), value(1_000));
+            btree.insert(key(23), value(1_100));
+            btree.insert(key(24), value(1_200));
 
-    //         // The result should look like this:
-    //         //                                         [(1, 2)]
-    //         //                                         /     \
-    //         // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 1)]       [(1, 3), (1, 4), (2, 1), (2, 2), (2, 3), (2, 4)]
+            // The result should look like this:
+            //                [12]
+            //               /   \
+            // [1, 2, 3, 4, 11]   [13, 14, 21, 22, 23, 24]
 
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Internal);
-    //         assert_eq!(root.entries(btree.memory()), vec![(b(&[1, 2]), vec![])]);
-    //         assert_eq!(root.children_len(), 2);
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![(key(12), encode(value(600)))]
+            );
+            assert_eq!(root.children_len(), 2);
 
-    //         // Tests a prefix that's smaller than the key in the internal node.
-    //         assert_eq!(
-    //             btree.range(b(&[0])..b(&[1])).collect::<Vec<_>>(),
-    //             vec![
-    //                 (b(&[0, 1]), b(&[])),
-    //                 (b(&[0, 2]), b(&[])),
-    //                 (b(&[0, 3]), b(&[])),
-    //                 (b(&[0, 4]), b(&[])),
-    //             ]
-    //         );
+            // Tests a prefix that's smaller than the key in the internal node.
+            assert_eq!(
+                btree.range(key(0)..key(11)).collect::<Vec<_>>(),
+                vec![
+                    (key(1), value(100)),
+                    (key(2), value(200)),
+                    (key(3), value(300)),
+                    (key(4), value(400)),
+                ]
+            );
 
-    //         // Tests a prefix that crosses several nodes.
-    //         assert_eq!(
-    //             btree.range(b(&[1])..b(&[2])).collect::<Vec<_>>(),
-    //             vec![
-    //                 (b(&[1, 1]), b(&[])),
-    //                 (b(&[1, 2]), b(&[])),
-    //                 (b(&[1, 3]), b(&[])),
-    //                 (b(&[1, 4]), b(&[])),
-    //             ]
-    //         );
+            // Tests a prefix that crosses several nodes.
+            assert_eq!(
+                btree.range(key(10)..key(20)).collect::<Vec<_>>(),
+                vec![
+                    (key(11), value(500)),
+                    (key(12), value(600)),
+                    (key(13), value(700)),
+                    (key(14), value(800)),
+                ]
+            );
 
-    //         // Tests a prefix that's larger than the key in the internal node.
-    //         assert_eq!(
-    //             btree.range(b(&[2])..b(&[3])).collect::<Vec<_>>(),
-    //             vec![
-    //                 (b(&[2, 1]), b(&[])),
-    //                 (b(&[2, 2]), b(&[])),
-    //                 (b(&[2, 3]), b(&[])),
-    //                 (b(&[2, 4]), b(&[])),
-    //             ]
-    //         );
-    //     });
-    // }
-    // btree_test!(test_, );
+            // Tests a prefix that's larger than the key in the internal node.
+            assert_eq!(
+                btree.range(key(20)..key(30)).collect::<Vec<_>>(),
+                vec![
+                    (key(21), value(900)),
+                    (key(22), value(1_000)),
+                    (key(23), value(1_100)),
+                    (key(24), value(1_200)),
+                ]
+            );
+        });
+    }
+    btree_test!(test_range_various_prefixes, range_various_prefixes);
 
-    // #[test]
-    // fn range_various_prefixes_2<K: TestKey, V: TestValue>() {
-    //     run_btree_test(|mut btree| {
-    //         btree.insert(b(&[0, 1]), b(&[]));
-    //         btree.insert(b(&[0, 2]), b(&[]));
-    //         btree.insert(b(&[0, 3]), b(&[]));
-    //         btree.insert(b(&[0, 4]), b(&[]));
-    //         btree.insert(b(&[1, 2]), b(&[]));
-    //         btree.insert(b(&[1, 4]), b(&[]));
-    //         btree.insert(b(&[1, 6]), b(&[]));
-    //         btree.insert(b(&[1, 8]), b(&[]));
-    //         btree.insert(b(&[1, 10]), b(&[]));
-    //         btree.insert(b(&[2, 1]), b(&[]));
-    //         btree.insert(b(&[2, 2]), b(&[]));
-    //         btree.insert(b(&[2, 3]), b(&[]));
-    //         btree.insert(b(&[2, 4]), b(&[]));
-    //         btree.insert(b(&[2, 5]), b(&[]));
-    //         btree.insert(b(&[2, 6]), b(&[]));
-    //         btree.insert(b(&[2, 7]), b(&[]));
-    //         btree.insert(b(&[2, 8]), b(&[]));
-    //         btree.insert(b(&[2, 9]), b(&[]));
+    fn range_various_prefixes_2<K: TestKey, V: TestValue>() {
+        let (key, value) = (|i| K::make(i), |i| V::make(i));
+        run_btree_test(|mut btree| {
+            btree.insert(key(1), value(100));
+            btree.insert(key(2), value(200));
+            btree.insert(key(3), value(300));
+            btree.insert(key(4), value(400));
+            btree.insert(key(12), value(500));
+            btree.insert(key(14), value(600));
+            btree.insert(key(16), value(700));
+            btree.insert(key(18), value(800));
+            btree.insert(key(19), value(900));
+            btree.insert(key(21), value(1000));
+            btree.insert(key(22), value(1100));
+            btree.insert(key(23), value(1200));
+            btree.insert(key(24), value(1300));
+            btree.insert(key(25), value(1400));
+            btree.insert(key(26), value(1500));
+            btree.insert(key(27), value(1600));
+            btree.insert(key(28), value(1700));
+            btree.insert(key(29), value(1800));
 
-    //         // The result should look like this:
-    //         //                                         [(1, 4), (2, 3)]
-    //         //                                         /      |       \
-    //         // [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2)]       |        [(2, 4), (2, 5), (2, 6), (2, 7), (2, 8), (2, 9)]
-    //         //                                                |
-    //         //                             [(1, 6), (1, 8), (1, 10), (2, 1), (2, 2)]
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Internal);
-    //         assert_eq!(
-    //             root.entries(btree.memory()),
-    //             vec![(b(&[1, 4]), vec![]), (b(&[2, 3]), vec![])]
-    //         );
-    //         assert_eq!(root.children_len(), 3);
-    //         let child_0 = btree.load_node(root.child(0));
-    //         assert_eq!(child_0.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_0.entries(btree.memory()),
-    //             vec![
-    //                 (b(&[0, 1]), vec![]),
-    //                 (b(&[0, 2]), vec![]),
-    //                 (b(&[0, 3]), vec![]),
-    //                 (b(&[0, 4]), vec![]),
-    //                 (b(&[1, 2]), vec![]),
-    //             ]
-    //         );
+            // The result should look like this:
+            //                    [14, 23]
+            //                 /      |     \
+            // [1, 2, 3, 4, 12]       |      [24, 25, 26, 27, 28, 29]
+            //                        |
+            //              [16, 18, 19, 21, 22]
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Internal);
+            assert_eq!(
+                root.entries(btree.memory()),
+                vec![
+                    (key(14), encode(value(600))),
+                    (key(23), encode(value(1200)))
+                ]
+            );
+            assert_eq!(root.children_len(), 3);
+            let child_0 = btree.load_node(root.child(0));
+            assert_eq!(child_0.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_0.entries(btree.memory()),
+                vec![
+                    (key(1), encode(value(100))),
+                    (key(2), encode(value(200))),
+                    (key(3), encode(value(300))),
+                    (key(4), encode(value(400))),
+                    (key(12), encode(value(500))),
+                ]
+            );
 
-    //         let child_1 = btree.load_node(root.child(1));
-    //         assert_eq!(child_1.node_type(), NodeType::Leaf);
-    //         assert_eq!(
-    //             child_1.entries(btree.memory()),
-    //             vec![
-    //                 (b(&[1, 6]), vec![]),
-    //                 (b(&[1, 8]), vec![]),
-    //                 (b(&[1, 10]), vec![]),
-    //                 (b(&[2, 1]), vec![]),
-    //                 (b(&[2, 2]), vec![]),
-    //             ]
-    //         );
+            let child_1 = btree.load_node(root.child(1));
+            assert_eq!(child_1.node_type(), NodeType::Leaf);
+            assert_eq!(
+                child_1.entries(btree.memory()),
+                vec![
+                    (key(16), encode(value(700))),
+                    (key(18), encode(value(800))),
+                    (key(19), encode(value(900))),
+                    (key(21), encode(value(1000))),
+                    (key(22), encode(value(1100))),
+                ]
+            );
 
-    //         let child_2 = btree.load_node(root.child(2));
-    //         assert_eq!(
-    //             child_2.entries(btree.memory()),
-    //             vec![
-    //                 (b(&[2, 4]), vec![]),
-    //                 (b(&[2, 5]), vec![]),
-    //                 (b(&[2, 6]), vec![]),
-    //                 (b(&[2, 7]), vec![]),
-    //                 (b(&[2, 8]), vec![]),
-    //                 (b(&[2, 9]), vec![]),
-    //             ]
-    //         );
+            let child_2 = btree.load_node(root.child(2));
+            assert_eq!(
+                child_2.entries(btree.memory()),
+                vec![
+                    (key(24), encode(value(1300))),
+                    (key(25), encode(value(1400))),
+                    (key(26), encode(value(1500))),
+                    (key(27), encode(value(1600))),
+                    (key(28), encode(value(1700))),
+                    (key(29), encode(value(1800))),
+                ]
+            );
 
-    //         // Tests a prefix that doesn't exist, but is in the middle of the root node.
-    //         assert_eq!(
-    //             btree.range(b(&[1, 5])..b(&[1, 6])).collect::<Vec<_>>(),
-    //             vec![]
-    //         );
+            // Tests a prefix that doesn't exist, but is in the middle of the root node.
+            assert_eq!(btree.range(key(15)..key(16)).collect::<Vec<_>>(), vec![]);
 
-    //         // Tests a prefix beginning in the middle of the tree and crossing several nodes.
-    //         assert_eq!(
-    //             btree.range(b(&[1, 5])..=b(&[2, 6])).collect::<Vec<_>>(),
-    //             vec![
-    //                 (b(&[1, 6]), b(&[])),
-    //                 (b(&[1, 8]), b(&[])),
-    //                 (b(&[1, 10]), b(&[])),
-    //                 (b(&[2, 1]), b(&[])),
-    //                 (b(&[2, 2]), b(&[])),
-    //                 (b(&[2, 3]), b(&[])),
-    //                 (b(&[2, 4]), b(&[])),
-    //                 (b(&[2, 5]), b(&[])),
-    //                 (b(&[2, 6]), b(&[])),
-    //             ]
-    //         );
+            // Tests a prefix beginning in the middle of the tree and crossing several nodes.
+            assert_eq!(
+                btree.range(key(15)..=key(26)).collect::<Vec<_>>(),
+                vec![
+                    (key(16), value(700)),
+                    (key(18), value(800)),
+                    (key(19), value(900)),
+                    (key(21), value(1000)),
+                    (key(22), value(1100)),
+                    (key(23), value(1200)),
+                    (key(24), value(1300)),
+                    (key(25), value(1400)),
+                    (key(26), value(1500)),
+                ]
+            );
 
-    //         // Tests a prefix that crosses several nodes.
-    //         assert_eq!(
-    //             btree.range(b(&[1])..b(&[2])).collect::<Vec<_>>(),
-    //             vec![
-    //                 (b(&[1, 2]), b(&[])),
-    //                 (b(&[1, 4]), b(&[])),
-    //                 (b(&[1, 6]), b(&[])),
-    //                 (b(&[1, 8]), b(&[])),
-    //                 (b(&[1, 10]), b(&[])),
-    //             ]
-    //         );
+            // Tests a prefix that crosses several nodes.
+            assert_eq!(
+                btree.range(key(10)..key(20)).collect::<Vec<_>>(),
+                vec![
+                    (key(12), value(500)),
+                    (key(14), value(600)),
+                    (key(16), value(700)),
+                    (key(18), value(800)),
+                    (key(19), value(900)),
+                ]
+            );
 
-    //         // Tests a prefix that starts from a leaf node, then iterates through the root and right
-    //         // sibling.
-    //         assert_eq!(
-    //             btree.range(b(&[2])..).collect::<Vec<_>>(),
-    //             vec![
-    //                 (b(&[2, 1]), b(&[])),
-    //                 (b(&[2, 2]), b(&[])),
-    //                 (b(&[2, 3]), b(&[])),
-    //                 (b(&[2, 4]), b(&[])),
-    //                 (b(&[2, 5]), b(&[])),
-    //                 (b(&[2, 6]), b(&[])),
-    //                 (b(&[2, 7]), b(&[])),
-    //                 (b(&[2, 8]), b(&[])),
-    //                 (b(&[2, 9]), b(&[])),
-    //             ]
-    //         );
-    //     });
-    // }
-    // btree_test!(test_, );
+            // Tests a prefix that starts from a leaf node, then iterates through the root and right
+            // sibling.
+            assert_eq!(
+                btree.range(key(20)..key(30)).collect::<Vec<_>>(),
+                vec![
+                    (key(21), value(1000)),
+                    (key(22), value(1100)),
+                    (key(23), value(1200)),
+                    (key(24), value(1300)),
+                    (key(25), value(1400)),
+                    (key(26), value(1500)),
+                    (key(27), value(1600)),
+                    (key(28), value(1700)),
+                    (key(29), value(1800)),
+                ]
+            );
+        });
+    }
+    btree_test!(test_range_various_prefixes_2, range_various_prefixes_2);
 
-    // #[test]
     // fn range_large<K: TestKey, V: TestValue>() {
     //     run_btree_test(|mut btree| {
     //         // Insert 1000 elements with prefix 0 and another 1000 elements with prefix 1.
@@ -2430,7 +2437,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn range_various_prefixes_with_offset() {
     //     run_btree_test(|mut btree| {
     //         btree.insert(b(&[0, 1]), b(&[]));
@@ -2478,7 +2484,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn range_various_prefixes_with_offset_2() {
     //     run_btree_test(|mut btree| {
     //         btree.insert(b(&[0, 1]), b(&[]));
@@ -2583,7 +2588,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // #[should_panic(expected = "max_key_size must be <= 4")]
     // fn v1_rejects_increases_in_max_key_size() {
     //     let mem = make_memory();
@@ -2592,7 +2596,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn v2_handles_increases_in_max_key_size_and_max_value_size() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<Blob<4>, Blob<4>, _> = BTreeMap::init(mem);
@@ -2621,7 +2624,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn accepts_small_or_equal_key_sizes() {
     //     let mem = make_memory();
     //     let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(mem);
@@ -2632,7 +2634,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // #[should_panic(expected = "max_value_size must be <= 3")]
     // fn v1_rejects_larger_value_sizes() {
     //     let mem = make_memory();
@@ -2641,7 +2642,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn accepts_small_or_equal_value_sizes() {
     //     let mem = make_memory();
     //     let btree: BTreeMap<Blob<4>, Blob<3>, _> = BTreeMap::init(mem);
@@ -2652,7 +2652,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn bruteforce_range_search() {
     //     run_btree_test(|mut stable_map| {
     //         use std::collections::BTreeMap;
@@ -2714,7 +2713,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn test_iter_upper_bound() {
     //     run_btree_test(|mut btree| {
     //         for k in 0..100u64 {
@@ -2735,6 +2733,7 @@ mod test {
     //         }
     //     });
     // }
+    // btree_test!(test_, );
 
     // // A buggy implementation of storable where the max_size is smaller than the serialized size.
     // #[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
@@ -2755,7 +2754,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
     // fn v1_panics_if_key_is_bigger_than_max_size() {
     //     let mut btree = BTreeMap::init_v1(make_memory());
@@ -2763,7 +2761,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
     // fn v2_panics_if_key_is_bigger_than_max_size() {
     //     let mut btree = BTreeMap::init(make_memory());
@@ -2771,7 +2768,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
     // fn v1_panics_if_value_is_bigger_than_max_size() {
     //     let mut btree = BTreeMap::init(make_memory());
@@ -2779,16 +2775,15 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // #[should_panic(expected = "expected an element with length <= 1 bytes, but found 4")]
     // fn v2_panics_if_value_is_bigger_than_max_size() {
     //     let mut btree = BTreeMap::init(make_memory());
     //     btree.insert((), BuggyStruct);
     // }
+    // btree_test!(test_, );
 
     // // To generate the memory dump file for the current version:
     // //   cargo test create_btreemap_dump_file -- --include-ignored
-    // #[test]
     // #[ignore]
     // fn create_btreemap_dump_file() {
     //     let mem = make_memory();
@@ -2803,7 +2798,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn produces_layout_identical_to_layout_version_1_with_packed_headers() {
     //     let mem = make_memory();
     //     let mut btree = BTreeMap::init_v1(mem.clone());
@@ -2815,7 +2809,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn read_write_header_is_identical_to_read_write_struct() {
     //     #[repr(C, packed)]
     //     struct BTreePackedHeader {
@@ -2874,7 +2867,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn migrate_from_bounded_to_unbounded_and_back() {
     //     // A type that is bounded.
     //     #[derive(PartialOrd, Ord, Clone, Eq, PartialEq, Debug)]
@@ -2930,7 +2922,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn test_clear_new_bounded_type() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<Blob<4>, Blob<4>, _> = BTreeMap::new(mem.clone());
@@ -2956,7 +2947,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn test_clear_new_unbounded_type() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<String, String, _> = BTreeMap::new(mem.clone());
@@ -2978,7 +2968,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn deallocating_node_with_overflows() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<Vec<u8>, Vec<u8>, _> = BTreeMap::new(mem.clone());
@@ -2999,7 +2988,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn repeatedly_deallocating_nodes_with_overflows() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<Vec<u8>, Vec<u8>, _> = BTreeMap::new(mem.clone());
@@ -3022,7 +3010,6 @@ mod test {
     // }
     // btree_test!(test_, );
 
-    // #[test]
     // fn deallocating_root_does_not_leak_memory() {
     //     let mem = make_memory();
     //     let mut btree: BTreeMap<Vec<u8>, _, _> = BTreeMap::new(mem.clone());

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1197,8 +1197,7 @@ mod test {
             Blob::try_from(&make_monotonic_buffer::<N>(i)[..]).unwrap()
         }
         fn empty() -> Self {
-            let x: &[u8] = &[];
-            Blob::try_from(x).unwrap()
+            Blob::try_from(&[][..]).unwrap()
         }
     }
 
@@ -1622,7 +1621,7 @@ mod test {
     btree_test!(test_last_key_value, last_key_value);
 
     fn pop_first_single_entry<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let key = |i| K::build(i);
         run_btree_test(|mut btree| {
             assert_eq!(btree.allocator.num_allocated_chunks(), 0);
 

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1222,29 +1222,29 @@ mod test {
     #[test]
     fn init_preserves_data() {
         run_btree_test(|mut btree| {
-            assert_eq!(btree.insert(k(1), v(2)), None);
-            assert_eq!(btree.get(&k(1)), Some(v(2)));
+            assert_eq!(btree.insert(k(1), v(20)), None);
+            assert_eq!(btree.get(&k(1)), Some(v(20)));
 
             // Reload the btree, verfiy data still exists.
             let btree = BTreeMap::init(btree.into_memory());
-            assert_eq!(btree.get(&k(1)), Some(v(2)));
+            assert_eq!(btree.get(&k(1)), Some(v(20)));
         });
     }
 
     #[test]
     fn insert_and_get() {
         run_btree_test(|mut btree| {
-            assert_eq!(btree.insert(k(1), v(2)), None);
-            assert_eq!(btree.get(&k(1)), Some(v(2)));
+            assert_eq!(btree.insert(k(1), v(20)), None);
+            assert_eq!(btree.get(&k(1)), Some(v(20)));
         });
     }
 
     #[test]
     fn insert_overwrites_previous_value() {
         run_btree_test(|mut btree| {
-            assert_eq!(btree.insert(k(1), v(2)), None);
-            assert_eq!(btree.insert(k(1), v(3)), Some(v(2)));
-            assert_eq!(btree.get(&k(1)), Some(v(3)));
+            assert_eq!(btree.insert(k(1), v(20)), None);
+            assert_eq!(btree.insert(k(1), v(30)), Some(v(20)));
+            assert_eq!(btree.get(&k(1)), Some(v(30)));
         });
     }
 
@@ -1287,8 +1287,8 @@ mod test {
             assert_eq!(right_child.key(median_index), &k(12));
 
             // Overwrite the value of the median key.
-            assert_eq!(btree.insert(k(12), v(123)), Some(v(0)));
-            assert_eq!(btree.get(&k(12)), Some(v(123)));
+            assert_eq!(btree.insert(k(12), v(100)), Some(v(0)));
+            assert_eq!(btree.get(&k(12)), Some(v(100)));
 
             // The child has not been split and is still full.
             let right_child = btree.load_node(root.child(1));

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -2399,25 +2399,29 @@ mod test {
     fn range_large<K: TestKey, V: TestValue>() {
         let (key, value) = (|i| K::make(i), |i| V::make(i));
         run_btree_test(|mut btree| {
-            let n = 2_000;
-            let m = n / 2;
+            const TOTAL: u32 = 2_000;
+            const MID: u32 = TOTAL / 2;
 
-            for i in 0..n {
+            for i in 0..TOTAL {
                 assert_eq!(btree.insert(key(i), value(i)), None);
             }
 
-            // Inspect the first half.
-            let keys: Vec<_> = btree.range(key(0)..key(m)).collect();
-            assert_eq!(keys.len(), m as usize);
-            for (i, (k, _)) in keys.into_iter().enumerate() {
-                assert_eq!(k, key(i as u32));
+            // Check range [0, MID): should yield exactly the first MID entries.
+            let keys: Vec<_> = btree.range(key(0)..key(MID)).collect();
+            assert_eq!(keys.len(), MID as usize);
+            for (i, (k, v)) in keys.into_iter().enumerate() {
+                let j = i as u32;
+                assert_eq!(k, key(j));
+                assert_eq!(v, value(j));
             }
 
-            // Inspect the second half.
-            let keys: Vec<_> = btree.range(key(m)..).collect();
-            assert_eq!(keys.len(), (n - m) as usize);
-            for (i, (k, _)) in keys.into_iter().enumerate() {
-                assert_eq!(k, key(m + i as u32));
+            // Check range [MID, TOTAL): should yield the remaining entries.
+            let keys: Vec<_> = btree.range(key(MID)..).collect();
+            assert_eq!(keys.len(), (TOTAL - MID) as usize);
+            for (i, (k, v)) in keys.into_iter().enumerate() {
+                let j = MID + i as u32;
+                assert_eq!(k, key(j));
+                assert_eq!(v, value(j));
             }
         });
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1345,7 +1345,7 @@ mod test {
     impl<T> TestValue for T where T: Storable + Clone + Builder + std::fmt::Debug + PartialEq {}
 
     fn insert_get_init_preserves_data<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             let n = 1_000;
             for i in 0..n {
@@ -1366,7 +1366,7 @@ mod test {
     );
 
     fn insert_overwrites_previous_value<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             let n = 1_000;
             for i in 0..n {
@@ -1382,7 +1382,7 @@ mod test {
     );
 
     fn insert_same_key_many<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             let n = 1_000;
             assert_eq!(btree.insert(key(1), value(2)), None);
@@ -1395,7 +1395,7 @@ mod test {
     btree_test!(test_insert_same_key_many, insert_same_key_many);
 
     fn insert_overwrite_median_key_in_full_child_node<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             for i in 1..=17 {
                 assert_eq!(btree.insert(key(i), value(0)), None);
@@ -1437,7 +1437,7 @@ mod test {
     );
 
     fn insert_overwrite_key_in_full_root_node<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             for i in 1..=11 {
                 assert_eq!(btree.insert(key(i), value(0)), None);
@@ -1464,7 +1464,7 @@ mod test {
     );
 
     fn allocations_without_split<K: TestKey, V: TestValue>() {
-        let key = |i| K::build(i);
+        let key = K::build;
         run_btree_test(|mut btree| {
             assert_eq!(btree.allocator.num_allocated_chunks(), 0);
 
@@ -1478,7 +1478,7 @@ mod test {
     btree_test!(test_allocations_without_split, allocations_without_split);
 
     fn allocations_with_split<K: TestKey, V: TestValue>() {
-        let key = |i| K::build(i);
+        let key = K::build;
         run_btree_test(|mut btree| {
             // Insert entries until the root node is full.
             let mut i = 0;
@@ -1503,7 +1503,7 @@ mod test {
     btree_test!(test_allocations_with_split, allocations_with_split);
 
     fn insert_split_node<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             for i in 1..=11 {
                 assert_eq!(btree.insert(key(i), value(10)), None);
@@ -1527,7 +1527,7 @@ mod test {
     btree_test!(test_insert_split_node, insert_split_node);
 
     fn insert_split_multiple_nodes<K: TestKey, V: TestValue>() {
-        let key = |i| K::build(i);
+        let key = K::build;
         let e = |i: u32| (key(i), encode(V::empty()));
         run_btree_test(|mut btree| {
             for i in 1..=11 {
@@ -1612,7 +1612,7 @@ mod test {
     );
 
     fn first_key_value<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree: BTreeMap<K, V, _>| {
             assert_eq!(btree.first_key_value(), None);
 
@@ -1634,7 +1634,7 @@ mod test {
     btree_test!(test_first_key_value, first_key_value);
 
     fn last_key_value<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree: BTreeMap<K, V, _>| {
             assert_eq!(btree.last_key_value(), None);
 
@@ -1656,7 +1656,7 @@ mod test {
     btree_test!(test_last_key_value, last_key_value);
 
     fn pop_first_single_entry<K: TestKey, V: TestValue>() {
-        let key = |i| K::build(i);
+        let key = K::build;
         run_btree_test(|mut btree| {
             assert_eq!(btree.allocator.num_allocated_chunks(), 0);
 
@@ -1672,7 +1672,7 @@ mod test {
     btree_test!(test_pop_first_single_entry, pop_first_single_entry);
 
     fn pop_last_single_entry<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             assert_eq!(btree.allocator.num_allocated_chunks(), 0);
 
@@ -1688,7 +1688,7 @@ mod test {
     btree_test!(test_pop_last_single_entry, pop_last_single_entry);
 
     fn remove_case_2a_and_2c<K: TestKey, V: TestValue>() {
-        let key = |i| K::build(i);
+        let key = K::build;
         let e = |i: u32| (key(i), encode(V::empty()));
         run_btree_test(|mut btree| {
             for i in 1..=11 {
@@ -1756,7 +1756,7 @@ mod test {
     btree_test!(test_remove_case_2a_and_2c, remove_case_2a_and_2c);
 
     fn remove_case_2b<K: TestKey, V: TestValue>() {
-        let key = |i| K::build(i);
+        let key = K::build;
         let e = |i: u32| (key(i), encode(V::empty()));
         run_btree_test(|mut btree| {
             for i in 1..=11 {
@@ -1818,7 +1818,7 @@ mod test {
     btree_test!(test_remove_case_2b, remove_case_2b);
 
     fn remove_case_3a_right<K: TestKey, V: TestValue>() {
-        let key = |i| K::build(i);
+        let key = K::build;
         let e = |i: u32| (key(i), encode(V::empty()));
         run_btree_test(|mut btree| {
             for i in 1..=11 {
@@ -1866,7 +1866,7 @@ mod test {
     btree_test!(test_remove_case_3a_right, remove_case_3a_right);
 
     fn remove_case_3a_left<K: TestKey, V: TestValue>() {
-        let key = |i| K::build(i);
+        let key = K::build;
         let e = |i: u32| (key(i), encode(V::empty()));
         run_btree_test(|mut btree| {
             for i in 1..=11 {
@@ -1913,7 +1913,7 @@ mod test {
     btree_test!(test_remove_case_3a_left, remove_case_3a_left);
 
     fn remove_case_3b_merge_into_right<K: TestKey, V: TestValue>() {
-        let key = |i| K::build(i);
+        let key = K::build;
         let e = |i: u32| (key(i), encode(V::empty()));
         run_btree_test(|mut btree| {
             for i in 1..=11 {
@@ -1985,7 +1985,7 @@ mod test {
     );
 
     fn remove_case_3b_merge_into_left<K: TestKey, V: TestValue>() {
-        let key = |i| K::build(i);
+        let key = K::build;
         let e = |i: u32| (key(i), encode(V::empty()));
         run_btree_test(|mut btree| {
             for i in 1..=11 {
@@ -2059,7 +2059,7 @@ mod test {
     );
 
     fn insert_remove_many<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             let n = 10_000;
             for i in 0..n {
@@ -2080,7 +2080,7 @@ mod test {
     btree_test!(test_insert_remove_many, insert_remove_many);
 
     fn pop_first_many<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             let n = 10_000;
 
@@ -2106,7 +2106,7 @@ mod test {
     btree_test!(test_pop_first_many, pop_first_many);
 
     fn pop_last_many<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             let n = 10_000;
 
@@ -2132,7 +2132,7 @@ mod test {
     btree_test!(test_pop_last_many, pop_last_many);
 
     fn reloading<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             let n = 1_000;
             for i in 0..n {
@@ -2162,7 +2162,7 @@ mod test {
     btree_test!(test_reloading, reloading);
 
     fn len<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             let n = 1_000;
             for i in 0..n {
@@ -2183,7 +2183,7 @@ mod test {
     btree_test!(test_len, len);
 
     fn contains_key<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             let n = 1_000;
             for i in (0..n).step_by(2) {
@@ -2199,7 +2199,7 @@ mod test {
     btree_test!(test_contains_key, contains_key);
 
     fn range_empty<K: TestKey, V: TestValue>() {
-        let key = |i| K::build(i);
+        let key = K::build;
         run_btree_test(|btree: BTreeMap<K, V, _>| {
             // Test prefixes that don't exist in the map.
             assert_eq!(collect(btree.range(key(0)..)), vec![]);
@@ -2211,7 +2211,7 @@ mod test {
 
     // Tests the case where the prefix is larger than all the entries in a leaf node.
     fn range_leaf_prefix_greater_than_all_entries<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             btree.insert(key(0), value(0));
 
@@ -2226,7 +2226,7 @@ mod test {
 
     // Tests the case where the prefix is larger than all the entries in an internal node.
     fn range_internal_prefix_greater_than_all_entries<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             for i in 1..=12 {
                 assert_eq!(btree.insert(key(i), value(i)), None);
@@ -2250,7 +2250,7 @@ mod test {
     );
 
     fn range_various_prefixes<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             btree.insert(key(1), value(100));
             btree.insert(key(2), value(200));
@@ -2315,7 +2315,7 @@ mod test {
     btree_test!(test_range_various_prefixes, range_various_prefixes);
 
     fn range_various_prefixes_2<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             btree.insert(key(1), value(100));
             btree.insert(key(2), value(200));
@@ -2443,7 +2443,7 @@ mod test {
     btree_test!(test_range_various_prefixes_2, range_various_prefixes_2);
 
     fn range_large<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             const TOTAL: u32 = 2_000;
             const MID: u32 = TOTAL / 2;
@@ -2474,7 +2474,7 @@ mod test {
     btree_test!(test_range_large, range_large);
 
     fn range_various_prefixes_with_offset<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             btree.insert(key(1), value(100));
             btree.insert(key(2), value(200));
@@ -2528,7 +2528,7 @@ mod test {
     );
 
     fn range_various_prefixes_with_offset_2<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             btree.insert(key(1), value(0));
             btree.insert(key(2), value(0));
@@ -2700,7 +2700,7 @@ mod test {
     }
 
     fn bruteforce_range_search<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut stable_map| {
             use std::collections::BTreeMap;
             const NKEYS: u32 = 60;
@@ -2747,7 +2747,7 @@ mod test {
     btree_test!(test_bruteforce_range_search, bruteforce_range_search);
 
     fn test_iter_upper_bound<K: TestKey, V: TestValue>() {
-        let (key, value) = (|i| K::build(i), |i| V::build(i));
+        let (key, value) = (K::build, V::build);
         run_btree_test(|mut btree| {
             for j in 0..100 {
                 btree.insert(key(j), value(j));

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1278,7 +1278,8 @@ mod test {
         V: Storable,
         F: Fn(BTreeMap<K, V, VectorMemory>) -> R,
     {
-        if K::BOUND != StorableBound::Unbounded {
+        // V1 does not support unbounded types.
+        if K::BOUND != StorableBound::Unbounded && V::BOUND != StorableBound::Unbounded {
             // Test with V1.
             let mem = make_memory();
             let tree_v1 = BTreeMap::new_v1(mem);
@@ -1321,17 +1322,23 @@ mod test {
         ($name:ident, $runner:ident) => {
             #[test]
             fn $name() {
-                // Set.
+                // Set, empty value.
                 verify_and_run!($runner, u32, ());
                 verify_and_run!($runner, Blob<10>, ());
                 verify_and_run!($runner, MonotonicVec32, ());
                 verify_and_run!($runner, MonotonicString32, ());
 
-                // Map.
+                // Map, bounded value.
                 verify_and_run!($runner, u32, Blob<20>);
                 verify_and_run!($runner, Blob<10>, Blob<20>);
                 verify_and_run!($runner, MonotonicVec32, Blob<20>);
                 verify_and_run!($runner, MonotonicString32, Blob<20>);
+
+                // Map, unbounded value.
+                verify_and_run!($runner, u32, MonotonicVec32);
+                verify_and_run!($runner, Blob<10>, MonotonicVec32);
+                verify_and_run!($runner, MonotonicVec32, MonotonicVec32);
+                verify_and_run!($runner, MonotonicString32, MonotonicVec32);
             }
         };
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1381,15 +1381,12 @@ mod test {
             let right_child = btree.load_node(root.child(1));
             assert!(right_child.is_full());
             let median_index = right_child.entries_len() / 2;
-            let expected_median_key = key(12);
-            assert_eq!(right_child.key(median_index), &expected_median_key);
+            let median_key = key(12);
+            assert_eq!(right_child.key(median_index), &median_key);
 
             // Overwrite the value of the median key.
-            assert_eq!(
-                btree.insert(expected_median_key.clone(), value(123)),
-                Some(value(0))
-            );
-            assert_eq!(btree.get(&expected_median_key), Some(value(123)));
+            assert_eq!(btree.insert(median_key.clone(), value(123)), Some(value(0)));
+            assert_eq!(btree.get(&median_key), Some(value(123)));
 
             // The child has not been split and is still full.
             let right_child = btree.load_node(root.child(1));

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1220,14 +1220,6 @@ mod test {
     }
 
     #[test]
-    fn test_insert_and_get() {
-        run_btree_test(|mut btree| {
-            assert_eq!(btree.insert(k(1), v(2)), None);
-            assert_eq!(btree.get(&k(1)), Some(v(2)));
-        });
-    }
-
-    #[test]
     fn test_init_preserves_data() {
         run_btree_test(|mut btree| {
             assert_eq!(btree.insert(k(1), v(2)), None);
@@ -1235,6 +1227,14 @@ mod test {
 
             // Reload the btree, verfiy data still exists.
             let btree = BTreeMap::init(btree.into_memory());
+            assert_eq!(btree.get(&k(1)), Some(v(2)));
+        });
+    }
+
+    #[test]
+    fn test_insert_and_get() {
+        run_btree_test(|mut btree| {
+            assert_eq!(btree.insert(k(1), v(2)), None);
             assert_eq!(btree.get(&k(1)), Some(v(2)));
         });
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1383,28 +1383,32 @@ mod test {
         insert_overwrite_median_key_in_full_child_node
     );
 
-    // #[test]
-    // fn insert_overwrite_key_in_full_root_node() {
-    //     run_btree_test(|mut btree| {
-    //         for i in 1..=11 {
-    //             assert_eq!(btree.insert(b(&[i]), b(&[])), None);
-    //         }
+    fn insert_overwrite_key_in_full_root_node<K: TestKey, V: TestValue>() {
+        run_btree_test(|mut btree| {
+            for i in 1..=11 {
+                assert_eq!(btree.insert(K::make(i), V::default()), None);
+            }
 
-    //         // We now have a root that is full and looks like this:
-    //         //
-    //         // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert!(root.is_full());
+            // We now have a root that is full and looks like this:
+            //
+            // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+            let root = btree.load_node(btree.root_addr);
+            assert!(root.is_full());
 
-    //         // Overwrite an element in the root. It should NOT cause the node to be split.
-    //         assert_eq!(btree.insert(b(&[6]), b(&[4, 5, 6])), Some(b(&[])));
+            // Overwrite an element in the root. It should NOT cause the node to be split.
+            assert_eq!(btree.insert(K::make(6), V::make(456)), Some(V::default()));
 
-    //         let root = btree.load_node(btree.root_addr);
-    //         assert_eq!(root.node_type(), NodeType::Leaf);
-    //         assert_eq!(btree.get(&b(&[6])), Some(b(&[4, 5, 6])));
-    //         assert_eq!(root.entries_len(), 11);
-    //     });
-    // }
+            let root = btree.load_node(btree.root_addr);
+            assert_eq!(root.node_type(), NodeType::Leaf);
+            assert_eq!(btree.get(&K::make(6)), Some(V::make(456)));
+            assert_eq!(root.entries_len(), 11);
+        });
+    }
+
+    btree_test!(
+        test_insert_overwrite_key_in_full_root_node,
+        insert_overwrite_key_in_full_root_node
+    );
 
     // #[test]
     // fn allocations() {

--- a/src/btreemap/proptests.rs
+++ b/src/btreemap/proptests.rs
@@ -1,6 +1,6 @@
 use crate::{
     btreemap::{
-        test::{b, btree_test, make_memory},
+        test::{b, make_memory, run_btree_test},
         BTreeMap,
     },
     storable::Blob,
@@ -105,7 +105,7 @@ fn comprehensive_fuzz() {
 
 #[proptest(cases = 10)]
 fn insert(#[strategy(pset(arb_blob(), 1000..10_000))] keys: BTreeSet<Blob<10>>) {
-    btree_test(|mut btree| {
+    run_btree_test(|mut btree| {
         let keys = keys.clone();
         for key in keys.iter() {
             assert_eq!(btree.insert(*key, *key), None);
@@ -122,7 +122,7 @@ fn insert(#[strategy(pset(arb_blob(), 1000..10_000))] keys: BTreeSet<Blob<10>>) 
 
 #[proptest]
 fn map_min_max(#[strategy(pvec(any::<u64>(), 10..100))] keys: Vec<u64>) {
-    btree_test(|mut map| {
+    run_btree_test(|mut map| {
         prop_assert_eq!(map.first_key_value(), None);
         prop_assert_eq!(map.last_key_value(), None);
 
@@ -142,7 +142,7 @@ fn map_min_max(#[strategy(pvec(any::<u64>(), 10..100))] keys: Vec<u64>) {
 
 #[proptest]
 fn map_upper_bound_iter(#[strategy(pvec(0u64..u64::MAX -1 , 10..100))] keys: Vec<u64>) {
-    btree_test(|mut map| {
+    run_btree_test(|mut map| {
         for k in keys.iter() {
             map.insert(*k, ());
 
@@ -155,7 +155,7 @@ fn map_upper_bound_iter(#[strategy(pvec(0u64..u64::MAX -1 , 10..100))] keys: Vec
 
 #[proptest(cases = 10)]
 fn iter_count_test(#[strategy(0..250u8)] start: u8, #[strategy(#start..255u8)] end: u8) {
-    btree_test(|mut btree| {
+    run_btree_test(|mut btree| {
         for i in start..end {
             assert_eq!(btree.insert(b(&[i]), b(&[])), None);
         }


### PR DESCRIPTION
Run each `BTreeMap` test for multiple key/value type pairs (bounded and unbounded) by using `btree_test!` macro.

No functional changes, only test code is modified.

Changes:
- add `Build` trait to generate key/value types from `u32` value in monotonic way
- add `btree_test!` macro to run each test on a set of key/value pairs (bounded/unbounded, set-like, map-like)
- add unified key/value helpers to abstract the actual type and improve readability of each test by using `key(i)`/`value(i)` instead of `b(&[1,2,3])`

Before:
```rs
assert_eq!(btree.insert(b(&[1,2,3]), b(&[4,5,6])), None);
assert_eq!(btree.get(&b(&[1,2,3])), Some(b(&[4,5,6])));
assert_eq!(
    btree.range(b(&[1, 5])..=b(&[2, 6])).collect::<Vec<_>>(),
    vec![
        (b(&[1, 6]), b(&[])),
        (b(&[1, 8]), b(&[])),
        (b(&[1, 10]), b(&[])),
        (b(&[2, 1]), b(&[])),
        (b(&[2, 2]), b(&[])),
        (b(&[2, 3]), b(&[])),
        (b(&[2, 4]), b(&[])),
        (b(&[2, 5]), b(&[])),
        (b(&[2, 6]), b(&[])),
    ]
);
```

After:
```rs
let (key, value) = (|i| K::build(i), |i| V::build(i));

assert_eq!(btree.insert(key(123), value(456)), None);
assert_eq!(btree.get(&key(123)), Some(value(456)));
assert_eq!(
    collect(btree.range(key(15)..=key(26))),
    vec![
        (key(16), V::empty()),
        (key(18), V::empty()),
        (key(19), V::empty()),
        (key(21), V::empty()),
        (key(22), V::empty()),
        (key(23), V::empty()),
        (key(24), V::empty()),
        (key(25), V::empty()),
        (key(26), V::empty()),
    ]
);
```
