### PR TITLE
refactor: improve naming of BTreeMap inner key/value storage

### DIFF
--- a/src/btreemap/node/v1.rs
+++ b/src/btreemap/node/v1.rs
@@ -48,7 +48,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
         Node {
             address,
             node_type,
-            keys_and_encoded_values: vec![],
+            entries: vec![],
             children: vec![],
             version: Version::V1(page_size),
             overflows: Vec::with_capacity(0),
@@ -67,7 +67,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
         let _p = canbench_rs::bench_scope("node_load_v1"); // May add significant overhead.
 
         // Load the entries.
-        let mut keys_encoded_values = Vec::with_capacity(header.num_entries as usize);
+        let mut entries = Vec::with_capacity(header.num_entries as usize);
         let mut offset = NodeHeader::size();
         for _ in 0..header.num_entries {
             let key_offset = offset;
@@ -80,7 +80,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
             let value = LazyValue::by_ref(value_offset);
             offset += Bytes::from(max_value_size);
 
-            keys_encoded_values.push((key, value));
+            entries.push((key, value));
         }
 
         // Load children if this is an internal node.
@@ -94,12 +94,12 @@ impl<K: Storable + Ord + Clone> Node<K> {
                 children.push(child);
             }
 
-            assert_eq!(children.len(), keys_encoded_values.len() + 1);
+            assert_eq!(children.len(), entries.len() + 1);
         }
 
         Self {
             address,
-            keys_and_encoded_values: keys_encoded_values,
+            entries,
             children,
             node_type: match header.node_type {
                 LEAF_NODE_TYPE => NodeType::Leaf,
@@ -123,16 +123,16 @@ impl<K: Storable + Ord + Clone> Node<K> {
                 assert!(self.children.is_empty());
             }
             NodeType::Internal => {
-                assert_eq!(self.children.len(), self.keys_and_encoded_values.len() + 1);
+                assert_eq!(self.children.len(), self.entries.len() + 1);
             }
         };
 
         // We should never be saving an empty node.
-        assert!(!self.keys_and_encoded_values.is_empty() || !self.children.is_empty());
+        assert!(!self.entries.is_empty() || !self.children.is_empty());
 
         // Assert entries are sorted in strictly increasing order.
         assert!(self
-            .keys_and_encoded_values
+            .entries
             .windows(2)
             .all(|arr| self.get_key(&arr[0], memory) < self.get_key(&arr[1], memory)));
 
@@ -151,7 +151,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
                 NodeType::Leaf => LEAF_NODE_TYPE,
                 NodeType::Internal => INTERNAL_NODE_TYPE,
             },
-            num_entries: self.keys_and_encoded_values.len() as u16,
+            num_entries: self.entries.len() as u16,
         };
 
         write_struct(&header, self.address, memory);
@@ -160,12 +160,12 @@ impl<K: Storable + Ord + Clone> Node<K> {
 
         // Load all the entries. This is necessary so that we don't overwrite referenced
         // entries when writing the entries to the node.
-        for i in 0..self.keys_and_encoded_values.len() {
+        for i in 0..self.entries.len() {
             self.entry(i, memory);
         }
 
         // Write the entries.
-        for i in 0..self.keys_and_encoded_values.len() {
+        for i in 0..self.entries.len() {
             // Write the size of the key.
             let key_bytes = self.key(i, memory).to_bytes_checked();
             write_u32(memory, self.address + offset, key_bytes.len() as u32);

--- a/src/btreemap/node/v2.rs
+++ b/src/btreemap/node/v2.rs
@@ -98,7 +98,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
             address,
             node_type,
             version: Version::V2(page_size),
-            keys_and_encoded_values: vec![],
+            entries: vec![],
             children: vec![],
             overflows: Vec::with_capacity(0),
         }
@@ -151,7 +151,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
 
         // Load the keys (eagerly if small).
         const EAGER_LOAD_KEY_SIZE_THRESHOLD: u32 = 16;
-        let mut keys_encoded_values = Vec::with_capacity(num_entries);
+        let mut entries = Vec::with_capacity(num_entries);
         let mut buf = vec![];
 
         for _ in 0..num_entries {
@@ -180,11 +180,11 @@ impl<K: Storable + Ord + Clone> Node<K> {
             };
 
             offset += Bytes::from(key_size);
-            keys_encoded_values.push((key, LazyValue::by_ref(Bytes::from(0_u64))));
+            entries.push((key, LazyValue::by_ref(Bytes::from(0_u64))));
         }
 
         // Load the values
-        for (_key, value) in keys_encoded_values.iter_mut() {
+        for (_key, value) in entries.iter_mut() {
             // Load the values lazily.
             *value = LazyValue::by_ref(Bytes::from(offset.get()));
             let value_size = read_u32(&reader, offset) as usize;
@@ -193,7 +193,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
 
         Self {
             address,
-            keys_and_encoded_values: keys_encoded_values,
+            entries,
             children,
             node_type,
             version: Version::V2(page_size),
@@ -211,7 +211,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
 
         // Load all the entries. One pass is required to load all entries;
         // results are not stored to avoid unnecessary allocations.
-        for i in 0..self.keys_and_encoded_values.len() {
+        for i in 0..self.entries.len() {
             self.entry(i, allocator.memory());
         }
 
@@ -233,7 +233,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
                 NodeType::Leaf => LEAF_NODE_TYPE,
                 NodeType::Internal => INTERNAL_NODE_TYPE,
             },
-            num_entries: self.keys_and_encoded_values.len() as u16,
+            num_entries: self.entries.len() as u16,
         };
 
         writer.write_struct(&header, offset);
@@ -251,7 +251,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
         }
 
         // Write the keys.
-        for i in 0..self.keys_and_encoded_values.len() {
+        for i in 0..self.entries.len() {
             let key = self.key(i, writer.memory());
             let key_bytes = key.to_bytes_checked();
 
@@ -267,7 +267,7 @@ impl<K: Storable + Ord + Clone> Node<K> {
         }
 
         // Write the values.
-        for i in 0..self.keys_and_encoded_values.len() {
+        for i in 0..self.entries.len() {
             // Write the size of the value.
             let value = self.value(i, writer.memory());
             writer.write_u32(offset, value.len() as u32);


### PR DESCRIPTION
This PR refactors the internal storage of `BTreeMap` nodes by renaming the `keys_and_encoded_values` field to `entries` and updating all related references across versioned implementations.