### PR TITLE
chore: update rust dependencies to canbench v0.1.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c101d2fdea74ae7b92b8593e03fb325d0158ffbac35a856190e08318f5ec1"
+checksum = "18098e8353459a3e86b2c8f283d652f379195ffc8d29664fcd7caff64f74bc98"
 dependencies = [
  "canbench-rs-macros",
  "candid",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8726b96a8bf207c605542bc29d597dd4f6676d16eb39da765e1a92ef76fcc7e"
+checksum = "e5a8af26a284c9a9be53e3879f24c373a47b9eddbb7c922a1e82d74037b7f40f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.6.8"
 [dependencies]
 ic_principal = { version = "0.1.1", default-features = false }
 # An optional dependency to benchmark parts of the code.
-canbench-rs = { version = "0.1.13", optional = true }
+canbench-rs = { version = "0.1.14", optional = true }
 
 [dev-dependencies]
 candid.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.6.8"
 
 [dependencies]
 ic_principal = { version = "0.1.1", default-features = false }
-canbench-rs = { workspace = true, optional = true }            # An optional dependency to benchmark parts of the code.
+canbench-rs = { workspace = true, optional = true }            # Optional to benchmark parts of the code.
 
 [dev-dependencies]
 candid.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ version = "0.6.8"
 
 [dependencies]
 ic_principal = { version = "0.1.1", default-features = false }
-# An optional dependency to benchmark parts of the code.
-canbench-rs = { version = "0.1.14", optional = true }
+canbench-rs = { workspace = true, optional = true }            # An optional dependency to benchmark parts of the code.
 
 [dev-dependencies]
 candid.workspace = true
@@ -30,6 +29,7 @@ test-strategy = "0.3.1"
 members = ["benchmarks"]
 
 [workspace.dependencies]
+canbench-rs = "0.1.14"
 candid = "0.10.3"
 ic-cdk = "0.12.1"
 ic-cdk-macros = "0.8.4"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-canbench-rs = "0.1.14"
+canbench-rs.workspace = true
 candid.workspace = true
 ic-cdk.workspace = true
 ic-cdk-macros.workspace = true

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-canbench-rs = "0.1.13"
+canbench-rs = "0.1.14"
 candid.workspace = true
 ic-cdk.workspace = true
 ic-cdk-macros.workspace = true


### PR DESCRIPTION
This is a left-over after https://github.com/dfinity/stable-structures/pull/304.