### PR TITLE
ci: re-enable io_chunks benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         name:
           - btreemap
           - btreeset
-          # - io_chunks TODO: re-enable after new folder is merged.
+          - io_chunks
           - memory-manager
           - vec
         include:
@@ -102,8 +102,8 @@ jobs:
             project_dir: ./benchmarks/btreemap
           - name: btreeset
             project_dir: ./benchmarks/btreeset
-          # - name: io_chunks
-          #   project_dir: ./benchmarks/io_chunks
+          - name: io_chunks
+            project_dir: ./benchmarks/io_chunks
           - name: memory-manager
             project_dir: ./benchmarks/memory_manager
           - name: vec

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -23,17 +23,17 @@ name = "btreemap"
 path = "btreemap/src/main.rs"
 
 [[bin]]
-name = "memory_manager"
-path = "memory_manager/src/main.rs"
-
-[[bin]]
-name = "vec"
-path = "vec/src/main.rs"
+name = "btreeset"
+path = "btreeset/src/main.rs"
 
 [[bin]]
 name = "io_chunks"
 path = "io_chunks/src/main.rs"
 
 [[bin]]
-name = "btreeset"
-path = "btreeset/src/main.rs"
+name = "memory_manager"
+path = "memory_manager/src/main.rs"
+
+[[bin]]
+name = "vec"
+path = "vec/src/main.rs"

--- a/benchmarks/io_chunks/canbench.yml
+++ b/benchmarks/io_chunks/canbench.yml
@@ -1,3 +1,3 @@
 build_cmd: cargo build -p benchmarks --release --target wasm32-unknown-unknown --locked
 
-wasm_path: ../../target/wasm32-unknown-unknown/release/compare.wasm
+wasm_path: ../../target/wasm32-unknown-unknown/release/io_chunks.wasm


### PR DESCRIPTION
This PR re-enables `io_chunks` benchmark in the CI.

This is a follow-up PR after https://github.com/dfinity/stable-structures/pull/368.