### PR TITLE
fix: gh pages publish dir

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -55,4 +55,4 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/book
+          publish_dir: ./docs/book/html


### PR DESCRIPTION
currently https://dfinity.github.io/stable-structures/html needs to be accessed instead of the in the readme advertised URL https://dfinity.github.io/stable-structures

I expect this change to fix this.