### PR TITLE
ci: upload persisted canbench_results.yml file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,11 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: canbench_results_persisted_${{ matrix.name }}_yml
+          path: /tmp/canbench_results_persisted_${{ matrix.name }}.yml
+
+      - uses: actions/upload-artifact@v4
+        with:
           name: canbench_results_${{ matrix.name }}_csv
           path: /tmp/canbench_results_${{ matrix.name }}.csv
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,13 @@ name: CI
 on: [pull_request]
 
 env:
+  RUST_VERSION: 1.84.0 # Use the same version as in `rust-toolchain.toml`
   CARGO_TERM_COLOR: always # Force Cargo to use colors
   TERM: xterm-256color
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [1.84.0]
-
     steps:
       - uses: actions/checkout@v4
 
@@ -28,8 +25,8 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
+          rustup update $RUST_VERSION --no-self-update
+          rustup default $RUST_VERSION
           rustup component add rustfmt
           rustup component add clippy
           rustup toolchain install nightly
@@ -68,8 +65,8 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
+          rustup update $RUST_VERSION --no-self-update
+          rustup default $RUST_VERSION
           rustup target add wasm32-unknown-unknown
 
       - name: Install DFX
@@ -135,8 +132,8 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update ${{ matrix.rust || 'stable' }} --no-self-update
-          rustup default ${{ matrix.rust || 'stable' }}
+          rustup update $RUST_VERSION --no-self-update
+          rustup default $RUST_VERSION
           rustup target add wasm32-unknown-unknown
 
       - name: Benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update $RUST_VERSION --no-self-update
-          rustup default $RUST_VERSION
+          rustup update ${RUST_VERSION} --no-self-update
+          rustup default ${RUST_VERSION}
           rustup component add rustfmt
           rustup component add clippy
           rustup toolchain install nightly
@@ -65,8 +65,8 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update $RUST_VERSION --no-self-update
-          rustup default $RUST_VERSION
+          rustup update ${RUST_VERSION} --no-self-update
+          rustup default ${RUST_VERSION}
           rustup target add wasm32-unknown-unknown
 
       - name: Install DFX
@@ -132,8 +132,8 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update $RUST_VERSION --no-self-update
-          rustup default $RUST_VERSION
+          rustup update ${RUST_VERSION} --no-self-update
+          rustup default ${RUST_VERSION}
           rustup target add wasm32-unknown-unknown
 
       - name: Benchmark

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,7 @@ jobs:
       MDBOOK_VERSION: 0.4.48
       MDBOOK_ADMONISH_VERSION: 1.19.0
       MDBOOK_LINKCHECK_VERSION: 0.7.7
-      RUST_VERSION: 1.84.0
+      RUST_VERSION: 1.84.0 # Use the same version as in `rust-toolchain.toml`
     steps:
       - uses: actions/checkout@v4
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.84.0"                   # Use the same version as in `.github/workflows/*.yml`
 targets = ["wasm32-unknown-unknown"]

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -19,6 +19,7 @@ BASELINE_BRANCH_DIR=_canbench_baseline_branch
 CANBENCH_OUTPUT=/tmp/canbench_output.txt
 
 CANBENCH_RESULTS_FILE="$CANISTER_PATH/canbench_results.yml"
+CANBENCH_RESULTS_PERSISTED_FILE="/tmp/canbench_results_persisted_${CANBENCH_JOB_NAME}.yml"
 BASELINE_BRANCH_RESULTS_FILE="$BASELINE_BRANCH_DIR/$CANBENCH_RESULTS_FILE"
 
 CANBENCH_RESULTS_CSV_FILE="/tmp/canbench_results_${CANBENCH_JOB_NAME}.csv"
@@ -57,7 +58,8 @@ has_updates() {
 
 # Check if the canbench results file is up to date.
 pushd "$CANISTER_PATH"
-canbench --less-verbose --hide-results --show-summary --csv > "$CANBENCH_OUTPUT"
+canbench --less-verbose --hide-results --show-summary --csv --persist > "$CANBENCH_OUTPUT"
+cp "./canbench_results.yml" "$CANBENCH_RESULTS_PERSISTED_FILE"
 cp "./canbench_results.csv" "$CANBENCH_RESULTS_CSV_FILE"
 if has_updates; then
   UPDATED_MSG="**❌ \`$CANBENCH_RESULTS_FILE\` is not up to date**


### PR DESCRIPTION
This PR uploads persisted `canbench_results.yml` files as CI artifacts and centralizes Rust toolchain version management across all CI jobs.

This avoids the need to have the exact local environment for calculating `canbench_results.yml` file.

It also centralizes the Rust toolchain version across all CI jobs by introducing a single `RUST_VERSION` variable and updating existing steps to use it.