### PR TITLE
perf: Inline from_bytes

### DIFF
--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -1,7 +1,7 @@
 benches:
   btreemap_v2_contains_10mib_values:
     total:
-      instructions: 142213004
+      instructions: 142205766
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -115,139 +115,139 @@ benches:
     scopes: {}
   btreemap_v2_contains_u64_blob8:
     total:
-      instructions: 234897323
+      instructions: 220415166
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_u64_u64:
     total:
-      instructions: 236421608
+      instructions: 221971411
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_u64_vec8:
     total:
-      instructions: 234897338
+      instructions: 220415181
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec8_u64:
     total:
-      instructions: 366491431
+      instructions: 366198881
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_1024_128:
     total:
-      instructions: 2875641971
+      instructions: 2875330977
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_128_128:
     total:
-      instructions: 698056573
+      instructions: 697749792
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_16_128:
     total:
-      instructions: 430496510
+      instructions: 430197715
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_256_128:
     total:
-      instructions: 1220085542
+      instructions: 1219777744
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_32_1024:
     total:
-      instructions: 573798539
+      instructions: 573496205
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_32_128:
     total:
-      instructions: 488603839
+      instructions: 488301624
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_32_16:
     total:
-      instructions: 408307710
+      instructions: 408003935
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_32_256:
     total:
-      instructions: 521878485
+      instructions: 521575504
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_32_32:
     total:
-      instructions: 408806200
+      instructions: 408501502
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_32_4:
     total:
-      instructions: 407179812
+      instructions: 406876890
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_32_512:
     total:
-      instructions: 536998195
+      instructions: 536695503
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_32_64:
     total:
-      instructions: 463602926
+      instructions: 463298379
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_32_8:
     total:
-      instructions: 407102811
+      instructions: 406799819
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_4_128:
     total:
-      instructions: 397153848
+      instructions: 396852340
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_512_128:
     total:
-      instructions: 1812299060
+      instructions: 1811992062
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_64_128:
     total:
-      instructions: 594729377
+      instructions: 594419422
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_contains_vec_8_128:
     total:
-      instructions: 388847731
+      instructions: 388565162
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_10mib_values:
     total:
-      instructions: 1227471777
+      instructions: 388591561
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_blob8_u64:
     total:
-      instructions: 296879911
+      instructions: 296039913
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -355,151 +355,151 @@ benches:
     scopes: {}
   btreemap_v2_get_u64_blob8:
     total:
-      instructions: 244922209
+      instructions: 230440052
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_u64_u64:
     total:
-      instructions: 248828645
+      instructions: 233538450
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_u64_vec8:
     total:
-      instructions: 245697433
+      instructions: 231215276
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec8_u64:
     total:
-      instructions: 376598286
+      instructions: 375465738
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_1024_128:
     total:
-      instructions: 2921699775
+      instructions: 2921388781
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_128_128:
     total:
-      instructions: 710567388
+      instructions: 710260607
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_16_128:
     total:
-      instructions: 440138211
+      instructions: 439839416
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_256_128:
     total:
-      instructions: 1233107092
+      instructions: 1232799294
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_32_1024:
     total:
-      instructions: 606171114
+      instructions: 605868780
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_32_128:
     total:
-      instructions: 498648637
+      instructions: 498346422
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_32_16:
     total:
-      instructions: 416689497
+      instructions: 416385722
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_32_256:
     total:
-      instructions: 539561398
+      instructions: 539258417
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_32_32:
     total:
-      instructions: 416760079
+      instructions: 416455381
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_32_4:
     total:
-      instructions: 414859023
+      instructions: 414556101
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_32_512:
     total:
-      instructions: 558523250
+      instructions: 558220558
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_32_64:
     total:
-      instructions: 471921771
+      instructions: 471617224
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_32_8:
     total:
-      instructions: 414819885
+      instructions: 414516893
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_4_128:
     total:
-      instructions: 406796995
+      instructions: 406495487
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_512_128:
     total:
-      instructions: 1825444224
+      instructions: 1825137226
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_64_128:
     total:
-      instructions: 605941847
+      instructions: 605631892
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_get_vec_8_128:
     total:
-      instructions: 398393757
+      instructions: 398111188
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_insert_10mib_values:
     total:
-      instructions: 5235946225
+      instructions: 5235938163
       heap_increase: 322
       stable_memory_increase: 3613
     scopes: {}
   btreemap_v2_insert_blob8_u64:
     total:
-      instructions: 441974588
+      instructions: 441904168
       heap_increase: 0
       stable_memory_increase: 4
     scopes: {}
   btreemap_v2_insert_blob_1024_128:
     total:
-      instructions: 5105662826
+      instructions: 5105502838
       heap_increase: 0
       stable_memory_increase: 196
     scopes: {}
   btreemap_v2_insert_blob_128_128:
     total:
-      instructions: 1136014881
+      instructions: 1135854893
       heap_increase: 0
       stable_memory_increase: 46
     scopes: {}
@@ -511,7 +511,7 @@ benches:
     scopes: {}
   btreemap_v2_insert_blob_256_128:
     total:
-      instructions: 1686187735
+      instructions: 1686027747
       heap_increase: 0
       stable_memory_increase: 67
     scopes: {}
@@ -529,7 +529,7 @@ benches:
     scopes: {}
   btreemap_v2_insert_blob_32_16:
     total:
-      instructions: 510601135
+      instructions: 510603697
       heap_increase: 0
       stable_memory_increase: 11
     scopes: {}
@@ -541,13 +541,13 @@ benches:
     scopes: {}
   btreemap_v2_insert_blob_32_32:
     total:
-      instructions: 516194516
+      instructions: 516197300
       heap_increase: 0
       stable_memory_increase: 13
     scopes: {}
   btreemap_v2_insert_blob_32_4:
     total:
-      instructions: 498763597
+      instructions: 498764491
       heap_increase: 0
       stable_memory_increase: 8
     scopes: {}
@@ -559,13 +559,13 @@ benches:
     scopes: {}
   btreemap_v2_insert_blob_32_64:
     total:
-      instructions: 521686409
+      instructions: 521846397
       heap_increase: 0
       stable_memory_increase: 18
     scopes: {}
   btreemap_v2_insert_blob_32_8:
     total:
-      instructions: 505899591
+      instructions: 505902273
       heap_increase: 0
       stable_memory_increase: 9
     scopes: {}
@@ -577,7 +577,7 @@ benches:
     scopes: {}
   btreemap_v2_insert_blob_512_128:
     total:
-      instructions: 2857359505
+      instructions: 2857199517
       heap_increase: 0
       stable_memory_increase: 111
     scopes: {}
@@ -595,127 +595,127 @@ benches:
     scopes: {}
   btreemap_v2_insert_u64_blob8:
     total:
-      instructions: 423592780
+      instructions: 409371990
       heap_increase: 0
       stable_memory_increase: 5
     scopes: {}
   btreemap_v2_insert_u64_u64:
     total:
-      instructions: 432443998
+      instructions: 418356354
       heap_increase: 0
       stable_memory_increase: 6
     scopes: {}
   btreemap_v2_insert_u64_vec8:
     total:
-      instructions: 430867481
+      instructions: 416646691
       heap_increase: 0
       stable_memory_increase: 21
     scopes: {}
   btreemap_v2_insert_vec8_u64:
     total:
-      instructions: 582936881
+      instructions: 582567628
       heap_increase: 0
       stable_memory_increase: 16
     scopes: {}
   btreemap_v2_insert_vec_1024_128:
     total:
-      instructions: 3320318834
+      instructions: 3320016640
       heap_increase: 0
       stable_memory_increase: 193
     scopes: {}
   btreemap_v2_insert_vec_128_128:
     total:
-      instructions: 1096900389
+      instructions: 1096598029
       heap_increase: 0
       stable_memory_increase: 51
     scopes: {}
   btreemap_v2_insert_vec_16_128:
     total:
-      instructions: 704339183
+      instructions: 704045105
       heap_increase: 0
       stable_memory_increase: 31
     scopes: {}
   btreemap_v2_insert_vec_256_128:
     total:
-      instructions: 1507926265
+      instructions: 1507625753
       heap_increase: 0
       stable_memory_increase: 71
     scopes: {}
   btreemap_v2_insert_vec_32_1024:
     total:
-      instructions: 1223287735
+      instructions: 1222990248
       heap_increase: 0
       stable_memory_increase: 171
     scopes: {}
   btreemap_v2_insert_vec_32_128:
     total:
-      instructions: 762764143
+      instructions: 762468172
       heap_increase: 0
       stable_memory_increase: 33
     scopes: {}
   btreemap_v2_insert_vec_32_16:
     total:
-      instructions: 664239153
+      instructions: 663941968
       heap_increase: 0
       stable_memory_increase: 20
     scopes: {}
   btreemap_v2_insert_vec_32_256:
     total:
-      instructions: 891677252
+      instructions: 891379346
       heap_increase: 0
       stable_memory_increase: 54
     scopes: {}
   btreemap_v2_insert_vec_32_32:
     total:
-      instructions: 667135925
+      instructions: 666836676
       heap_increase: 0
       stable_memory_increase: 20
     scopes: {}
   btreemap_v2_insert_vec_32_4:
     total:
-      instructions: 661311742
+      instructions: 661014217
       heap_increase: 0
       stable_memory_increase: 20
     scopes: {}
   btreemap_v2_insert_vec_32_512:
     total:
-      instructions: 1010088836
+      instructions: 1009791311
       heap_increase: 0
       stable_memory_increase: 91
     scopes: {}
   btreemap_v2_insert_vec_32_64:
     total:
-      instructions: 693089031
+      instructions: 692793122
       heap_increase: 0
       stable_memory_increase: 24
     scopes: {}
   btreemap_v2_insert_vec_32_8:
     total:
-      instructions: 661078751
+      instructions: 660781147
       heap_increase: 0
       stable_memory_increase: 20
     scopes: {}
   btreemap_v2_insert_vec_4_128:
     total:
-      instructions: 609741470
+      instructions: 609473881
       heap_increase: 0
       stable_memory_increase: 16
     scopes: {}
   btreemap_v2_insert_vec_512_128:
     total:
-      instructions: 2129038112
+      instructions: 2128736325
       heap_increase: 0
       stable_memory_increase: 112
     scopes: {}
   btreemap_v2_insert_vec_64_128:
     total:
-      instructions: 881440750
+      instructions: 881141840
       heap_increase: 0
       stable_memory_increase: 41
     scopes: {}
   btreemap_v2_insert_vec_8_128:
     total:
-      instructions: 667374677
+      instructions: 667087649
       heap_increase: 0
       stable_memory_increase: 23
     scopes: {}
@@ -727,199 +727,199 @@ benches:
     scopes: {}
   btreemap_v2_mem_manager_contains_u64_blob512:
     total:
-      instructions: 311110875
+      instructions: 296668292
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_contains_u64_u64:
     total:
-      instructions: 316748263
+      instructions: 302298066
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_contains_u64_vec512:
     total:
-      instructions: 395074621
+      instructions: 380632038
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_contains_vec512_u64:
     total:
-      instructions: 1752116437
+      instructions: 1751810053
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_get_blob512_u64:
     total:
-      instructions: 2783677145
+      instructions: 2782777145
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_get_u64_blob512:
     total:
-      instructions: 327428758
+      instructions: 312986175
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_get_u64_u64:
     total:
-      instructions: 329340567
+      instructions: 314050372
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_get_u64_vec512:
     total:
-      instructions: 421502583
+      instructions: 407060000
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_get_vec512_u64:
     total:
-      instructions: 1789420475
+      instructions: 1788274093
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_insert_blob512_u64:
     total:
-      instructions: 2962176994
+      instructions: 2962196009
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_insert_u64_blob512:
     total:
-      instructions: 648004738
+      instructions: 633935946
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_insert_u64_u64:
     total:
-      instructions: 561775331
+      instructions: 547687687
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_insert_u64_vec512:
     total:
-      instructions: 901574161
+      instructions: 887505369
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_insert_vec512_u64:
     total:
-      instructions: 2238965672
+      instructions: 2238675735
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_remove_blob512_u64:
     total:
-      instructions: 3913225555
+      instructions: 3913176508
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_remove_u64_blob512:
     total:
-      instructions: 949014826
+      instructions: 933112094
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_remove_u64_u64:
     total:
-      instructions: 808984406
+      instructions: 792963230
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_remove_u64_vec512:
     total:
-      instructions: 1287075502
+      instructions: 1271172770
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_mem_manager_remove_vec512_u64:
     total:
-      instructions: 3315100142
+      instructions: 3314692170
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob8_u64:
     total:
-      instructions: 610076679
+      instructions: 609874035
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_1024_128:
     total:
-      instructions: 9473750849
+      instructions: 9515561561
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_128_128:
     total:
-      instructions: 2024824067
+      instructions: 2030770067
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_16_128:
     total:
-      instructions: 759603609
+      instructions: 759809597
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_256_128:
     total:
-      instructions: 3125559031
+      instructions: 3136633439
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_32_1024:
     total:
-      instructions: 1135364137
+      instructions: 1135813034
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_32_128:
     total:
-      instructions: 879305768
+      instructions: 879754618
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_32_16:
     total:
-      instructions: 822800521
+      instructions: 823288744
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_32_256:
     total:
-      instructions: 910422266
+      instructions: 910872808
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_32_32:
     total:
-      instructions: 834514097
+      instructions: 835124401
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_32_4:
     total:
-      instructions: 804990930
+      instructions: 805506792
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_32_512:
     total:
-      instructions: 976167116
+      instructions: 976616577
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_32_64:
     total:
-      instructions: 841582013
+      instructions: 842029077
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_32_8:
     total:
-      instructions: 821403059
+      instructions: 821861603
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -931,229 +931,229 @@ benches:
     scopes: {}
   btreemap_v2_pop_first_blob_512_128:
     total:
-      instructions: 5232539214
+      instructions: 5253856494
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_64_128:
     total:
-      instructions: 1339157047
+      instructions: 1342523431
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_blob_8_128:
     total:
-      instructions: 613144726
+      instructions: 613229459
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_u64_blob8:
     total:
-      instructions: 706691473
+      instructions: 680849585
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_u64_u64:
     total:
-      instructions: 718797824
+      instructions: 693078421
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_u64_vec8:
     total:
-      instructions: 711032954
+      instructions: 685131066
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec8_u64:
     total:
-      instructions: 783923358
+      instructions: 783315453
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_1024_128:
     total:
-      instructions: 5766183703
+      instructions: 5765642368
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_128_128:
     total:
-      instructions: 1818488923
+      instructions: 1817945546
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_16_128:
     total:
-      instructions: 1026459366
+      instructions: 1025977623
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_256_128:
     total:
-      instructions: 2531808247
+      instructions: 2531258700
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_32_1024:
     total:
-      instructions: 1814183356
+      instructions: 1813667702
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_32_128:
     total:
-      instructions: 1207063329
+      instructions: 1206539580
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_32_16:
     total:
-      instructions: 1041324535
+      instructions: 1040807541
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_32_256:
     total:
-      instructions: 1329079800
+      instructions: 1328565779
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_32_32:
     total:
-      instructions: 1057519198
+      instructions: 1057002665
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_32_4:
     total:
-      instructions: 1040271200
+      instructions: 1039757290
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_32_512:
     total:
-      instructions: 1492583596
+      instructions: 1492074658
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_32_64:
     total:
-      instructions: 1091781548
+      instructions: 1091266495
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_32_8:
     total:
-      instructions: 1052203470
+      instructions: 1051685356
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_4_128:
     total:
-      instructions: 538556765
+      instructions: 538301544
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_512_128:
     total:
-      instructions: 3603065641
+      instructions: 3602527844
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_64_128:
     total:
-      instructions: 1404350364
+      instructions: 1403820790
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_first_vec_8_128:
     total:
-      instructions: 847219043
+      instructions: 846811612
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob8_u64:
     total:
-      instructions: 594162375
+      instructions: 593959731
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_1024_128:
     total:
-      instructions: 9281444843
+      instructions: 9323255555
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_128_128:
     total:
-      instructions: 1974316871
+      instructions: 1980262871
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_16_128:
     total:
-      instructions: 740752586
+      instructions: 740958574
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_256_128:
     total:
-      instructions: 3048994597
+      instructions: 3060069005
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_32_1024:
     total:
-      instructions: 1115278184
+      instructions: 1115727081
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_32_128:
     total:
-      instructions: 857085110
+      instructions: 857533960
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_32_16:
     total:
-      instructions: 801512889
+      instructions: 802001112
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_32_256:
     total:
-      instructions: 889378285
+      instructions: 889828827
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_32_32:
     total:
-      instructions: 813485127
+      instructions: 814095431
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_32_4:
     total:
-      instructions: 790488590
+      instructions: 791004452
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_32_512:
     total:
-      instructions: 957923677
+      instructions: 958373138
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_32_64:
     total:
-      instructions: 823338095
+      instructions: 823785159
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_32_8:
     total:
-      instructions: 800608795
+      instructions: 801067339
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -1165,211 +1165,211 @@ benches:
     scopes: {}
   btreemap_v2_pop_last_blob_512_128:
     total:
-      instructions: 5107040498
+      instructions: 5128357778
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_64_128:
     total:
-      instructions: 1316489984
+      instructions: 1319856368
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_blob_8_128:
     total:
-      instructions: 612929739
+      instructions: 613014472
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_u64_blob8:
     total:
-      instructions: 694235523
+      instructions: 668402753
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_u64_u64:
     total:
-      instructions: 705953291
+      instructions: 680229470
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_u64_vec8:
     total:
-      instructions: 697342452
+      instructions: 671449682
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec8_u64:
     total:
-      instructions: 765235452
+      instructions: 764632330
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_1024_128:
     total:
-      instructions: 6013737134
+      instructions: 6013195562
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_128_128:
     total:
-      instructions: 1832338790
+      instructions: 1831799415
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_16_128:
     total:
-      instructions: 1014626579
+      instructions: 1014148555
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_256_128:
     total:
-      instructions: 2585070338
+      instructions: 2584522543
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_32_1024:
     total:
-      instructions: 1808965981
+      instructions: 1808452255
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_32_128:
     total:
-      instructions: 1206236071
+      instructions: 1205715175
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_32_16:
     total:
-      instructions: 1030158861
+      instructions: 1029643856
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_32_256:
     total:
-      instructions: 1326501391
+      instructions: 1325990822
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_32_32:
     total:
-      instructions: 1045847838
+      instructions: 1045332009
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_32_4:
     total:
-      instructions: 1038590548
+      instructions: 1038073629
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_32_512:
     total:
-      instructions: 1492847763
+      instructions: 1492336097
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_32_64:
     total:
-      instructions: 1086526699
+      instructions: 1086012022
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_32_8:
     total:
-      instructions: 1040373918
+      instructions: 1039859226
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_4_128:
     total:
-      instructions: 529673567
+      instructions: 529420356
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_512_128:
     total:
-      instructions: 3725977783
+      instructions: 3725438908
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_64_128:
     total:
-      instructions: 1417816514
+      instructions: 1417283058
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_pop_last_vec_8_128:
     total:
-      instructions: 854824045
+      instructions: 854405408
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_range_count_1k_0b:
     total:
-      instructions: 16871
+      instructions: 16116
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_range_count_1k_10kib:
     total:
-      instructions: 2440306
+      instructions: 2430698
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_range_count_20_10mib:
     total:
-      instructions: 20572482
+      instructions: 20572085
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_range_key_sum_1k_0b:
     total:
-      instructions: 17405
+      instructions: 16636
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_range_key_sum_1k_10kib:
     total:
-      instructions: 57254917
+      instructions: 57223447
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_range_key_sum_20_10mib:
     total:
-      instructions: 1105826146
+      instructions: 1105825157
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_range_value_sum_1k_0b:
     total:
-      instructions: 17419
+      instructions: 16650
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_range_value_sum_1k_10kib:
     total:
-      instructions: 57266913
+      instructions: 57235443
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_range_value_sum_20_10mib:
     total:
-      instructions: 1105826382
+      instructions: 1105825393
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_10mib_values:
     total:
-      instructions: 5561184088
+      instructions: 4722303381
       heap_increase: 0
       stable_memory_increase: 657
     scopes: {}
   btreemap_v2_remove_blob8_u64:
     total:
-      instructions: 589464558
+      instructions: 589502787
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -1411,7 +1411,7 @@ benches:
     scopes: {}
   btreemap_v2_remove_blob_32_16:
     total:
-      instructions: 690540819
+      instructions: 690598257
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -1423,13 +1423,13 @@ benches:
     scopes: {}
   btreemap_v2_remove_blob_32_32:
     total:
-      instructions: 699351787
+      instructions: 699409003
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_blob_32_4:
     total:
-      instructions: 682724479
+      instructions: 682743585
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -1447,7 +1447,7 @@ benches:
     scopes: {}
   btreemap_v2_remove_blob_32_8:
     total:
-      instructions: 683317453
+      instructions: 683374771
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -1477,235 +1477,235 @@ benches:
     scopes: {}
   btreemap_v2_remove_u64_blob8:
     total:
-      instructions: 599175833
+      instructions: 583411497
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_u64_u64:
     total:
-      instructions: 620769990
+      instructions: 604748819
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_u64_vec8:
     total:
-      instructions: 605095020
+      instructions: 589270684
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec8_u64:
     total:
-      instructions: 752630424
+      instructions: 752324238
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_1024_128:
     total:
-      instructions: 5025216242
+      instructions: 5024878622
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_128_128:
     total:
-      instructions: 1454626976
+      instructions: 1454289615
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_16_128:
     total:
-      instructions: 910188712
+      instructions: 909857926
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_256_128:
     total:
-      instructions: 2317533219
+      instructions: 2317194166
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_32_1024:
     total:
-      instructions: 1676471982
+      instructions: 1676138434
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_32_128:
     total:
-      instructions: 1013253216
+      instructions: 1012919630
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_32_16:
     total:
-      instructions: 837109438
+      instructions: 836775350
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_32_256:
     total:
-      instructions: 1231722935
+      instructions: 1231388606
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_32_32:
     total:
-      instructions: 843622950
+      instructions: 843288710
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_32_4:
     total:
-      instructions: 842127510
+      instructions: 841791715
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_32_512:
     total:
-      instructions: 1395485657
+      instructions: 1395152647
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_32_64:
     total:
-      instructions: 926200014
+      instructions: 925864211
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_32_8:
     total:
-      instructions: 835788684
+      instructions: 835455678
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_4_128:
     total:
-      instructions: 651172604
+      instructions: 650876759
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_512_128:
     total:
-      instructions: 3269241618
+      instructions: 3268904351
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_64_128:
     total:
-      instructions: 1181251874
+      instructions: 1180916062
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_remove_vec_8_128:
     total:
-      instructions: 822231376
+      instructions: 821907983
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_iter_1k_0b:
     total:
-      instructions: 1493458
+      instructions: 1462853
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_iter_1k_10kib:
     total:
-      instructions: 57069957
+      instructions: 57039052
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_iter_20_10mib:
     total:
-      instructions: 1103719699
+      instructions: 1103718913
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_iter_rev_1k_0b:
     total:
-      instructions: 1495597
+      instructions: 1464279
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_iter_rev_1k_10kib:
     total:
-      instructions: 57047594
+      instructions: 57015976
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_iter_rev_20_10mib:
     total:
-      instructions: 1103719281
+      instructions: 1103718490
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_keys_1k_0b:
     total:
-      instructions: 946083
+      instructions: 935633
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_keys_1k_10kib:
     total:
-      instructions: 2359607
+      instructions: 2348959
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_keys_20_10mib:
     total:
-      instructions: 18465439
+      instructions: 18465091
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_keys_rev_1k_0b:
     total:
-      instructions: 963320
+      instructions: 936583
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_keys_rev_1k_10kib:
     total:
-      instructions: 2355505
+      instructions: 2328902
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_keys_rev_20_10mib:
     total:
-      instructions: 18465774
+      instructions: 18465101
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_values_1k_0b:
     total:
-      instructions: 1490856
+      instructions: 1457191
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_values_1k_10kib:
     total:
-      instructions: 57067355
+      instructions: 57033390
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_values_20_10mib:
     total:
-      instructions: 1103719649
+      instructions: 1103718803
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_values_rev_1k_0b:
     total:
-      instructions: 1492995
+      instructions: 1459281
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_values_rev_1k_10kib:
     total:
-      instructions: 57044992
+      instructions: 57010978
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   btreemap_v2_scan_values_rev_20_10mib:
     total:
-      instructions: 1103719231
+      instructions: 1103718392
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -1735,25 +1735,25 @@ benches:
     scopes: {}
   vec_get_blob_16:
     total:
-      instructions: 6345942
+      instructions: 6405942
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   vec_get_blob_32:
     total:
-      instructions: 7063501
+      instructions: 7123501
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   vec_get_blob_4:
     total:
-      instructions: 4804323
+      instructions: 4824323
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   vec_get_blob_4_mem_manager:
     total:
-      instructions: 7171673
+      instructions: 7191673
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -1771,13 +1771,13 @@ benches:
     scopes: {}
   vec_get_blob_8:
     total:
-      instructions: 5620865
+      instructions: 5723197
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   vec_get_u64:
     total:
-      instructions: 5270302
+      instructions: 4790302
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -179,6 +179,7 @@ impl<const N: usize> Storable for Blob<N> {
         Cow::Borrowed(self.as_slice())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Self::try_from(bytes.borrow()).unwrap()
     }
@@ -223,6 +224,7 @@ impl<const N: usize> Storable for FixedVec<N> {
         Cow::Owned(self.0.clone())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         FixedVec(bytes.into_owned())
     }
@@ -247,6 +249,7 @@ impl Storable for () {
         Cow::Borrowed(&[])
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         assert!(bytes.is_empty());
     }
@@ -264,8 +267,9 @@ impl Storable for Vec<u8> {
         Cow::Borrowed(self)
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        bytes.to_vec()
+        bytes.into_owned()
     }
 
     const BOUND: Bound = Bound::Unbounded;
@@ -276,8 +280,9 @@ impl Storable for String {
         Cow::Borrowed(self.as_bytes())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        String::from_utf8(bytes.to_vec()).unwrap()
+        String::from_utf8(bytes.into_owned()).unwrap()
     }
 
     const BOUND: Bound = Bound::Unbounded;
@@ -288,6 +293,7 @@ impl Storable for u128 {
         Cow::Owned(self.to_be_bytes().to_vec())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Self::from_be_bytes(bytes.as_ref().try_into().unwrap())
     }
@@ -303,6 +309,7 @@ impl Storable for u64 {
         Cow::Owned(self.to_be_bytes().to_vec())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Self::from_be_bytes(bytes.as_ref().try_into().unwrap())
     }
@@ -318,6 +325,7 @@ impl Storable for f64 {
         Cow::Owned(self.to_be_bytes().to_vec())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Self::from_be_bytes(bytes.as_ref().try_into().unwrap())
     }
@@ -333,6 +341,7 @@ impl Storable for u32 {
         Cow::Owned(self.to_be_bytes().to_vec())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Self::from_be_bytes(bytes.as_ref().try_into().unwrap())
     }
@@ -348,6 +357,7 @@ impl Storable for f32 {
         Cow::Owned(self.to_be_bytes().to_vec())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Self::from_be_bytes(bytes.as_ref().try_into().unwrap())
     }
@@ -363,6 +373,7 @@ impl Storable for u16 {
         Cow::Owned(self.to_be_bytes().to_vec())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Self::from_be_bytes(bytes.as_ref().try_into().unwrap())
     }
@@ -378,6 +389,7 @@ impl Storable for u8 {
         Cow::Owned(self.to_be_bytes().to_vec())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Self::from_be_bytes(bytes.as_ref().try_into().unwrap())
     }
@@ -394,6 +406,7 @@ impl Storable for bool {
         Cow::Owned(num.to_be_bytes().to_vec())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         assert_eq!(bytes.len(), 1);
         match bytes[0] {
@@ -414,6 +427,7 @@ impl<const N: usize> Storable for [u8; N] {
         Cow::Borrowed(&self[..])
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         assert_eq!(bytes.len(), N);
         let mut arr = [0; N];
@@ -432,6 +446,7 @@ impl<T: Storable> Storable for Reverse<T> {
         self.0.to_bytes()
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Self(T::from_bytes(bytes))
     }
@@ -451,6 +466,7 @@ impl<T: Storable> Storable for Option<T> {
         }
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         match bytes.split_last() {
             Some((last, rest)) => match last {
@@ -484,6 +500,7 @@ impl Storable for Principal {
         Cow::Borrowed(self.as_slice())
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Self::from_slice(&bytes)
     }

--- a/src/storable/tuples.rs
+++ b/src/storable/tuples.rs
@@ -49,6 +49,7 @@ where
         }
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         match Self::BOUND {
             Bound::Bounded { max_size, .. } => {
@@ -294,6 +295,7 @@ where
         Cow::Owned(bytes)
     }
 
+    #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         let mut bytes_read_total = 0;
 


### PR DESCRIPTION
Add the `#[inline]` attribute to the `from_bytes` method in all `Storable` trait implementations.

The motivation is that it's usually known at the call site what `Cow` variant is being passed (owned or borrowed). By inlining, the compiler can optimize for the passed `Cow` variant.
