### PR TITLE
refactor: rename FixedVec to UnboundedVecN

### DIFF
--- a/benchmarks/btreemap/src/main.rs
+++ b/benchmarks/btreemap/src/main.rs
@@ -2,7 +2,7 @@ use benchmarks::common::Random;
 use canbench_rs::{bench, bench_fn, BenchResult};
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
 use ic_stable_structures::{
-    storable::{Blob, FixedVec},
+    storable::{Blob, UnboundedVecN},
     BTreeMap, DefaultMemoryImpl, Memory, Storable,
 };
 use std::ops::Bound;
@@ -20,15 +20,15 @@ type Blob512 = Blob<512>;
 type Blob1024 = Blob<1024>;
 
 // Unbounded types.
-type FixedVec4 = FixedVec<4>;
-type FixedVec8 = FixedVec<8>;
-type FixedVec16 = FixedVec<16>;
-type FixedVec32 = FixedVec<32>;
-type FixedVec64 = FixedVec<64>;
-type FixedVec128 = FixedVec<128>;
-type FixedVec256 = FixedVec<256>;
-type FixedVec512 = FixedVec<512>;
-type FixedVec1024 = FixedVec<1024>;
+type UnboundedVecN4 = UnboundedVecN<4>;
+type UnboundedVecN8 = UnboundedVecN<8>;
+type UnboundedVecN16 = UnboundedVecN<16>;
+type UnboundedVecN32 = UnboundedVecN<32>;
+type UnboundedVecN64 = UnboundedVecN<64>;
+type UnboundedVecN128 = UnboundedVecN<128>;
+type UnboundedVecN256 = UnboundedVecN<256>;
+type UnboundedVecN512 = UnboundedVecN<512>;
+type UnboundedVecN1024 = UnboundedVecN<1024>;
 
 #[allow(non_upper_case_globals)]
 const KiB: usize = 1024;
@@ -92,40 +92,40 @@ bench_tests! {
     btreemap_v2_insert_blob_32_1024, insert_helper_v2, Blob32, Blob1024;
 
     // vec K x 128
-    btreemap_v2_insert_vec_4_128,    insert_helper_v2,    FixedVec4, FixedVec128;
-    btreemap_v2_insert_vec_8_128,    insert_helper_v2,    FixedVec8, FixedVec128;
-    btreemap_v2_insert_vec_16_128,   insert_helper_v2,   FixedVec16, FixedVec128;
-    btreemap_v2_insert_vec_32_128,   insert_helper_v2,   FixedVec32, FixedVec128;
-    btreemap_v2_insert_vec_64_128,   insert_helper_v2,   FixedVec64, FixedVec128;
-    btreemap_v2_insert_vec_128_128,  insert_helper_v2,  FixedVec128, FixedVec128;
-    btreemap_v2_insert_vec_256_128,  insert_helper_v2,  FixedVec256, FixedVec128;
-    btreemap_v2_insert_vec_512_128,  insert_helper_v2,  FixedVec512, FixedVec128;
-    btreemap_v2_insert_vec_1024_128, insert_helper_v2, FixedVec1024, FixedVec128;
+    btreemap_v2_insert_vec_4_128,    insert_helper_v2,    UnboundedVecN4, UnboundedVecN128;
+    btreemap_v2_insert_vec_8_128,    insert_helper_v2,    UnboundedVecN8, UnboundedVecN128;
+    btreemap_v2_insert_vec_16_128,   insert_helper_v2,   UnboundedVecN16, UnboundedVecN128;
+    btreemap_v2_insert_vec_32_128,   insert_helper_v2,   UnboundedVecN32, UnboundedVecN128;
+    btreemap_v2_insert_vec_64_128,   insert_helper_v2,   UnboundedVecN64, UnboundedVecN128;
+    btreemap_v2_insert_vec_128_128,  insert_helper_v2,  UnboundedVecN128, UnboundedVecN128;
+    btreemap_v2_insert_vec_256_128,  insert_helper_v2,  UnboundedVecN256, UnboundedVecN128;
+    btreemap_v2_insert_vec_512_128,  insert_helper_v2,  UnboundedVecN512, UnboundedVecN128;
+    btreemap_v2_insert_vec_1024_128, insert_helper_v2, UnboundedVecN1024, UnboundedVecN128;
 
     // vec 32 x V
-    btreemap_v2_insert_vec_32_4,    insert_helper_v2, FixedVec32,    FixedVec4;
-    btreemap_v2_insert_vec_32_8,    insert_helper_v2, FixedVec32,    FixedVec8;
-    btreemap_v2_insert_vec_32_16,   insert_helper_v2, FixedVec32,   FixedVec16;
-    btreemap_v2_insert_vec_32_32,   insert_helper_v2, FixedVec32,   FixedVec32;
-    btreemap_v2_insert_vec_32_64,   insert_helper_v2, FixedVec32,   FixedVec64;
-    //btreemap_v2_insert_vec_32_128,  insert_helper_v2, FixedVec32,  FixedVec128;  // Skip repeated.
-    btreemap_v2_insert_vec_32_256,  insert_helper_v2, FixedVec32,  FixedVec256;
-    btreemap_v2_insert_vec_32_512,  insert_helper_v2, FixedVec32,  FixedVec512;
-    btreemap_v2_insert_vec_32_1024, insert_helper_v2, FixedVec32, FixedVec1024;
+    btreemap_v2_insert_vec_32_4,    insert_helper_v2, UnboundedVecN32,    UnboundedVecN4;
+    btreemap_v2_insert_vec_32_8,    insert_helper_v2, UnboundedVecN32,    UnboundedVecN8;
+    btreemap_v2_insert_vec_32_16,   insert_helper_v2, UnboundedVecN32,   UnboundedVecN16;
+    btreemap_v2_insert_vec_32_32,   insert_helper_v2, UnboundedVecN32,   UnboundedVecN32;
+    btreemap_v2_insert_vec_32_64,   insert_helper_v2, UnboundedVecN32,   UnboundedVecN64;
+    //btreemap_v2_insert_vec_32_128,  insert_helper_v2, UnboundedVecN32,  UnboundedVecN128;  // Skip repeated.
+    btreemap_v2_insert_vec_32_256,  insert_helper_v2, UnboundedVecN32,  UnboundedVecN256;
+    btreemap_v2_insert_vec_32_512,  insert_helper_v2, UnboundedVecN32,  UnboundedVecN512;
+    btreemap_v2_insert_vec_32_1024, insert_helper_v2, UnboundedVecN32, UnboundedVecN1024;
 
     // u64 / blob8 / vec8
-    btreemap_v2_insert_u64_u64,        insert_helper_v2,       u64,       u64;
-    btreemap_v2_insert_u64_blob8,      insert_helper_v2,       u64,     Blob8;
-    btreemap_v2_insert_blob8_u64,      insert_helper_v2,     Blob8,       u64;
-    btreemap_v2_insert_u64_vec8,       insert_helper_v2,       u64, FixedVec8;
-    btreemap_v2_insert_vec8_u64,       insert_helper_v2, FixedVec8,       u64;
+    btreemap_v2_insert_u64_u64,        insert_helper_v2,            u64,            u64;
+    btreemap_v2_insert_u64_blob8,      insert_helper_v2,            u64,          Blob8;
+    btreemap_v2_insert_blob8_u64,      insert_helper_v2,          Blob8,            u64;
+    btreemap_v2_insert_u64_vec8,       insert_helper_v2,            u64, UnboundedVecN8;
+    btreemap_v2_insert_vec8_u64,       insert_helper_v2, UnboundedVecN8,            u64;
 
     // memory manager u64 / blob512 / vec512
-    btreemap_v2_mem_manager_insert_u64_u64,      insert_helper_v2_mem_manager,         u64,         u64;
-    btreemap_v2_mem_manager_insert_u64_blob512,  insert_helper_v2_mem_manager,         u64,     Blob512;
-    btreemap_v2_mem_manager_insert_blob512_u64,  insert_helper_v2_mem_manager,     Blob512,         u64;
-    btreemap_v2_mem_manager_insert_u64_vec512,   insert_helper_v2_mem_manager,         u64, FixedVec512;
-    btreemap_v2_mem_manager_insert_vec512_u64,   insert_helper_v2_mem_manager, FixedVec512,         u64;
+    btreemap_v2_mem_manager_insert_u64_u64,      insert_helper_v2_mem_manager,              u64,              u64;
+    btreemap_v2_mem_manager_insert_u64_blob512,  insert_helper_v2_mem_manager,              u64,          Blob512;
+    btreemap_v2_mem_manager_insert_blob512_u64,  insert_helper_v2_mem_manager,          Blob512,              u64;
+    btreemap_v2_mem_manager_insert_u64_vec512,   insert_helper_v2_mem_manager,              u64, UnboundedVecN512;
+    btreemap_v2_mem_manager_insert_vec512_u64,   insert_helper_v2_mem_manager, UnboundedVecN512,              u64;
 }
 
 fn insert_helper_v2<K: TestKey, V: TestValue>() -> BenchResult {
@@ -192,40 +192,40 @@ bench_tests! {
     btreemap_v2_remove_blob_32_1024, remove_helper_v2, Blob32, Blob1024;
 
     // vec K x 128
-    btreemap_v2_remove_vec_4_128,    remove_helper_v2,    FixedVec4, FixedVec128;
-    btreemap_v2_remove_vec_8_128,    remove_helper_v2,    FixedVec8, FixedVec128;
-    btreemap_v2_remove_vec_16_128,   remove_helper_v2,   FixedVec16, FixedVec128;
-    btreemap_v2_remove_vec_32_128,   remove_helper_v2,   FixedVec32, FixedVec128;
-    btreemap_v2_remove_vec_64_128,   remove_helper_v2,   FixedVec64, FixedVec128;
-    btreemap_v2_remove_vec_128_128,  remove_helper_v2,  FixedVec128, FixedVec128;
-    btreemap_v2_remove_vec_256_128,  remove_helper_v2,  FixedVec256, FixedVec128;
-    btreemap_v2_remove_vec_512_128,  remove_helper_v2,  FixedVec512, FixedVec128;
-    btreemap_v2_remove_vec_1024_128, remove_helper_v2, FixedVec1024, FixedVec128;
+    btreemap_v2_remove_vec_4_128,    remove_helper_v2,    UnboundedVecN4, UnboundedVecN128;
+    btreemap_v2_remove_vec_8_128,    remove_helper_v2,    UnboundedVecN8, UnboundedVecN128;
+    btreemap_v2_remove_vec_16_128,   remove_helper_v2,   UnboundedVecN16, UnboundedVecN128;
+    btreemap_v2_remove_vec_32_128,   remove_helper_v2,   UnboundedVecN32, UnboundedVecN128;
+    btreemap_v2_remove_vec_64_128,   remove_helper_v2,   UnboundedVecN64, UnboundedVecN128;
+    btreemap_v2_remove_vec_128_128,  remove_helper_v2,  UnboundedVecN128, UnboundedVecN128;
+    btreemap_v2_remove_vec_256_128,  remove_helper_v2,  UnboundedVecN256, UnboundedVecN128;
+    btreemap_v2_remove_vec_512_128,  remove_helper_v2,  UnboundedVecN512, UnboundedVecN128;
+    btreemap_v2_remove_vec_1024_128, remove_helper_v2, UnboundedVecN1024, UnboundedVecN128;
 
     // vec 32 x V
-    btreemap_v2_remove_vec_32_4,    remove_helper_v2, FixedVec32,    FixedVec4;
-    btreemap_v2_remove_vec_32_8,    remove_helper_v2, FixedVec32,    FixedVec8;
-    btreemap_v2_remove_vec_32_16,   remove_helper_v2, FixedVec32,   FixedVec16;
-    btreemap_v2_remove_vec_32_32,   remove_helper_v2, FixedVec32,   FixedVec32;
-    btreemap_v2_remove_vec_32_64,   remove_helper_v2, FixedVec32,   FixedVec64;
-    //btreemap_v2_remove_vec_32_128,  remove_helper_v2, FixedVec32,  FixedVec128;  // Skip repeated.
-    btreemap_v2_remove_vec_32_256,  remove_helper_v2, FixedVec32,  FixedVec256;
-    btreemap_v2_remove_vec_32_512,  remove_helper_v2, FixedVec32,  FixedVec512;
-    btreemap_v2_remove_vec_32_1024, remove_helper_v2, FixedVec32, FixedVec1024;
+    btreemap_v2_remove_vec_32_4,    remove_helper_v2, UnboundedVecN32,    UnboundedVecN4;
+    btreemap_v2_remove_vec_32_8,    remove_helper_v2, UnboundedVecN32,    UnboundedVecN8;
+    btreemap_v2_remove_vec_32_16,   remove_helper_v2, UnboundedVecN32,   UnboundedVecN16;
+    btreemap_v2_remove_vec_32_32,   remove_helper_v2, UnboundedVecN32,   UnboundedVecN32;
+    btreemap_v2_remove_vec_32_64,   remove_helper_v2, UnboundedVecN32,   UnboundedVecN64;
+    //btreemap_v2_remove_vec_32_128,  remove_helper_v2, UnboundedVecN32,  UnboundedVecN128;  // Skip repeated.
+    btreemap_v2_remove_vec_32_256,  remove_helper_v2, UnboundedVecN32,  UnboundedVecN256;
+    btreemap_v2_remove_vec_32_512,  remove_helper_v2, UnboundedVecN32,  UnboundedVecN512;
+    btreemap_v2_remove_vec_32_1024, remove_helper_v2, UnboundedVecN32, UnboundedVecN1024;
 
     // u64 / blob8 / vec8
-    btreemap_v2_remove_u64_u64,        remove_helper_v2,       u64,       u64;
-    btreemap_v2_remove_u64_blob8,      remove_helper_v2,       u64,     Blob8;
-    btreemap_v2_remove_blob8_u64,      remove_helper_v2,     Blob8,       u64;
-    btreemap_v2_remove_u64_vec8,       remove_helper_v2,       u64, FixedVec8;
-    btreemap_v2_remove_vec8_u64,       remove_helper_v2, FixedVec8,       u64;
+    btreemap_v2_remove_u64_u64,        remove_helper_v2,            u64,            u64;
+    btreemap_v2_remove_u64_blob8,      remove_helper_v2,            u64,          Blob8;
+    btreemap_v2_remove_blob8_u64,      remove_helper_v2,          Blob8,            u64;
+    btreemap_v2_remove_u64_vec8,       remove_helper_v2,            u64, UnboundedVecN8;
+    btreemap_v2_remove_vec8_u64,       remove_helper_v2, UnboundedVecN8,            u64;
 
     // memory manager u64 / blob512 / vec512
-    btreemap_v2_mem_manager_remove_u64_u64,      remove_helper_v2_mem_manager,         u64,         u64;
-    btreemap_v2_mem_manager_remove_u64_blob512,  remove_helper_v2_mem_manager,         u64,     Blob512;
-    btreemap_v2_mem_manager_remove_blob512_u64,  remove_helper_v2_mem_manager,     Blob512,         u64;
-    btreemap_v2_mem_manager_remove_u64_vec512,   remove_helper_v2_mem_manager,         u64, FixedVec512;
-    btreemap_v2_mem_manager_remove_vec512_u64,   remove_helper_v2_mem_manager, FixedVec512,         u64;
+    btreemap_v2_mem_manager_remove_u64_u64,      remove_helper_v2_mem_manager,              u64,              u64;
+    btreemap_v2_mem_manager_remove_u64_blob512,  remove_helper_v2_mem_manager,              u64,          Blob512;
+    btreemap_v2_mem_manager_remove_blob512_u64,  remove_helper_v2_mem_manager,          Blob512,              u64;
+    btreemap_v2_mem_manager_remove_u64_vec512,   remove_helper_v2_mem_manager,              u64, UnboundedVecN512;
+    btreemap_v2_mem_manager_remove_vec512_u64,   remove_helper_v2_mem_manager, UnboundedVecN512,              u64;
 }
 
 fn remove_helper_v2<K: TestKey, V: TestValue>() -> BenchResult {
@@ -299,40 +299,40 @@ bench_tests! {
     btreemap_v2_get_blob_32_1024, get_helper_v2, Blob32, Blob1024;
 
     // vec K x 128
-    btreemap_v2_get_vec_4_128,    get_helper_v2,    FixedVec4, FixedVec128;
-    btreemap_v2_get_vec_8_128,    get_helper_v2,    FixedVec8, FixedVec128;
-    btreemap_v2_get_vec_16_128,   get_helper_v2,   FixedVec16, FixedVec128;
-    btreemap_v2_get_vec_32_128,   get_helper_v2,   FixedVec32, FixedVec128;
-    btreemap_v2_get_vec_64_128,   get_helper_v2,   FixedVec64, FixedVec128;
-    btreemap_v2_get_vec_128_128,  get_helper_v2,  FixedVec128, FixedVec128;
-    btreemap_v2_get_vec_256_128,  get_helper_v2,  FixedVec256, FixedVec128;
-    btreemap_v2_get_vec_512_128,  get_helper_v2,  FixedVec512, FixedVec128;
-    btreemap_v2_get_vec_1024_128, get_helper_v2, FixedVec1024, FixedVec128;
+    btreemap_v2_get_vec_4_128,    get_helper_v2,    UnboundedVecN4, UnboundedVecN128;
+    btreemap_v2_get_vec_8_128,    get_helper_v2,    UnboundedVecN8, UnboundedVecN128;
+    btreemap_v2_get_vec_16_128,   get_helper_v2,   UnboundedVecN16, UnboundedVecN128;
+    btreemap_v2_get_vec_32_128,   get_helper_v2,   UnboundedVecN32, UnboundedVecN128;
+    btreemap_v2_get_vec_64_128,   get_helper_v2,   UnboundedVecN64, UnboundedVecN128;
+    btreemap_v2_get_vec_128_128,  get_helper_v2,  UnboundedVecN128, UnboundedVecN128;
+    btreemap_v2_get_vec_256_128,  get_helper_v2,  UnboundedVecN256, UnboundedVecN128;
+    btreemap_v2_get_vec_512_128,  get_helper_v2,  UnboundedVecN512, UnboundedVecN128;
+    btreemap_v2_get_vec_1024_128, get_helper_v2, UnboundedVecN1024, UnboundedVecN128;
 
     // vec 32 x V
-    btreemap_v2_get_vec_32_4,    get_helper_v2, FixedVec32,    FixedVec4;
-    btreemap_v2_get_vec_32_8,    get_helper_v2, FixedVec32,    FixedVec8;
-    btreemap_v2_get_vec_32_16,   get_helper_v2, FixedVec32,   FixedVec16;
-    btreemap_v2_get_vec_32_32,   get_helper_v2, FixedVec32,   FixedVec32;
-    btreemap_v2_get_vec_32_64,   get_helper_v2, FixedVec32,   FixedVec64;
-    //btreemap_v2_get_vec_32_128,  get_helper_v2, FixedVec32,  FixedVec128;  // Skip repeated.
-    btreemap_v2_get_vec_32_256,  get_helper_v2, FixedVec32,  FixedVec256;
-    btreemap_v2_get_vec_32_512,  get_helper_v2, FixedVec32,  FixedVec512;
-    btreemap_v2_get_vec_32_1024, get_helper_v2, FixedVec32, FixedVec1024;
+    btreemap_v2_get_vec_32_4,    get_helper_v2, UnboundedVecN32,    UnboundedVecN4;
+    btreemap_v2_get_vec_32_8,    get_helper_v2, UnboundedVecN32,    UnboundedVecN8;
+    btreemap_v2_get_vec_32_16,   get_helper_v2, UnboundedVecN32,   UnboundedVecN16;
+    btreemap_v2_get_vec_32_32,   get_helper_v2, UnboundedVecN32,   UnboundedVecN32;
+    btreemap_v2_get_vec_32_64,   get_helper_v2, UnboundedVecN32,   UnboundedVecN64;
+    //btreemap_v2_get_vec_32_128,  get_helper_v2, UnboundedVecN32,  UnboundedVecN128;  // Skip repeated.
+    btreemap_v2_get_vec_32_256,  get_helper_v2, UnboundedVecN32,  UnboundedVecN256;
+    btreemap_v2_get_vec_32_512,  get_helper_v2, UnboundedVecN32,  UnboundedVecN512;
+    btreemap_v2_get_vec_32_1024, get_helper_v2, UnboundedVecN32, UnboundedVecN1024;
 
     // u64 / blob8 / vec8
-    btreemap_v2_get_u64_u64,        get_helper_v2,       u64,       u64;
-    btreemap_v2_get_u64_blob8,      get_helper_v2,       u64,     Blob8;
-    btreemap_v2_get_blob8_u64,      get_helper_v2,     Blob8,       u64;
-    btreemap_v2_get_u64_vec8,       get_helper_v2,       u64, FixedVec8;
-    btreemap_v2_get_vec8_u64,       get_helper_v2, FixedVec8,       u64;
+    btreemap_v2_get_u64_u64,        get_helper_v2,            u64,            u64;
+    btreemap_v2_get_u64_blob8,      get_helper_v2,            u64,          Blob8;
+    btreemap_v2_get_blob8_u64,      get_helper_v2,          Blob8,            u64;
+    btreemap_v2_get_u64_vec8,       get_helper_v2,            u64, UnboundedVecN8;
+    btreemap_v2_get_vec8_u64,       get_helper_v2, UnboundedVecN8,            u64;
 
     // memory manager u64 / blob512 / vec512
-    btreemap_v2_mem_manager_get_u64_u64,      get_helper_v2_mem_manager,         u64,         u64;
-    btreemap_v2_mem_manager_get_u64_blob512,  get_helper_v2_mem_manager,         u64,     Blob512;
-    btreemap_v2_mem_manager_get_blob512_u64,  get_helper_v2_mem_manager,     Blob512,         u64;
-    btreemap_v2_mem_manager_get_u64_vec512,   get_helper_v2_mem_manager,         u64, FixedVec512;
-    btreemap_v2_mem_manager_get_vec512_u64,   get_helper_v2_mem_manager, FixedVec512,         u64;
+    btreemap_v2_mem_manager_get_u64_u64,      get_helper_v2_mem_manager,              u64,              u64;
+    btreemap_v2_mem_manager_get_u64_blob512,  get_helper_v2_mem_manager,              u64,          Blob512;
+    btreemap_v2_mem_manager_get_blob512_u64,  get_helper_v2_mem_manager,          Blob512,              u64;
+    btreemap_v2_mem_manager_get_u64_vec512,   get_helper_v2_mem_manager,              u64, UnboundedVecN512;
+    btreemap_v2_mem_manager_get_vec512_u64,   get_helper_v2_mem_manager, UnboundedVecN512,              u64;
 }
 
 fn get_helper_v2<K: TestKey, V: TestValue>() -> BenchResult {
@@ -406,40 +406,40 @@ bench_tests! {
     btreemap_v2_contains_blob_32_1024, contains_helper_v2, Blob32, Blob1024;
 
     // vec K x 128
-    btreemap_v2_contains_vec_4_128,    contains_helper_v2,    FixedVec4, FixedVec128;
-    btreemap_v2_contains_vec_8_128,    contains_helper_v2,    FixedVec8, FixedVec128;
-    btreemap_v2_contains_vec_16_128,   contains_helper_v2,   FixedVec16, FixedVec128;
-    btreemap_v2_contains_vec_32_128,   contains_helper_v2,   FixedVec32, FixedVec128;
-    btreemap_v2_contains_vec_64_128,   contains_helper_v2,   FixedVec64, FixedVec128;
-    btreemap_v2_contains_vec_128_128,  contains_helper_v2,  FixedVec128, FixedVec128;
-    btreemap_v2_contains_vec_256_128,  contains_helper_v2,  FixedVec256, FixedVec128;
-    btreemap_v2_contains_vec_512_128,  contains_helper_v2,  FixedVec512, FixedVec128;
-    btreemap_v2_contains_vec_1024_128, contains_helper_v2, FixedVec1024, FixedVec128;
+    btreemap_v2_contains_vec_4_128,    contains_helper_v2,    UnboundedVecN4, UnboundedVecN128;
+    btreemap_v2_contains_vec_8_128,    contains_helper_v2,    UnboundedVecN8, UnboundedVecN128;
+    btreemap_v2_contains_vec_16_128,   contains_helper_v2,   UnboundedVecN16, UnboundedVecN128;
+    btreemap_v2_contains_vec_32_128,   contains_helper_v2,   UnboundedVecN32, UnboundedVecN128;
+    btreemap_v2_contains_vec_64_128,   contains_helper_v2,   UnboundedVecN64, UnboundedVecN128;
+    btreemap_v2_contains_vec_128_128,  contains_helper_v2,  UnboundedVecN128, UnboundedVecN128;
+    btreemap_v2_contains_vec_256_128,  contains_helper_v2,  UnboundedVecN256, UnboundedVecN128;
+    btreemap_v2_contains_vec_512_128,  contains_helper_v2,  UnboundedVecN512, UnboundedVecN128;
+    btreemap_v2_contains_vec_1024_128, contains_helper_v2, UnboundedVecN1024, UnboundedVecN128;
 
     // vec 32 x V
-    btreemap_v2_contains_vec_32_4,    contains_helper_v2, FixedVec32,    FixedVec4;
-    btreemap_v2_contains_vec_32_8,    contains_helper_v2, FixedVec32,    FixedVec8;
-    btreemap_v2_contains_vec_32_16,   contains_helper_v2, FixedVec32,   FixedVec16;
-    btreemap_v2_contains_vec_32_32,   contains_helper_v2, FixedVec32,   FixedVec32;
-    btreemap_v2_contains_vec_32_64,   contains_helper_v2, FixedVec32,   FixedVec64;
-    //btreemap_v2_contains_vec_32_128,  contains_helper_v2, FixedVec32,  FixedVec128;  // Skip repeated.
-    btreemap_v2_contains_vec_32_256,  contains_helper_v2, FixedVec32,  FixedVec256;
-    btreemap_v2_contains_vec_32_512,  contains_helper_v2, FixedVec32,  FixedVec512;
-    btreemap_v2_contains_vec_32_1024, contains_helper_v2, FixedVec32, FixedVec1024;
+    btreemap_v2_contains_vec_32_4,    contains_helper_v2, UnboundedVecN32,    UnboundedVecN4;
+    btreemap_v2_contains_vec_32_8,    contains_helper_v2, UnboundedVecN32,    UnboundedVecN8;
+    btreemap_v2_contains_vec_32_16,   contains_helper_v2, UnboundedVecN32,   UnboundedVecN16;
+    btreemap_v2_contains_vec_32_32,   contains_helper_v2, UnboundedVecN32,   UnboundedVecN32;
+    btreemap_v2_contains_vec_32_64,   contains_helper_v2, UnboundedVecN32,   UnboundedVecN64;
+    //btreemap_v2_contains_vec_32_128,  contains_helper_v2, UnboundedVecN32,  UnboundedVecN128;  // Skip repeated.
+    btreemap_v2_contains_vec_32_256,  contains_helper_v2, UnboundedVecN32,  UnboundedVecN256;
+    btreemap_v2_contains_vec_32_512,  contains_helper_v2, UnboundedVecN32,  UnboundedVecN512;
+    btreemap_v2_contains_vec_32_1024, contains_helper_v2, UnboundedVecN32, UnboundedVecN1024;
 
     // u64 / blob8 / vec8
-    btreemap_v2_contains_u64_u64,        contains_helper_v2,       u64,       u64;
-    btreemap_v2_contains_u64_blob8,      contains_helper_v2,       u64,     Blob8;
-    btreemap_v2_contains_blob8_u64,      contains_helper_v2,     Blob8,       u64;
-    btreemap_v2_contains_u64_vec8,       contains_helper_v2,       u64, FixedVec8;
-    btreemap_v2_contains_vec8_u64,       contains_helper_v2, FixedVec8,       u64;
+    btreemap_v2_contains_u64_u64,        contains_helper_v2,            u64,            u64;
+    btreemap_v2_contains_u64_blob8,      contains_helper_v2,            u64,          Blob8;
+    btreemap_v2_contains_blob8_u64,      contains_helper_v2,          Blob8,            u64;
+    btreemap_v2_contains_u64_vec8,       contains_helper_v2,            u64, UnboundedVecN8;
+    btreemap_v2_contains_vec8_u64,       contains_helper_v2, UnboundedVecN8,            u64;
 
     // memory manager u64 / blob512 / vec512
-    btreemap_v2_mem_manager_contains_u64_u64,      contains_helper_v2_mem_manager,         u64,         u64;
-    btreemap_v2_mem_manager_contains_u64_blob512,  contains_helper_v2_mem_manager,         u64,     Blob512;
-    btreemap_v2_mem_manager_contains_blob512_u64,  contains_helper_v2_mem_manager,     Blob512,         u64;
-    btreemap_v2_mem_manager_contains_u64_vec512,   contains_helper_v2_mem_manager,         u64, FixedVec512;
-    btreemap_v2_mem_manager_contains_vec512_u64,   contains_helper_v2_mem_manager, FixedVec512,         u64;
+    btreemap_v2_mem_manager_contains_u64_u64,      contains_helper_v2_mem_manager,              u64,              u64;
+    btreemap_v2_mem_manager_contains_u64_blob512,  contains_helper_v2_mem_manager,              u64,          Blob512;
+    btreemap_v2_mem_manager_contains_blob512_u64,  contains_helper_v2_mem_manager,          Blob512,              u64;
+    btreemap_v2_mem_manager_contains_u64_vec512,   contains_helper_v2_mem_manager,              u64, UnboundedVecN512;
+    btreemap_v2_mem_manager_contains_vec512_u64,   contains_helper_v2_mem_manager, UnboundedVecN512,              u64;
 }
 
 fn contains_helper_v2<K: TestKey, V: TestValue>() -> BenchResult {
@@ -535,33 +535,33 @@ bench_tests! {
     btreemap_v2_pop_first_blob_32_1024, pop_first_helper_v2, Blob32, Blob1024;
 
     // vec K x 128
-    btreemap_v2_pop_first_vec_4_128,    pop_first_helper_v2,    FixedVec4, FixedVec128;
-    btreemap_v2_pop_first_vec_8_128,    pop_first_helper_v2,    FixedVec8, FixedVec128;
-    btreemap_v2_pop_first_vec_16_128,   pop_first_helper_v2,   FixedVec16, FixedVec128;
-    btreemap_v2_pop_first_vec_32_128,   pop_first_helper_v2,   FixedVec32, FixedVec128;
-    btreemap_v2_pop_first_vec_64_128,   pop_first_helper_v2,   FixedVec64, FixedVec128;
-    btreemap_v2_pop_first_vec_128_128,  pop_first_helper_v2,  FixedVec128, FixedVec128;
-    btreemap_v2_pop_first_vec_256_128,  pop_first_helper_v2,  FixedVec256, FixedVec128;
-    btreemap_v2_pop_first_vec_512_128,  pop_first_helper_v2,  FixedVec512, FixedVec128;
-    btreemap_v2_pop_first_vec_1024_128, pop_first_helper_v2, FixedVec1024, FixedVec128;
+    btreemap_v2_pop_first_vec_4_128,    pop_first_helper_v2,    UnboundedVecN4, UnboundedVecN128;
+    btreemap_v2_pop_first_vec_8_128,    pop_first_helper_v2,    UnboundedVecN8, UnboundedVecN128;
+    btreemap_v2_pop_first_vec_16_128,   pop_first_helper_v2,   UnboundedVecN16, UnboundedVecN128;
+    btreemap_v2_pop_first_vec_32_128,   pop_first_helper_v2,   UnboundedVecN32, UnboundedVecN128;
+    btreemap_v2_pop_first_vec_64_128,   pop_first_helper_v2,   UnboundedVecN64, UnboundedVecN128;
+    btreemap_v2_pop_first_vec_128_128,  pop_first_helper_v2,  UnboundedVecN128, UnboundedVecN128;
+    btreemap_v2_pop_first_vec_256_128,  pop_first_helper_v2,  UnboundedVecN256, UnboundedVecN128;
+    btreemap_v2_pop_first_vec_512_128,  pop_first_helper_v2,  UnboundedVecN512, UnboundedVecN128;
+    btreemap_v2_pop_first_vec_1024_128, pop_first_helper_v2, UnboundedVecN1024, UnboundedVecN128;
 
     // vec 32 x V
-    btreemap_v2_pop_first_vec_32_4,    pop_first_helper_v2, FixedVec32,    FixedVec4;
-    btreemap_v2_pop_first_vec_32_8,    pop_first_helper_v2, FixedVec32,    FixedVec8;
-    btreemap_v2_pop_first_vec_32_16,   pop_first_helper_v2, FixedVec32,   FixedVec16;
-    btreemap_v2_pop_first_vec_32_32,   pop_first_helper_v2, FixedVec32,   FixedVec32;
-    btreemap_v2_pop_first_vec_32_64,   pop_first_helper_v2, FixedVec32,   FixedVec64;
-    //btreemap_v2_pop_first_vec_32_128,  pop_first_helper_v2, FixedVec32,  FixedVec128;  // Skip repeated.
-    btreemap_v2_pop_first_vec_32_256,  pop_first_helper_v2, FixedVec32,  FixedVec256;
-    btreemap_v2_pop_first_vec_32_512,  pop_first_helper_v2, FixedVec32,  FixedVec512;
-    btreemap_v2_pop_first_vec_32_1024, pop_first_helper_v2, FixedVec32, FixedVec1024;
+    btreemap_v2_pop_first_vec_32_4,    pop_first_helper_v2, UnboundedVecN32,    UnboundedVecN4;
+    btreemap_v2_pop_first_vec_32_8,    pop_first_helper_v2, UnboundedVecN32,    UnboundedVecN8;
+    btreemap_v2_pop_first_vec_32_16,   pop_first_helper_v2, UnboundedVecN32,   UnboundedVecN16;
+    btreemap_v2_pop_first_vec_32_32,   pop_first_helper_v2, UnboundedVecN32,   UnboundedVecN32;
+    btreemap_v2_pop_first_vec_32_64,   pop_first_helper_v2, UnboundedVecN32,   UnboundedVecN64;
+    //btreemap_v2_pop_first_vec_32_128,  pop_first_helper_v2, UnboundedVecN32,  UnboundedVecN128;  // Skip repeated.
+    btreemap_v2_pop_first_vec_32_256,  pop_first_helper_v2, UnboundedVecN32,  UnboundedVecN256;
+    btreemap_v2_pop_first_vec_32_512,  pop_first_helper_v2, UnboundedVecN32,  UnboundedVecN512;
+    btreemap_v2_pop_first_vec_32_1024, pop_first_helper_v2, UnboundedVecN32, UnboundedVecN1024;
 
     // u64 / blob8 / vec8
-    btreemap_v2_pop_first_u64_u64,        pop_first_helper_v2,       u64,       u64;
-    btreemap_v2_pop_first_u64_blob8,      pop_first_helper_v2,       u64,     Blob8;
-    btreemap_v2_pop_first_blob8_u64,      pop_first_helper_v2,     Blob8,       u64;
-    btreemap_v2_pop_first_u64_vec8,       pop_first_helper_v2,       u64, FixedVec8;
-    btreemap_v2_pop_first_vec8_u64,       pop_first_helper_v2, FixedVec8,       u64;
+    btreemap_v2_pop_first_u64_u64,        pop_first_helper_v2,            u64,            u64;
+    btreemap_v2_pop_first_u64_blob8,      pop_first_helper_v2,            u64,          Blob8;
+    btreemap_v2_pop_first_blob8_u64,      pop_first_helper_v2,          Blob8,            u64;
+    btreemap_v2_pop_first_u64_vec8,       pop_first_helper_v2,            u64, UnboundedVecN8;
+    btreemap_v2_pop_first_vec8_u64,       pop_first_helper_v2, UnboundedVecN8,            u64;
 }
 
 // Last
@@ -589,33 +589,33 @@ bench_tests! {
     btreemap_v2_pop_last_blob_32_1024, pop_last_helper_v2, Blob32, Blob1024;
 
     // vec K x 128
-    btreemap_v2_pop_last_vec_4_128,    pop_last_helper_v2,    FixedVec4, FixedVec128;
-    btreemap_v2_pop_last_vec_8_128,    pop_last_helper_v2,    FixedVec8, FixedVec128;
-    btreemap_v2_pop_last_vec_16_128,   pop_last_helper_v2,   FixedVec16, FixedVec128;
-    btreemap_v2_pop_last_vec_32_128,   pop_last_helper_v2,   FixedVec32, FixedVec128;
-    btreemap_v2_pop_last_vec_64_128,   pop_last_helper_v2,   FixedVec64, FixedVec128;
-    btreemap_v2_pop_last_vec_128_128,  pop_last_helper_v2,  FixedVec128, FixedVec128;
-    btreemap_v2_pop_last_vec_256_128,  pop_last_helper_v2,  FixedVec256, FixedVec128;
-    btreemap_v2_pop_last_vec_512_128,  pop_last_helper_v2,  FixedVec512, FixedVec128;
-    btreemap_v2_pop_last_vec_1024_128, pop_last_helper_v2, FixedVec1024, FixedVec128;
+    btreemap_v2_pop_last_vec_4_128,    pop_last_helper_v2,    UnboundedVecN4, UnboundedVecN128;
+    btreemap_v2_pop_last_vec_8_128,    pop_last_helper_v2,    UnboundedVecN8, UnboundedVecN128;
+    btreemap_v2_pop_last_vec_16_128,   pop_last_helper_v2,   UnboundedVecN16, UnboundedVecN128;
+    btreemap_v2_pop_last_vec_32_128,   pop_last_helper_v2,   UnboundedVecN32, UnboundedVecN128;
+    btreemap_v2_pop_last_vec_64_128,   pop_last_helper_v2,   UnboundedVecN64, UnboundedVecN128;
+    btreemap_v2_pop_last_vec_128_128,  pop_last_helper_v2,  UnboundedVecN128, UnboundedVecN128;
+    btreemap_v2_pop_last_vec_256_128,  pop_last_helper_v2,  UnboundedVecN256, UnboundedVecN128;
+    btreemap_v2_pop_last_vec_512_128,  pop_last_helper_v2,  UnboundedVecN512, UnboundedVecN128;
+    btreemap_v2_pop_last_vec_1024_128, pop_last_helper_v2, UnboundedVecN1024, UnboundedVecN128;
 
     // vec 32 x V
-    btreemap_v2_pop_last_vec_32_4,    pop_last_helper_v2, FixedVec32,    FixedVec4;
-    btreemap_v2_pop_last_vec_32_8,    pop_last_helper_v2, FixedVec32,    FixedVec8;
-    btreemap_v2_pop_last_vec_32_16,   pop_last_helper_v2, FixedVec32,   FixedVec16;
-    btreemap_v2_pop_last_vec_32_32,   pop_last_helper_v2, FixedVec32,   FixedVec32;
-    btreemap_v2_pop_last_vec_32_64,   pop_last_helper_v2, FixedVec32,   FixedVec64;
-    //btreemap_v2_pop_last_vec_32_128,  pop_last_helper_v2, FixedVec32,  FixedVec128;  // Skip repeated.
-    btreemap_v2_pop_last_vec_32_256,  pop_last_helper_v2, FixedVec32,  FixedVec256;
-    btreemap_v2_pop_last_vec_32_512,  pop_last_helper_v2, FixedVec32,  FixedVec512;
-    btreemap_v2_pop_last_vec_32_1024, pop_last_helper_v2, FixedVec32, FixedVec1024;
+    btreemap_v2_pop_last_vec_32_4,    pop_last_helper_v2, UnboundedVecN32,    UnboundedVecN4;
+    btreemap_v2_pop_last_vec_32_8,    pop_last_helper_v2, UnboundedVecN32,    UnboundedVecN8;
+    btreemap_v2_pop_last_vec_32_16,   pop_last_helper_v2, UnboundedVecN32,   UnboundedVecN16;
+    btreemap_v2_pop_last_vec_32_32,   pop_last_helper_v2, UnboundedVecN32,   UnboundedVecN32;
+    btreemap_v2_pop_last_vec_32_64,   pop_last_helper_v2, UnboundedVecN32,   UnboundedVecN64;
+    //btreemap_v2_pop_last_vec_32_128,  pop_last_helper_v2, UnboundedVecN32,  UnboundedVecN128;  // Skip repeated.
+    btreemap_v2_pop_last_vec_32_256,  pop_last_helper_v2, UnboundedVecN32,  UnboundedVecN256;
+    btreemap_v2_pop_last_vec_32_512,  pop_last_helper_v2, UnboundedVecN32,  UnboundedVecN512;
+    btreemap_v2_pop_last_vec_32_1024, pop_last_helper_v2, UnboundedVecN32, UnboundedVecN1024;
 
     // u64 / blob8 / vec8
-    btreemap_v2_pop_last_u64_u64,        pop_last_helper_v2,       u64,       u64;
-    btreemap_v2_pop_last_u64_blob8,      pop_last_helper_v2,       u64,     Blob8;
-    btreemap_v2_pop_last_blob8_u64,      pop_last_helper_v2,     Blob8,       u64;
-    btreemap_v2_pop_last_u64_vec8,       pop_last_helper_v2,       u64, FixedVec8;
-    btreemap_v2_pop_last_vec8_u64,       pop_last_helper_v2, FixedVec8,       u64;
+    btreemap_v2_pop_last_u64_u64,        pop_last_helper_v2,            u64,            u64;
+    btreemap_v2_pop_last_u64_blob8,      pop_last_helper_v2,            u64,          Blob8;
+    btreemap_v2_pop_last_blob8_u64,      pop_last_helper_v2,          Blob8,            u64;
+    btreemap_v2_pop_last_u64_vec8,       pop_last_helper_v2,            u64, UnboundedVecN8;
+    btreemap_v2_pop_last_vec8_u64,       pop_last_helper_v2, UnboundedVecN8,            u64;
 }
 
 fn pop_first_helper_v2<K: TestKey, V: TestValue>() -> BenchResult {

--- a/benchmarks/src/common.rs
+++ b/benchmarks/src/common.rs
@@ -1,4 +1,4 @@
-use ic_stable_structures::storable::{Blob, FixedVec, Storable};
+use ic_stable_structures::storable::{Blob, Storable, UnboundedVecN};
 use tiny_rng::{Rand, Rng};
 
 pub trait Random {
@@ -18,14 +18,14 @@ impl<const K: usize> Random for Blob<K> {
     }
 }
 
-impl<const K: usize> Random for FixedVec<K> {
+impl<const K: usize> Random for UnboundedVecN<K> {
     fn random(rng: &mut Rng) -> Self {
         let size = rng.rand_u32() % Self::max_size();
         let mut buf = Vec::with_capacity(size as usize);
         for _ in 0..size {
             buf.push(rng.rand_u8());
         }
-        FixedVec::from(&buf)
+        Self::from(&buf)
     }
 }
 

--- a/src/storable.rs
+++ b/src/storable.rs
@@ -190,11 +190,11 @@ impl<const N: usize> Storable for Blob<N> {
     };
 }
 
-/// Byte‑vector for testing size N; otherwise just a Vec<u8>.
+/// Unbounded vector of bytes, always of length `N`.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub struct FixedVec<const N: usize>(Vec<u8>);
+pub struct UnboundedVecN<const N: usize>(Vec<u8>);
 
-impl<const N: usize> FixedVec<N> {
+impl<const N: usize> UnboundedVecN<N> {
     pub fn max_size() -> u32 {
         N as u32
     }
@@ -209,24 +209,24 @@ impl<const N: usize> FixedVec<N> {
         let mut vec = Vec::with_capacity(N);
         vec.extend_from_slice(slice);
         vec.resize(N, 0);
-        FixedVec(vec)
+        Self(vec)
     }
 }
 
-impl<const N: usize> Default for FixedVec<N> {
+impl<const N: usize> Default for UnboundedVecN<N> {
     fn default() -> Self {
-        FixedVec(vec![0; N])
+        Self(vec![0; N])
     }
 }
 
-impl<const N: usize> Storable for FixedVec<N> {
+impl<const N: usize> Storable for UnboundedVecN<N> {
     fn to_bytes(&self) -> Cow<[u8]> {
         Cow::Owned(self.0.clone())
     }
 
     #[inline]
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        FixedVec(bytes.into_owned())
+        Self(bytes.into_owned())
     }
 
     const BOUND: Bound = Bound::Unbounded;


### PR DESCRIPTION
This PR refactors the code by renaming the `FixedVec` type to `UnboundedVecN` and updates all corresponding references in both the storable module and benchmark tests.