### PR TITLE
docs: update Memory trait documentation

### DIFF
--- a/docs/src/concepts/memory-trait.md
+++ b/docs/src/concepts/memory-trait.md
@@ -23,6 +23,13 @@ The `Memory` trait intentionally models a [WebAssembly memory instance](https://
 This design choice ensures consistency with the interface of memories available to canisters.
 It also provides future compatibility with potential multi-memory support in canisters.
 
+## Safety contract  
+
+⚠️ `read` and `write` **assume the caller will not access memory outside the current size**.
+
+If the range `[offset … offset + len)` exceeds available memory, the call panics (in native tests) or traps (in a Wasm canister).
+Callers must store and check data lengths themselves or use higher-level containers such as `StableVec`.
+
 ## Available Memory Implementations
 
 The library provides several implementations of the `Memory` trait, each designed for specific use cases:

--- a/docs/src/concepts/memory-trait.md
+++ b/docs/src/concepts/memory-trait.md
@@ -9,12 +9,15 @@ pub trait Memory {
     fn size(&self) -> u64;
 
     /// Equivalent to WebAssembly memory.grow.
+    /// Returns the previous size, or -1 if the grow fails.
     fn grow(&self, pages: u64) -> i64;
 
     /// Copies bytes from this memory to the heap (in Wasm, memory 0).
+    /// Panics or traps if out of bounds.
     fn read(&self, offset: u64, dst: &mut [u8]);
 
     /// Writes bytes from the heap (in Wasm, memory 0) to this memory.
+    /// Panics or traps if out of bounds.
     fn write(&self, offset: u64, src: &[u8]);
 }
 ```

--- a/docs/src/concepts/memory-trait.md
+++ b/docs/src/concepts/memory-trait.md
@@ -26,7 +26,7 @@ The `Memory` trait intentionally models a [WebAssembly memory instance](https://
 This design choice ensures consistency with the interface of memories available to canisters.
 It also provides future compatibility with potential multi-memory support in canisters.
 
-## Safety contract  
+## Panics  
 
 ⚠️ `read` and `write` **assume the caller will not access memory outside the current size**.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub trait Memory {
     /// Panics or traps if the read would go out of bounds.
     #[inline]
     unsafe fn read_unsafe(&self, offset: u64, dst: *mut u8, count: usize) {
+        // Initialize the buffer to make the slice valid.
         std::ptr::write_bytes(dst, 0, count);
         let slice = std::slice::from_raw_parts_mut(dst, count);
         self.read(offset, slice)


### PR DESCRIPTION
This PR documents that `Memory` trait methods panic or trap on out-of-bounds access.