### PR TITLE
ci: rename 'main' to 'baseline' to support custom benchmark branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,7 @@ jobs:
       - name: Checkout baseline branch
         uses: actions/checkout@v4
         with:
-          #ref: main
-          ref: maksym/baseline-v0.6.7
+          ref: main
           path: _canbench_baseline_branch
 
       - uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,8 @@ jobs:
       - name: Checkout baseline branch
         uses: actions/checkout@v4
         with:
-          ref: main
+          #ref: main
+          ref: maksym/baseline-v0.6.7
           path: _canbench_baseline_branch
 
       - uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,11 @@ jobs:
       - name: Checkout current PR
         uses: actions/checkout@v4
 
-      - name: Checkout main branch
+      - name: Checkout baseline branch
         uses: actions/checkout@v4
         with:
           ref: main
-          path: _canbench_main_branch
+          path: _canbench_baseline_branch
 
       - uses: actions/cache@v4
         with:

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -13,13 +13,13 @@ CANBENCH_JOB_NAME=$2
 # Must match the file path specified in the GitHub Action.
 COMMENT_MESSAGE_PATH=/tmp/canbench_result_${CANBENCH_JOB_NAME}
 
-# GitHub CI is expected to have the main branch checked out in this folder.
-MAIN_BRANCH_DIR=_canbench_main_branch
+# GitHub CI is expected to have the baseline branch checked out in this folder.
+BASELINE_BRANCH_DIR=_canbench_baseline_branch
 
 CANBENCH_OUTPUT=/tmp/canbench_output.txt
 
 CANBENCH_RESULTS_FILE="$CANISTER_PATH/canbench_results.yml"
-MAIN_BRANCH_RESULTS_FILE="$MAIN_BRANCH_DIR/$CANBENCH_RESULTS_FILE"
+BASELINE_BRANCH_RESULTS_FILE="$BASELINE_BRANCH_DIR/$CANBENCH_RESULTS_FILE"
 
 CANBENCH_RESULTS_CSV_FILE="/tmp/canbench_results_${CANBENCH_JOB_NAME}.csv"
 
@@ -78,12 +78,12 @@ time=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
 # Print output with correct formatting
 echo "# \`canbench\` 🏋 (dir: $CANISTER_PATH) $commit_hash $time" > "$COMMENT_MESSAGE_PATH"
 
-# Check for performance changes relative to the main branch.
-if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
-  # Replace the current results with the main branch results.
-  mv "$MAIN_BRANCH_RESULTS_FILE" "$CANBENCH_RESULTS_FILE"
+# Check for performance changes relative to the baseline branch.
+if [ -f "$BASELINE_BRANCH_RESULTS_FILE" ]; then
+  # Replace the current results with the baseline branch results.
+  mv "$BASELINE_BRANCH_RESULTS_FILE" "$CANBENCH_RESULTS_FILE"
 
-  # Run canbench to compare results with the main branch.
+  # Run canbench to compare results with the baseline branch.
   pushd "$CANISTER_PATH"
   canbench --less-verbose --hide-results --show-summary --csv > "$CANBENCH_OUTPUT"
   cp "./canbench_results.csv" "$CANBENCH_RESULTS_CSV_FILE"


### PR DESCRIPTION
This PR renames references from “main” to a generic “baseline” branch to support custom benchmark baselines.