### PR TITLE
fix: fix dependency for bench_scope feature in benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tempfile = "3.3.0"
 test-strategy = "0.3.1"
 
 [features]
-bench_scope = [] # May add significant overhead.
+bench_scope = ["dep:canbench-rs"] # May add significant overhead.
 
 [workspace]
 members = ["benchmarks"]


### PR DESCRIPTION
This PR fixes the benchmarks dependencies when used with `bench_scope` feature flag.