### PR TITLE
feat: publish stable structures book to github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,39 +130,10 @@ jobs:
         run: |
           bash ./scripts/ci_post_run_benchmark.sh
 
-  documentation-book:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
-          rustup target add wasm32-unknown-unknown
-
-      - name: Install mdbook
-        run: |
-          cargo install mdbook --version 0.4.48
-          cargo install mdbook-admonish --version 1.19.0
-
-      - name: Build book
-        run: |
-          cd docs
-          mdbook-admonish install
-          mdbook build
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        if: ${{ github.ref == 'refs/heads/main' }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/book
-
   checks-pass:
     # Always run this job!
     if: always()
-    needs: [build, examples, benchmark, documentation-book]
+    needs: [build, examples, benchmark]
     runs-on: ubuntu-latest
     steps:
       - name: check build result
@@ -173,7 +144,4 @@ jobs:
         run: exit 1
       - name: check benchmark result
         if: ${{ needs.benchmark.result != 'success' }}
-        run: exit 1
-      - name: check documentation-book result
-        if: ${{ needs.documentation-book.result != 'success' }}
         run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
           mdbook build
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: CI
-on: #pull_request]
-  workflow_dispatch:
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
-on: [pull_request]
+on: #pull_request]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy docs to Github Pages
+name: Github Pages Book
 
 on:
   # Only run this workflow when there are changes to the docs directory
@@ -17,8 +17,7 @@ permissions:
   contents: write
 
 jobs:
-  # Build job
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     env:
       MDBOOK_VERSION: 0.4.48

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MDBOOK_VERSION: 0.4.48
-      MDBOOK_ADMONISH_VERSION: 0.4.48
+      MDBOOK_ADMONISH_VERSION: 1.19.0
       RUST_VERSION: 1.84.0
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
-        if: ${{ github.ref == 'refs/heads/main' }}
+        # if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/book

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,55 @@
+name: Deploy docs to Github Pages
+
+on:
+  push:
+    branches:
+      - main
+      - ielashi/mdbook_worflow
+#    paths:
+ #     - 'docs/**'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MDBOOK_VERSION: 0.4.48
+      MDBOOK_ADMONISH_VERSION: 0.4.48
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        run: |
+          rustup update ${{ matrix.rust }} --no-self-update
+          rustup default ${{ matrix.rust }}
+          rustup target add wasm32-unknown-unknown
+
+      - name: Install mdbook
+        run: |
+          cargo install mdbook --version ${MDBOOK_VERSION}
+          cargo install mdbook-admonish --version ${MDBOOK_ADMONISH_VERSION}
+
+      - name: Build book
+        run: |
+          cd docs
+          mdbook-admonish install
+          mdbook build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/book
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/book

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,13 +1,13 @@
 name: Deploy docs to Github Pages
 
 on:
+  # Only run this workflow when there are changes to the docs directory
   pull_request:
-#  push:
- #   branches:
-  #    - main
-   #   - ielashi/mdbook_worflow
-#    paths:
- #     - 'docs/**'
+    paths:
+      - 'docs/**'
+  push:
+    paths:
+      - 'docs/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -51,7 +51,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
-        # if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/book

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,10 +1,11 @@
 name: Deploy docs to Github Pages
 
 on:
-  push:
-    branches:
-      - main
-      - ielashi/mdbook_worflow
+  pull_request:
+#  push:
+ #   branches:
+  #    - main
+   #   - ielashi/mdbook_worflow
 #    paths:
  #     - 'docs/**'
 
@@ -22,13 +23,14 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.48
       MDBOOK_ADMONISH_VERSION: 0.4.48
+      RUST_VERSION: 1.84.0
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust
         run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
+          rustup update ${RUST_VERSION} --no-self-update
+          rustup default ${RUST_VERSION}
           rustup target add wasm32-unknown-unknown
 
       - name: Install mdbook

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A collection of scalable data structures for the [Internet Computer](https://int
 
 Stable structures are designed to use stable memory as the backing store, allowing them to grow to gigabytes in size without the need for `pre_upgrade`/`post_upgrade` hooks.
 
+You can read more about the library in the [Stable Structures Book](https://dfinity.github.io/stable-structures/)
+
 ## Background
 
 The conventional approach to canister state persistence is to serialize the entire state to stable memory in the `pre_upgrade` hook and decode it back in the `post_upgrade` hook.
@@ -18,7 +20,6 @@ This approach is easy to implement and works well for relatively small datasets.
 Unfortunately, it does not scale well and can render a canister non-upgradable.
 
 This library aims to simplify managing data structures directly in stable memory.
-For more information about the philosophy behind the library, see [Roman's tutorial on stable structures](https://mmapped.blog/posts/14-stable-structures.html).
 
 ## Available Data Structures
 


### PR DESCRIPTION
This commit updates CI to publish the stable structures book (verified to work: https://dfinity.github.io/stable-structures/). It also updates the README to link to the book.