### PR TITLE
ci: sanitize PR name in Slack notification messages like <&test>

### DIFF
--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -24,7 +24,7 @@ jobs:
           echo "safe_title=$ESCAPED_TITLE" >> "$GITHUB_OUTPUT"
 
       - name: Post to a Slack channel
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         with:
           channel-id: eng-execution-mrs
           slack-message: ":github: `${{ github.repository }}` <${{ github.event.pull_request.html_url }}|${{ steps.sanitize.outputs.safe_title }}>"

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -12,10 +12,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Sanitize PR title
+        id: sanitize
+        run: |
+          RAW_TITLE="${{ github.event.pull_request.title }}"
+          ESCAPED_TITLE=$(echo "$RAW_TITLE" \
+            | sed 's/&/\&amp;/g' \
+            | sed 's/</\&lt;/g' \
+            | sed 's/>/\&gt;/g')
+          echo "safe_title=$ESCAPED_TITLE" >> "$GITHUB_OUTPUT"
+
       - name: Post to a Slack channel
-        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        uses: slackapi/slack-github-action@v1
         with:
           channel-id: eng-execution-mrs
-          slack-message: ":github: `${{ github.repository }}` <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
+          slack-message: ":github: `${{ github.repository }}` <${{ github.event.pull_request.html_url }}|${{ steps.sanitize.outputs.safe_title }}>"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}


### PR DESCRIPTION
This PR updates the Slack notification workflow to escape special characters `&`, `<` and `>`.

https://api.slack.com/reference/surfaces/formatting#escaping