### PR TITLE
test: fix compare benchmarks

### DIFF
--- a/benchmarks/compare/canbench_results.yml
+++ b/benchmarks/compare/canbench_results.yml
@@ -2,127 +2,127 @@ benches:
   read_chunks_btreemap_1:
     total:
       calls: 1
-      instructions: 799994339
-      heap_increase: 1635
-      stable_memory_increase: 1665
+      instructions: 148723119
+      heap_increase: 0
+      stable_memory_increase: 0
     scopes: {}
   read_chunks_btreemap_1k:
     total:
       calls: 1
-      instructions: 4994472213
-      heap_increase: 1602
-      stable_memory_increase: 1665
+      instructions: 499445396
+      heap_increase: 0
+      stable_memory_increase: 0
     scopes: {}
   read_chunks_btreemap_1m:
     total:
       calls: 1
-      instructions: 133159275732
-      heap_increase: 1892
-      stable_memory_increase: 3201
+      instructions: 43947440627
+      heap_increase: 0
+      stable_memory_increase: 0
     scopes: {}
   read_chunks_stable_1:
     total:
       calls: 1
-      instructions: 812767304
-      heap_increase: 1601
-      stable_memory_increase: 1665
+      instructions: 104859143
+      heap_increase: 0
+      stable_memory_increase: 0
     scopes: {}
   read_chunks_stable_1k:
     total:
       calls: 1
-      instructions: 525926643
-      heap_increase: 1600
-      stable_memory_increase: 1665
+      instructions: 104985739
+      heap_increase: 0
+      stable_memory_increase: 0
     scopes: {}
   read_chunks_stable_1m:
     total:
       calls: 1
-      instructions: 1307625777
-      heap_increase: 1892
-      stable_memory_increase: 1665
+      instructions: 230002739
+      heap_increase: 0
+      stable_memory_increase: 0
     scopes: {}
   read_chunks_vec_1:
     total:
       calls: 1
-      instructions: 1363286413
-      heap_increase: 3202
-      stable_memory_increase: 1665
+      instructions: 104859760
+      heap_increase: 0
+      stable_memory_increase: 0
     scopes: {}
   read_chunks_vec_1k:
     total:
       calls: 1
-      instructions: 1378477856
-      heap_increase: 3200
-      stable_memory_increase: 1665
+      instructions: 105826498
+      heap_increase: 0
+      stable_memory_increase: 0
     scopes: {}
   read_chunks_vec_1m:
     total:
       calls: 1
-      instructions: 4724968939
-      heap_increase: 3784
-      stable_memory_increase: 1665
+      instructions: 1010905944
+      heap_increase: 0
+      stable_memory_increase: 0
     scopes: {}
   write_chunks_btreemap_1:
     total:
       calls: 1
-      instructions: 650634827
-      heap_increase: 1635
-      stable_memory_increase: 1665
+      instructions: 362178795
+      heap_increase: 34
+      stable_memory_increase: 1536
     scopes: {}
   write_chunks_btreemap_1k:
     total:
       calls: 1
-      instructions: 4494392310
-      heap_increase: 1602
-      stable_memory_increase: 1665
+      instructions: 4205340423
+      heap_increase: 2
+      stable_memory_increase: 1536
     scopes: {}
   write_chunks_btreemap_1m:
     total:
       calls: 1
-      instructions: 89213197943
-      heap_increase: 1892
-      stable_memory_increase: 3201
+      instructions: 88707302109
+      heap_increase: 0
+      stable_memory_increase: 3072
     scopes: {}
   write_chunks_stable_1:
     total:
       calls: 1
-      instructions: 418914504
-      heap_increase: 1601
-      stable_memory_increase: 1665
+      instructions: 130471968
+      heap_increase: 0
+      stable_memory_increase: 1664
     scopes: {}
   write_chunks_stable_1k:
     total:
       calls: 1
-      instructions: 420017246
-      heap_increase: 1600
-      stable_memory_increase: 1665
+      instructions: 130598745
+      heap_increase: 0
+      stable_memory_increase: 1664
     scopes: {}
   write_chunks_stable_1m:
     total:
       calls: 1
-      instructions: 1076987527
-      heap_increase: 1892
-      stable_memory_increase: 1665
+      instructions: 255406658
+      heap_increase: 0
+      stable_memory_increase: 1664
     scopes: {}
   write_chunks_vec_1:
     total:
       calls: 1
-      instructions: 1257790959
-      heap_increase: 3202
-      stable_memory_increase: 1665
+      instructions: 549903573
+      heap_increase: 0
+      stable_memory_increase: 1536
     scopes: {}
   write_chunks_vec_1k:
     total:
       calls: 1
-      instructions: 1272015664
-      heap_increase: 3200
-      stable_memory_increase: 1665
+      instructions: 562257515
+      heap_increase: 0
+      stable_memory_increase: 1536
     scopes: {}
   write_chunks_vec_1m:
     total:
       calls: 1
-      instructions: 3715427301
-      heap_increase: 3784
-      stable_memory_increase: 1665
+      instructions: 1896593101
+      heap_increase: 0
+      stable_memory_increase: 1536
     scopes: {}
 version: 0.2.0

--- a/benchmarks/compare/src/main.rs
+++ b/benchmarks/compare/src/main.rs
@@ -1,5 +1,5 @@
 use benchmarks::vec::BoundedVecN;
-use canbench_rs::{bench, bench_fn};
+use canbench_rs::{bench, bench_fn, BenchResult};
 use ic_cdk::api::stable::WASM_PAGE_SIZE_IN_BYTES;
 use ic_stable_structures::{
     memory_manager::{MemoryId, MemoryManager},
@@ -32,7 +32,7 @@ fn chunk_data(n: usize) -> Vec<Vec<u8>> {
 
 // Stable Memory benchmarks
 
-fn write_chunks_stable(mem_id: u8, n: usize) {
+fn write_chunks_stable(mem_id: u8, n: usize) -> BenchResult {
     let memory = init_memory(mem_id);
     let chunks = chunk_data(n);
     let chunk_size = TOTAL_SIZE / n;
@@ -42,10 +42,10 @@ fn write_chunks_stable(mem_id: u8, n: usize) {
         for (i, chunk) in chunks.iter().enumerate() {
             memory.write((i * chunk_size) as u64, chunk);
         }
-    });
+    })
 }
 
-fn read_chunks_stable(mem_id: u8, n: usize) {
+fn read_chunks_stable(mem_id: u8, n: usize) -> BenchResult {
     write_chunks_stable(mem_id, n);
     let memory = init_memory(mem_id);
     let chunk_size = TOTAL_SIZE / n;
@@ -55,12 +55,12 @@ fn read_chunks_stable(mem_id: u8, n: usize) {
         for i in 0..n {
             memory.read((i * chunk_size) as u64, &mut buf);
         }
-    });
+    })
 }
 
 // BTreeMap benchmarks
 
-fn write_chunks_btreemap(mem_id: u8, n: usize) {
+fn write_chunks_btreemap(mem_id: u8, n: usize) -> BenchResult {
     let mut map = BTreeMap::init(init_memory(mem_id));
     let chunks = chunk_data(n);
 
@@ -68,22 +68,22 @@ fn write_chunks_btreemap(mem_id: u8, n: usize) {
         for (i, chunk) in chunks.into_iter().enumerate() {
             map.insert(i as u32, chunk);
         }
-    });
+    })
 }
 
-fn read_chunks_btreemap(mem_id: u8, n: usize) {
+fn read_chunks_btreemap(mem_id: u8, n: usize) -> BenchResult {
     write_chunks_btreemap(mem_id, n);
     let map: BTreeMap<_, Vec<u8>, _> = BTreeMap::init(init_memory(mem_id));
     bench_fn(|| {
         for i in 0..n {
             let _ = map.get(&(i as u32));
         }
-    });
+    })
 }
 
 // StableVec benchmarks
 
-fn write_chunks_vec<const CHUNK_SIZE: usize>(mem_id: u8, n: usize) {
+fn write_chunks_vec<const CHUNK_SIZE: usize>(mem_id: u8, n: usize) -> BenchResult {
     let vec: StableVec<BoundedVecN<CHUNK_SIZE>, _> = StableVec::new(init_memory(mem_id));
     let chunks: Vec<_> = chunk_data(n).iter().map(|v| BoundedVecN::from(v)).collect();
 
@@ -91,10 +91,10 @@ fn write_chunks_vec<const CHUNK_SIZE: usize>(mem_id: u8, n: usize) {
         for chunk in &chunks {
             vec.push(chunk);
         }
-    });
+    })
 }
 
-fn read_chunks_vec<const CHUNK_SIZE: usize>(mem_id: u8, n: usize) {
+fn read_chunks_vec<const CHUNK_SIZE: usize>(mem_id: u8, n: usize) -> BenchResult {
     write_chunks_vec::<CHUNK_SIZE>(mem_id, n);
     let vec: StableVec<BoundedVecN<CHUNK_SIZE>, _> = StableVec::init(init_memory(mem_id));
 
@@ -102,26 +102,26 @@ fn read_chunks_vec<const CHUNK_SIZE: usize>(mem_id: u8, n: usize) {
         for i in 0..n as u64 {
             let _ = vec.get(i);
         }
-    });
+    })
 }
 
 // Benchmark macros
 
 macro_rules! bench_case {
     ($name:ident, $func:ident, $mem_id:expr, $n:expr) => {
-        #[bench]
-        fn $name() {
-            $func($mem_id, $n);
+        #[bench(raw)]
+        fn $name() -> BenchResult {
+            $func($mem_id, $n)
         }
     };
 }
 
 macro_rules! bench_case_sized {
     ($name:ident, $func:ident, $mem_id:expr, $n:expr) => {
-        #[bench]
-        fn $name() {
+        #[bench(raw)]
+        fn $name() -> BenchResult {
             const SIZE: usize = chunk_size::<$n>();
-            $func::<SIZE>($mem_id, $n);
+            $func::<SIZE>($mem_id, $n)
         }
     };
 }


### PR DESCRIPTION
This PR fixes `compare` benchmarks, now it correctly measures instructions only inside `bench_fn`.

Here's the documentation about excluding setup code: 
https://docs.rs/canbench-rs/0.2.1/canbench_rs/#excluding-setup-code