### PR TITLE
feat(log): add first() and last() methods

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -180,6 +180,26 @@ impl<T: Storable, INDEX: Memory, DATA: Memory> Log<T, INDEX, DATA> {
         log
     }
 
+    /// Returns the first entry in the log, if any.
+    ///
+    /// Complexity: O(1)
+    #[inline]
+    pub fn first(&self) -> Option<T> {
+        self.get(0)
+    }
+
+    /// Returns the last entry in the log, if any.
+    ///
+    /// Complexity: O(1)
+    #[inline]
+    pub fn last(&self) -> Option<T> {
+        let len = self.len();
+        if len == 0 {
+            return None;
+        }
+        self.get(len - 1)
+    }
+
     /// Initializes the log based on the contents of the provided memory trait objects.
     /// If the memory trait objects already contain a stable log, this function recovers it from the stable
     /// memory. Otherwise, this function allocates a new empty log.

--- a/src/log/tests.rs
+++ b/src/log/tests.rs
@@ -221,6 +221,25 @@ fn test_iter() {
     assert_eq!(log.iter().skip(usize::MAX).count(), 0);
 }
 
+#[test]
+fn test_first_last() {
+    let log = Log::<String, _, _>::new(VectorMemory::default(), VectorMemory::default());
+    assert_eq!(log.first(), None);
+    assert_eq!(log.last(), None);
+
+    log.append(&"apple".to_string()).unwrap();
+    assert_eq!(log.first(), Some("apple".to_string()));
+    assert_eq!(log.last(), Some("apple".to_string()));
+
+    log.append(&"banana".to_string()).unwrap();
+    assert_eq!(log.first(), Some("apple".to_string()));
+    assert_eq!(log.last(), Some("banana".to_string()));
+
+    log.append(&"cider".to_string()).unwrap();
+    assert_eq!(log.first(), Some("apple".to_string()));
+    assert_eq!(log.last(), Some("cider".to_string()));
+}
+
 #[allow(clippy::iter_nth_zero)]
 #[test]
 fn test_thread_local_iter() {


### PR DESCRIPTION
### Motivation
- Provide convenient accessors for the first and last log entries.

### Solution
- Implemented first(&self) -> Option<T> returning self.get(0).
- Implemented last(&self) -> Option<T> returning the last entry or None when empty.
- Both are inlined and O(1) complexity.

### Details
- first/last preserve existing retrieval semantics and types.
- last handles empty logs safely by early None.

### Meta
updated tests accordingly