### PR TITLE
fix: do not trigger slack notification upon adding reviewers

### DIFF
--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -2,11 +2,12 @@ name: PR Slack Notification
 
 on:
   pull_request:
-    types: [review_requested]
+    types: [opened, ready_for_review]
 
 jobs:
   notify-slack:
     name: Notify Slack
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR fixes the slack notification bot to only push a notification when the PR is opened (not as a draft) or marked as ready for review. In particular, no notifications are pushed when individual reviewers are asked for a review.