### PR TITLE
chore: fix compilation warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/dfinity/stable-structures"
 version = "0.6.8"
 
 [dependencies]
-canbench-rs = { workspace = true, optional = true }           # Optional to benchmark parts of the code.
-ic_principal = { workspace = true, default-features = false }
+canbench-rs = { workspace = true, optional = true } # Optional to benchmark parts of the code.
+ic_principal.workspace = true
 
 [dev-dependencies]
 candid.workspace = true
@@ -35,7 +35,7 @@ members = ["benchmarks"]
 canbench-rs = "0.1.15"
 candid = "0.10.14"
 hex = "0.4.3"
-ic_principal = "0.1.1"
+ic_principal = { version = "0.1.1", default-features = false }
 ic-cdk = "0.12.1"
 ic-cdk-macros = "0.8.4"
 maplit = "1.0.2"


### PR DESCRIPTION
This PR fixes `default-features is ignored` compilation warning.

Before [log](https://github.com/dfinity/stable-structures/actions/runs/15302670009/job/43047459951#step:6:316)
```
+ canbench --less-verbose --hide-results --show-summary --csv
~/work/stable-structures/stable-structures/benchmarks/vec ~/work/stable-structures/stable-structures
warning: /home/runner/work/stable-structures/stable-structures/Cargo.toml: `default-features` is ignored for ic_principal, since `default-features` was not specified for `workspace.dependencies.ic_principal`, this could become a hard error in the future
    Finished `release` profile [optimized] target(s) in 0.04s
+ cp ./canbench_results.csv /tmp/canbench_results_vec.csv
```

After [log](https://github.com/dfinity/stable-structures/actions/runs/15388993829/job/43294187926#step:6:666):
```
~/work/stable-structures/stable-structures/benchmarks/vec ~/work/stable-structures/stable-structures
+ canbench --less-verbose --hide-results --show-summary --csv
    Finished `release` profile [optimized] target(s) in 0.04s
+ cp ./canbench_results.csv /tmp/canbench_results_vec.csv
```