### PR TITLE
Revert "chore(deps): bump slackapi/slack-github-action from 1.25.0 to 2.1.1"

### DIFF
--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -24,7 +24,7 @@ jobs:
           echo "safe_title=$ESCAPED_TITLE" >> "$GITHUB_OUTPUT"
 
       - name: Post to a Slack channel
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         with:
           channel-id: eng-execution-mrs
           slack-message: ":github: `${{ github.repository }}` <${{ github.event.pull_request.html_url }}|${{ steps.sanitize.outputs.safe_title }}>"


### PR DESCRIPTION
Reverts dfinity/stable-structures#373

this version bump breaks CI:

```bash
Warning: Unexpected input(s) 'channel-id', 'slack-message', valid inputs are ['api', 'errors', 'method', 'payload', 'payload-delimiter', 'payload-file-path', 'payload-templated', 'proxy', 'retries', 'token', 'webhook', 'webhook-type']
Run slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
Error: Missing input! Either a method or webhook is required to take action.
SlackError: Missing input! Either a method or webhook is required to take action.
    at Config.validate (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/src/config.js:193:1)
    at new Config (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/src/config.js:124:1)
    at send (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/src/send.js:13:1)
    at file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/src/index.js:9:1
    at Function.__nccwpck_require__.a (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/webpack/runtime/async module:49:1)
    at Object.9722 (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/dist/index.js:45875:21)
    at __nccwpck_require__ (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/webpack/bootstrap:21:1)
    at file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/webpack/startup:4:1
    at ModuleJob.run (node:internal/modules/esm/module_job:263:25)
    at ModuleLoader.import (node:internal/modules/esm/loader:540:24)

file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/src/config.js:193
        throw new SlackError(
^
SlackError: Missing input! Either a method or webhook is required to take action.
    at Config.validate (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/src/config.js:193:1)
    at new Config (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/src/config.js:124:1)
    at send (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/src/send.js:13:1)
    at file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/src/index.js:9:1
    at Function.__nccwpck_require__.a (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/webpack/runtime/async module:49:1)
    at Object.9722 (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/dist/index.js:45875:21)
    at __nccwpck_require__ (file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/webpack/bootstrap:21:1)
    at file:///home/runner/work/_actions/slackapi/slack-github-action/91efab103c0de0a537f72a35f6b8cda0ee76bf0a/webpack/startup:4:1
    at ModuleJob.run (node:internal/modules/esm/module_job:263:25)
    at ModuleLoader.import (node:internal/modules/esm/loader:540:24)
```