### PR TITLE
fix: broken link in memory manager doc

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.48
       MDBOOK_ADMONISH_VERSION: 1.19.0
+      MDBOOK_LINKCHECK_VERSION: 0.7.7
       RUST_VERSION: 1.84.0
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +37,7 @@ jobs:
         run: |
           cargo install mdbook --version ${MDBOOK_VERSION}
           cargo install mdbook-admonish --version ${MDBOOK_ADMONISH_VERSION}
+          cargo install mdbook-linkcheck --version ${MDBOOK_LINKCHECK_VERSION}
 
       - name: Build book
         run: |

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -13,6 +13,8 @@ create-missing = false
 git-repository-url = "https://github.com/dfinity/stable-structures"
 additional-css = ["./mdbook-admonish.css"]
 
+[output.linkcheck]
+
 [preprocessor]
 
 [preprocessor.admonish]

--- a/docs/src/concepts/memory-manager.md
+++ b/docs/src/concepts/memory-manager.md
@@ -1,7 +1,7 @@
 # Memory Manager
 
 As mentioned in the previous section, each stable structure requires its own dedicated `Memory` instance.
-This is an intentional design decision that limits [the blast radius](./design-principles.md) of potential bugs, ensuring that issues only affect the specific stable structure and its associated memory, not other stable structures.
+This is an intentional design decision that limits [the blast radius](../introduction/design-principles.md) of potential bugs, ensuring that issues only affect the specific stable structure and its associated memory, not other stable structures.
 
 ## Overview
 


### PR DESCRIPTION
There was a broken link in the documentation. This commit fixes it, and adds a CI check to fail if broken links are detected in the future.