### PR TITLE
feat: implement `entry` for `BTreeMap` similar to std lib

### DIFF
--- a/benchmarks/btreemap/canbench_results.yml
+++ b/benchmarks/btreemap/canbench_results.yml
@@ -1,4 +1,18 @@
 benches:
+  btreemap_get_and_incr:
+    total:
+      calls: 1
+      instructions: 376179070
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  btreemap_get_and_incr_via_entry:
+    total:
+      calls: 1
+      instructions: 317352818
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
   btreemap_v2_contains_10mib_values:
     total:
       calls: 1

--- a/benchmarks/btreemap/src/main.rs
+++ b/benchmarks/btreemap/src/main.rs
@@ -1,6 +1,7 @@
 use benchmarks::{random::Random, vec::UnboundedVecN};
 use canbench_rs::{bench, bench_fn, BenchResult};
 use candid::Principal;
+use ic_stable_structures::btreemap::entry::Entry::Occupied;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
 use ic_stable_structures::{storable::Blob, BTreeMap, DefaultMemoryImpl, Memory, Storable};
 use std::ops::Bound;
@@ -392,6 +393,45 @@ pub fn btreemap_v2_get_10mib_values() -> BenchResult {
     bench_fn(|| {
         for i in 0..count {
             btree.get(&(i as u32));
+        }
+    })
+}
+
+#[bench(raw)]
+pub fn btreemap_get_and_incr() -> BenchResult {
+    let count = 10000;
+    let mut btree = BTreeMap::new(DefaultMemoryImpl::default());
+    let mut rng = Rng::from_seed(0);
+    let values = generate_random_kv::<u64, u64>(count, &mut rng);
+    for (key, value) in values.iter().copied() {
+        btree.insert(key, value);
+    }
+
+    bench_fn(|| {
+        for (key, _) in values {
+            let existing = btree.get(&key).unwrap();
+            btree.insert(key, existing + 1);
+        }
+    })
+}
+
+#[bench(raw)]
+pub fn btreemap_get_and_incr_via_entry() -> BenchResult {
+    let count = 10000;
+    let mut btree = BTreeMap::new(DefaultMemoryImpl::default());
+    let mut rng = Rng::from_seed(0);
+    let values = generate_random_kv::<u64, u64>(count, &mut rng);
+    for (key, value) in values.iter().copied() {
+        btree.insert(key, value);
+    }
+
+    bench_fn(|| {
+        for (key, _) in values {
+            let Occupied(e) = btree.entry(key) else {
+                panic!()
+            };
+            let existing = e.get();
+            e.insert(existing + 1);
         }
     })
 }

--- a/benchmarks/nns/src/nns_vote_cascading/tests.rs
+++ b/benchmarks/nns/src/nns_vote_cascading/tests.rs
@@ -168,7 +168,7 @@ fn set_up_worst_case<NS: NeuronStore>(
     for neuron_id in num_followees..num_neurons {
         let previous_neuron_ids = (neuron_id - num_half_followees - 1)..neuron_id;
         let followee_neuron_ids = previous_neuron_ids
-            .map(|id| NeuronId::from(id))
+            .map(NeuronId::from)
             .chain(not_voting_neuron_ids.clone().into_iter())
             .collect::<Vec<_>>();
         neuron_store.set_followees(

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -62,7 +62,6 @@ use allocator::Allocator;
 pub use iter::Iter;
 use node::{DerivedPageSize, Node, NodeType, PageSize, Version};
 use std::borrow::Cow;
-use std::cell::Cell;
 use std::marker::PhantomData;
 use std::ops::{Bound, RangeBounds};
 
@@ -526,6 +525,19 @@ where
     /// Once you have the entry you can `get` the value, `insert` a new value, or `remove`
     /// the value.
     pub fn entry(&mut self, key: K) -> entry::Entry<K, V, M> {
+        // For an empty map the key is trivially absent.  Avoid calling
+        // `find_node_for_insert` here because that eagerly allocates a root
+        // node and persists `root_addr` to the header, which would leave the
+        // map in an inconsistent state if the returned `VacantEntry` is dropped
+        // without calling `insert`.
+        if self.root_addr == NULL {
+            return entry::Entry::Vacant(entry::VacantEntry {
+                map: self,
+                key,
+                location: None,
+            });
+        }
+
         let (node, search_result) = self.find_node_for_insert(&key);
 
         match search_result {
@@ -534,13 +546,11 @@ where
                 key,
                 node,
                 idx,
-                cached_value: Cell::default(),
             }),
             Err(idx) => entry::Entry::Vacant(entry::VacantEntry {
                 map: self,
                 key,
-                node,
-                idx,
+                location: Some((node, idx)),
             }),
         }
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -519,6 +519,11 @@ where
         }
     }
 
+    /// Searches for the entry within the map where the key belongs.
+    /// The value returned is either a `VacantEntry` (if the key doesn't already exist), or an
+    /// `OccupiedEntry` (if the key does exist).
+    /// Once you have the entry you can `get` the value, `insert` a new value, or `remove`
+    /// the value.
     pub fn entry(&mut self, key: K) -> entry::Entry<K, V, M> {
         let (node, search_result) = self.find_node_for_insert(&key);
 
@@ -538,6 +543,10 @@ where
         }
     }
 
+    /// Finds the node the key (and its corresponding value) should be inserted into
+    /// Return value is a tuple, the first value is the node the key should be inserted into, the
+    /// seconds value is a `Result` which is `Ok` if the key exists in the node, or `Err` if not.
+    /// The value in either case is the index at which the key should be inserted.
     fn find_node_for_insert(&mut self, key: &K) -> (Node<K>, Result<usize, usize>) {
         if self.root_addr == NULL {
             // No root present. Allocate one.

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1383,7 +1383,6 @@ where
     /// PRECONDITION
     ///   - `node` is a leaf node
     ///   - `node.entries_len() > 1` or node is the root node
-    #[inline(always)]
     fn remove_from_leaf_node(&mut self, mut node: Node<K>, idx: usize) -> Vec<u8> {
         debug_assert_eq!(node.node_type(), NodeType::Leaf);
 
@@ -1413,7 +1412,6 @@ where
     /// PRECONDITION
     ///   - `node` is an internal node
     ///   - `node` contains `key` at index `idx`
-    #[inline(always)]
     fn remove_from_internal_node(&mut self, mut node: Node<K>, idx: usize, key: &K) -> Vec<u8> {
         debug_assert_eq!(node.node_type(), NodeType::Internal);
         debug_assert_eq!(node.search(key, self.memory()), Ok(idx));

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -637,20 +637,109 @@ where
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         let value = value.into_bytes_checked();
 
-        let (mut node, search_result) = self.find_node_for_insert(&key);
+        let root = if self.root_addr == NULL {
+            // No root present. Allocate one.
+            let node = self.allocate_node(NodeType::Leaf);
+            self.root_addr = node.address();
+            self.save_header();
+            node
+        } else {
+            // Load the root from memory.
+            let mut root = self.load_node(self.root_addr);
 
-        match search_result {
-            Ok(idx) => Some(V::from_bytes(Cow::Owned(
-                self.update_value(&mut node, idx, value),
-            ))),
-            Err(idx) => {
-                node.insert_entry(idx, (key, value));
-                self.save_node(&mut node);
+            // Check if the key already exists in the root.
+            if let Ok(idx) = root.search(&key, self.memory()) {
+                // Key found, replace its value and return the old one.
+                return Some(V::from_bytes(Cow::Owned(
+                    self.update_value(&mut root, idx, value),
+                )));
+            }
 
-                // Update the length.
-                self.length += 1;
+            // If the root is full, we need to introduce a new node as the root.
+            //
+            // NOTE: In the case where we are overwriting an existing key, then introducing
+            // a new root node isn't strictly necessary. However, that's a micro-optimization
+            // that adds more complexity than it's worth.
+            if root.is_full() {
+                // The root is full. Allocate a new node that will be used as the new root.
+                let mut new_root = self.allocate_node(NodeType::Internal);
+
+                // The new root has the old root as its only child.
+                new_root.push_child(self.root_addr);
+
+                // Update the root address.
+                self.root_addr = new_root.address();
                 self.save_header();
-                None
+
+                // Split the old (full) root.
+                self.split_child(&mut new_root, 0);
+
+                new_root
+            } else {
+                root
+            }
+        };
+
+        self.insert_nonfull(root, key, value)
+            .map(Cow::Owned)
+            .map(V::from_bytes)
+    }
+
+    /// Inserts an entry into a node that is *not full*.
+    fn insert_nonfull(&mut self, mut node: Node<K>, key: K, value: Vec<u8>) -> Option<Vec<u8>> {
+        // We're guaranteed by the caller that the provided node is not full.
+        assert!(!node.is_full());
+
+        // Look for the key in the node.
+        match node.search(&key, self.memory()) {
+            Ok(idx) => {
+                // Key found, replace its value and return the old one.
+                Some(self.update_value(&mut node, idx, value))
+            }
+            Err(idx) => {
+                // The key isn't in the node. `idx` is where that key should be inserted.
+
+                match node.node_type() {
+                    NodeType::Leaf => {
+                        // The node is a non-full leaf.
+                        // Insert the entry at the proper location.
+                        node.insert_entry(idx, (key, value));
+                        self.save_node(&mut node);
+
+                        // Update the length.
+                        self.length += 1;
+                        self.save_header();
+
+                        // No previous value to return.
+                        None
+                    }
+                    NodeType::Internal => {
+                        // The node is an internal node.
+                        // Load the child that we should add the entry to.
+                        let mut child = self.load_node(node.child(idx));
+
+                        if child.is_full() {
+                            // Check if the key already exists in the child.
+                            if let Ok(idx) = child.search(&key, self.memory()) {
+                                // Key found, replace its value and return the old one.
+                                return Some(self.update_value(&mut child, idx, value));
+                            }
+
+                            // The child is full. Split the child.
+                            self.split_child(&mut node, idx);
+
+                            // The children have now changed. Search again for
+                            // the child where we need to store the entry in.
+                            let idx = node.search(&key, self.memory()).unwrap_or_else(|idx| idx);
+                            child = self.load_node(node.child(idx));
+                        }
+
+                        // The child should now be not full.
+                        assert!(!child.is_full());
+
+                        self.insert_nonfull(child, key, value)
+                    }
+                }
             }
         }
     }
@@ -710,7 +799,40 @@ where
             });
         }
 
-        let (node, search_result) = self.find_node_for_insert(&key);
+        // Load the root from memory.
+        let mut root = self.load_node(self.root_addr);
+
+        let (node, search_result) = {
+            // Check if the key already exists in the root.
+            if let Ok(idx) = root.search(&key, self.memory()) {
+                // Key found
+                (root, Ok(idx))
+            } else {
+                // If the root is full, we need to introduce a new node as the root.
+                //
+                // NOTE: In the case where we are overwriting an existing key, then introducing
+                // a new root node isn't strictly necessary. However, that's a micro-optimization
+                // that adds more complexity than it's worth.
+                if root.is_full() {
+                    // The root is full. Allocate a new node that will be used as the new root.
+                    let mut new_root = self.allocate_node(NodeType::Internal);
+
+                    // The new root has the old root as its only child.
+                    new_root.push_child(self.root_addr);
+
+                    // Update the root address.
+                    self.root_addr = new_root.address();
+                    self.save_header();
+
+                    // Split the old (full) root.
+                    self.split_child(&mut new_root, 0);
+
+                    root = new_root;
+                }
+
+                self.find_node_for_insert_nonfull(root, &key)
+            }
+        };
 
         match search_result {
             Ok(idx) => entry::Entry::Occupied(entry::OccupiedEntry {
@@ -725,53 +847,6 @@ where
                 location: Some((node, idx)),
             }),
         }
-    }
-
-    /// Finds the node the key (and its corresponding value) should be inserted into
-    /// Return value is a tuple, the first value is the node the key should be inserted into, the
-    /// seconds value is a `Result` which is `Ok` if the key exists in the node, or `Err` if not.
-    /// The value in either case is the index at which the key should be inserted.
-    fn find_node_for_insert(&mut self, key: &K) -> (Node<K>, Result<usize, usize>) {
-        if self.root_addr == NULL {
-            // No root present. Allocate one.
-            let node = self.allocate_node(NodeType::Leaf);
-            self.root_addr = node.address();
-            self.save_header();
-            return (node, Err(0));
-        }
-
-        // Load the root from memory.
-        let mut root = self.load_node(self.root_addr);
-
-        // Check if the key already exists in the root.
-        if let Ok(idx) = root.search(key, self.memory()) {
-            // Key found
-            return (root, Ok(idx));
-        }
-
-        // If the root is full, we need to introduce a new node as the root.
-        //
-        // NOTE: In the case where we are overwriting an existing key, then introducing
-        // a new root node isn't strictly necessary. However, that's a micro-optimization
-        // that adds more complexity than it's worth.
-        if root.is_full() {
-            // The root is full. Allocate a new node that will be used as the new root.
-            let mut new_root = self.allocate_node(NodeType::Internal);
-
-            // The new root has the old root as its only child.
-            new_root.push_child(self.root_addr);
-
-            // Update the root address.
-            self.root_addr = new_root.address();
-            self.save_header();
-
-            // Split the old (full) root.
-            self.split_child(&mut new_root, 0);
-
-            root = new_root;
-        }
-
-        self.find_node_for_insert_nonfull(root, key)
     }
 
     /// Finds the node the key (and its corresponding value) should be inserted into
@@ -1308,6 +1383,7 @@ where
     /// PRECONDITION
     ///   - `node` is a leaf node
     ///   - `node.entries_len() > 1` or node is the root node
+    #[inline(always)]
     fn remove_from_leaf_node(&mut self, mut node: Node<K>, idx: usize) -> Vec<u8> {
         debug_assert_eq!(node.node_type(), NodeType::Leaf);
 
@@ -1337,6 +1413,7 @@ where
     /// PRECONDITION
     ///   - `node` is an internal node
     ///   - `node` contains `key` at index `idx`
+    #[inline(always)]
     fn remove_from_internal_node(&mut self, mut node: Node<K>, idx: usize, key: &K) -> Vec<u8> {
         debug_assert_eq!(node.node_type(), NodeType::Internal);
         debug_assert_eq!(node.search(key, self.memory()), Ok(idx));

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -655,93 +655,25 @@ where
                 )));
             }
 
-            // If the root is full, we need to introduce a new node as the root.
-            //
             // NOTE: In the case where we are overwriting an existing key, then introducing
             // a new root node isn't strictly necessary. However, that's a micro-optimization
             // that adds more complexity than it's worth.
-            if root.is_full() {
-                // The root is full. Allocate a new node that will be used as the new root.
-                let mut new_root = self.allocate_node(NodeType::Internal);
-
-                // The new root has the old root as its only child.
-                new_root.push_child(self.root_addr);
-
-                // Update the root address.
-                self.root_addr = new_root.address();
-                self.save_header();
-
-                // Split the old (full) root.
-                self.split_child(&mut new_root, 0);
-
-                new_root
-            } else {
-                root
-            }
+            self.split_root_if_full(root)
         };
 
-        self.insert_nonfull(root, key, value)
-            .map(Cow::Owned)
-            .map(V::from_bytes)
-    }
-
-    /// Inserts an entry into a node that is *not full*.
-    fn insert_nonfull(&mut self, mut node: Node<K>, key: K, value: Vec<u8>) -> Option<Vec<u8>> {
-        // We're guaranteed by the caller that the provided node is not full.
-        assert!(!node.is_full());
-
-        // Look for the key in the node.
-        match node.search(&key, self.memory()) {
-            Ok(idx) => {
-                // Key found, replace its value and return the old one.
-                Some(self.update_value(&mut node, idx, value))
+        self.find_node_for_insert(root, key, move |map, mut node, idx, key, key_exists| {
+            if key_exists {
+                Some(map.update_value(&mut node, idx, value))
+            } else {
+                node.insert_entry(idx, (key, value));
+                map.save_node(&mut node);
+                map.length += 1;
+                map.save_header();
+                None
             }
-            Err(idx) => {
-                // The key isn't in the node. `idx` is where that key should be inserted.
-
-                match node.node_type() {
-                    NodeType::Leaf => {
-                        // The node is a non-full leaf.
-                        // Insert the entry at the proper location.
-                        node.insert_entry(idx, (key, value));
-                        self.save_node(&mut node);
-
-                        // Update the length.
-                        self.length += 1;
-                        self.save_header();
-
-                        // No previous value to return.
-                        None
-                    }
-                    NodeType::Internal => {
-                        // The node is an internal node.
-                        // Load the child that we should add the entry to.
-                        let mut child = self.load_node(node.child(idx));
-
-                        if child.is_full() {
-                            // Check if the key already exists in the child.
-                            if let Ok(idx) = child.search(&key, self.memory()) {
-                                // Key found, replace its value and return the old one.
-                                return Some(self.update_value(&mut child, idx, value));
-                            }
-
-                            // The child is full. Split the child.
-                            self.split_child(&mut node, idx);
-
-                            // The children have now changed. Search again for
-                            // the child where we need to store the entry in.
-                            let idx = node.search(&key, self.memory()).unwrap_or_else(|idx| idx);
-                            child = self.load_node(node.child(idx));
-                        }
-
-                        // The child should now be not full.
-                        assert!(!child.is_full());
-
-                        self.insert_nonfull(child, key, value)
-                    }
-                }
-            }
-        }
+        })
+        .map(Cow::Owned)
+        .map(V::from_bytes)
     }
 
     /// Gets an [`Entry`](entry::Entry) for the given `key`, which gives efficient in-place access
@@ -802,37 +734,27 @@ where
         // Load the root from memory.
         let mut root = self.load_node(self.root_addr);
 
-        let (node, search_result) = {
-            // Check if the key already exists in the root.
-            if let Ok(idx) = root.search(&key, self.memory()) {
-                // Key found
-                (root, Ok(idx))
-            } else {
-                // If the root is full, we need to introduce a new node as the root.
-                //
-                // NOTE: In the case where we are overwriting an existing key, then introducing
-                // a new root node isn't strictly necessary. However, that's a micro-optimization
-                // that adds more complexity than it's worth.
-                if root.is_full() {
-                    // The root is full. Allocate a new node that will be used as the new root.
-                    let mut new_root = self.allocate_node(NodeType::Internal);
+        // Check if the key already exists in the root.
+        if let Ok(idx) = root.search(&key, self.memory()) {
+            // Key found
+            return entry::Entry::Occupied(entry::OccupiedEntry {
+                map: self,
+                key,
+                node: root,
+                idx,
+            });
+        }
 
-                    // The new root has the old root as its only child.
-                    new_root.push_child(self.root_addr);
+        root = self.split_root_if_full(root);
 
-                    // Update the root address.
-                    self.root_addr = new_root.address();
-                    self.save_header();
-
-                    // Split the old (full) root.
-                    self.split_child(&mut new_root, 0);
-
-                    root = new_root;
+        let (key, node, search_result) =
+            self.find_node_for_insert(root, key, |_, node, idx, key, key_exists| {
+                if key_exists {
+                    (key, node, Ok(idx))
+                } else {
+                    (key, node, Err(idx))
                 }
-
-                self.find_node_for_insert_nonfull(root, &key)
-            }
-        };
+            });
 
         match search_result {
             Ok(idx) => entry::Entry::Occupied(entry::OccupiedEntry {
@@ -849,23 +771,61 @@ where
         }
     }
 
-    /// Finds the node the key (and its corresponding value) should be inserted into
+    /// Ensures the root node is not full, called before an insertion.
     ///
-    /// PRECONDITION:
-    ///   - `node` is not full.
-    fn find_node_for_insert_nonfull(
+    /// If `root` is full, a new internal node is allocated, made the parent of the old
+    /// root, and the old root is split into two children.  The new (non-full) root is
+    /// returned.  If `root` is not full it is returned unchanged.
+    fn split_root_if_full(&mut self, root: Node<K>) -> Node<K> {
+        if !root.is_full() {
+            return root;
+        }
+
+        // Allocate a new node that will become the new root.
+        let mut new_root = self.allocate_node(NodeType::Internal);
+
+        // The new root has the old root as its only child.
+        new_root.push_child(self.root_addr);
+
+        // Persist the updated root address before splitting.
+        self.root_addr = new_root.address();
+        self.save_header();
+
+        // Split the old (full) root into two children of new_root.
+        self.split_child(&mut new_root, 0);
+
+        new_root
+    }
+
+    /// Core B-tree insertion traversal, shared by [`BTreeMap::insert`] and [`BTreeMap::entry`].
+    ///
+    /// Descends from `node` (which must not be full) to the leaf or internal node where
+    /// `key` either already exists or should be inserted, then invokes `callback` with:
+    ///
+    /// * `map`        — mutable access to the map (for saving nodes, updating length, etc.)
+    /// * `node`       — the target node
+    /// * `idx`        — the relevant slot index within `node`
+    /// * `key`        — the key being inserted
+    /// * `key_exists` — `true` if `key` is already present at `idx`; `false` if `idx` is
+    ///                  the position where `key` should be inserted
+    ///
+    /// The callback's return value is propagated back to the caller.
+    ///
+    /// PRECONDITION: `node` is not full.
+    fn find_node_for_insert<R>(
         &mut self,
         mut node: Node<K>,
-        key: &K,
-    ) -> (Node<K>, Result<usize, usize>) {
+        key: K,
+        callback: impl FnOnce(&mut Self, Node<K>, usize, K, bool) -> R,
+    ) -> R {
         // We're guaranteed by the caller that the provided node is not full.
         assert!(!node.is_full());
 
         // Look for the key in the node.
-        match node.search(key, self.memory()) {
+        match node.search(&key, self.memory()) {
             Ok(idx) => {
-                // Key found
-                (node, Ok(idx))
+                // Key found.
+                callback(self, node, idx, key, true)
             }
             Err(idx) => {
                 // The key isn't in the node. `idx` is where that key should be inserted.
@@ -873,7 +833,7 @@ where
                 match node.node_type() {
                     NodeType::Leaf => {
                         // The node is a non-full leaf.
-                        (node, Err(idx))
+                        callback(self, node, idx, key, false)
                     }
                     NodeType::Internal => {
                         // The node is an internal node.
@@ -882,9 +842,9 @@ where
 
                         if child.is_full() {
                             // Check if the key already exists in the child.
-                            if let Ok(idx) = child.search(key, self.memory()) {
-                                // Key found
-                                return (child, Ok(idx));
+                            if let Ok(idx) = child.search(&key, self.memory()) {
+                                // Key found.
+                                return callback(self, child, idx, key, true);
                             }
 
                             // The child is full. Split the child.
@@ -892,14 +852,14 @@ where
 
                             // The children have now changed. Search again for
                             // the child where we need to store the entry in.
-                            let idx = node.search(key, self.memory()).unwrap_or_else(|idx| idx);
+                            let idx = node.search(&key, self.memory()).unwrap_or_else(|idx| idx);
                             child = self.load_node(node.child(idx));
                         }
 
                         // The child should now be not full.
                         assert!(!child.is_full());
 
-                        self.find_node_for_insert_nonfull(child, key)
+                        self.find_node_for_insert(child, key, callback)
                     }
                 }
             }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -551,7 +551,7 @@ where
         let mut root = self.load_node(self.root_addr);
 
         // Check if the key already exists in the root.
-        if let Ok(idx) = root.search(&key, self.memory()) {
+        if let Ok(idx) = root.search(key, self.memory()) {
             // Key found
             return (root, Ok(idx));
         }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -62,6 +62,7 @@ use allocator::Allocator;
 pub use iter::Iter;
 use node::{DerivedPageSize, Node, NodeType, PageSize, Version};
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::marker::PhantomData;
 use std::ops::{Bound, RangeBounds};
 
@@ -533,6 +534,7 @@ where
                 key,
                 node,
                 idx,
+                cached_value: Cell::default(),
             }),
             Err(idx) => entry::Entry::Vacant(entry::VacantEntry {
                 map: self,

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -49,6 +49,7 @@
 //! ----------------------------------------
 //! ```
 mod allocator;
+pub mod entry;
 mod iter;
 mod node;
 use crate::btreemap::iter::{IterInternal, KeysIter, ValuesIter};
@@ -59,7 +60,7 @@ use crate::{
 };
 use allocator::Allocator;
 pub use iter::Iter;
-use node::{DerivedPageSize, Entry, Node, NodeType, PageSize, Version};
+use node::{DerivedPageSize, Node, NodeType, PageSize, Version};
 use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::ops::{Bound, RangeBounds};
@@ -500,64 +501,103 @@ where
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         let value = value.into_bytes_checked();
 
-        let root = if self.root_addr == NULL {
+        let (mut node, search_result) = self.find_node_for_insert(&key);
+
+        match search_result {
+            Ok(idx) => Some(V::from_bytes(Cow::Owned(
+                self.update_value(&mut node, idx, value),
+            ))),
+            Err(idx) => {
+                node.insert_entry(idx, (key, value));
+                self.save_node(&mut node);
+
+                // Update the length.
+                self.length += 1;
+                self.save_header();
+                None
+            }
+        }
+    }
+
+    pub fn entry(&mut self, key: K) -> entry::Entry<K, V, M> {
+        let (node, search_result) = self.find_node_for_insert(&key);
+
+        match search_result {
+            Ok(idx) => entry::Entry::Occupied(entry::OccupiedEntry {
+                map: self,
+                key,
+                node,
+                idx,
+            }),
+            Err(idx) => entry::Entry::Vacant(entry::VacantEntry {
+                map: self,
+                key,
+                node,
+                idx,
+            }),
+        }
+    }
+
+    fn find_node_for_insert(&mut self, key: &K) -> (Node<K>, Result<usize, usize>) {
+        if self.root_addr == NULL {
             // No root present. Allocate one.
             let node = self.allocate_node(NodeType::Leaf);
             self.root_addr = node.address();
             self.save_header();
-            node
-        } else {
-            // Load the root from memory.
-            let mut root = self.load_node(self.root_addr);
+            return (node, Err(0));
+        }
 
-            // Check if the key already exists in the root.
-            if let Ok(idx) = root.search(&key, self.memory()) {
-                // Key found, replace its value and return the old one.
-                return Some(V::from_bytes(Cow::Owned(
-                    self.update_value(&mut root, idx, value),
-                )));
-            }
+        // Load the root from memory.
+        let mut root = self.load_node(self.root_addr);
 
-            // If the root is full, we need to introduce a new node as the root.
-            //
-            // NOTE: In the case where we are overwriting an existing key, then introducing
-            // a new root node isn't strictly necessary. However, that's a micro-optimization
-            // that adds more complexity than it's worth.
-            if root.is_full() {
-                // The root is full. Allocate a new node that will be used as the new root.
-                let mut new_root = self.allocate_node(NodeType::Internal);
+        // Check if the key already exists in the root.
+        if let Ok(idx) = root.search(&key, self.memory()) {
+            // Key found
+            return (root, Ok(idx));
+        }
 
-                // The new root has the old root as its only child.
-                new_root.push_child(self.root_addr);
+        // If the root is full, we need to introduce a new node as the root.
+        //
+        // NOTE: In the case where we are overwriting an existing key, then introducing
+        // a new root node isn't strictly necessary. However, that's a micro-optimization
+        // that adds more complexity than it's worth.
+        if root.is_full() {
+            // The root is full. Allocate a new node that will be used as the new root.
+            let mut new_root = self.allocate_node(NodeType::Internal);
 
-                // Update the root address.
-                self.root_addr = new_root.address();
-                self.save_header();
+            // The new root has the old root as its only child.
+            new_root.push_child(self.root_addr);
 
-                // Split the old (full) root.
-                self.split_child(&mut new_root, 0);
+            // Update the root address.
+            self.root_addr = new_root.address();
+            self.save_header();
 
-                new_root
-            } else {
-                root
-            }
-        };
+            // Split the old (full) root.
+            self.split_child(&mut new_root, 0);
 
-        self.insert_nonfull(root, key, value)
-            .map(Cow::Owned)
-            .map(V::from_bytes)
+            root = new_root;
+        }
+
+        self.find_node_for_insert_nonfull(root, key)
     }
 
-    /// Inserts an entry into a node that is *not full*.
-    fn insert_nonfull(&mut self, mut node: Node<K>, key: K, value: Vec<u8>) -> Option<Vec<u8>> {
+    /// Finds the node the key (and its corresponding value) should be inserted into
+    ///
+    /// PRECONDITION:
+    ///   - `node` is not full.
+    fn find_node_for_insert_nonfull(
+        &mut self,
+        mut node: Node<K>,
+        key: &K,
+    ) -> (Node<K>, Result<usize, usize>) {
         // We're guaranteed by the caller that the provided node is not full.
         assert!(!node.is_full());
 
         // Look for the key in the node.
-        match node.search(&key, self.memory()) {
+        match node.search(key, self.memory()) {
             Ok(idx) => {
-                // Key found, replace its value and return the old one.
-                Some(self.update_value(&mut node, idx, value))
+                // Key found
+                (node, Ok(idx))
             }
             Err(idx) => {
                 // The key isn't in the node. `idx` is where that key should be inserted.
@@ -565,16 +605,7 @@ where
                 match node.node_type() {
                     NodeType::Leaf => {
                         // The node is a non-full leaf.
-                        // Insert the entry at the proper location.
-                        node.insert_entry(idx, (key, value));
-                        self.save_node(&mut node);
-
-                        // Update the length.
-                        self.length += 1;
-                        self.save_header();
-
-                        // No previous value to return.
-                        None
+                        (node, Err(idx))
                     }
                     NodeType::Internal => {
                         // The node is an internal node.
@@ -583,9 +614,9 @@ where
 
                         if child.is_full() {
                             // Check if the key already exists in the child.
-                            if let Ok(idx) = child.search(&key, self.memory()) {
-                                // Key found, replace its value and return the old one.
-                                return Some(self.update_value(&mut child, idx, value));
+                            if let Ok(idx) = child.search(key, self.memory()) {
+                                // Key found
+                                return (child, Ok(idx));
                             }
 
                             // The child is full. Split the child.
@@ -593,14 +624,14 @@ where
 
                             // The children have now changed. Search again for
                             // the child where we need to store the entry in.
-                            let idx = node.search(&key, self.memory()).unwrap_or_else(|idx| idx);
+                            let idx = node.search(key, self.memory()).unwrap_or_else(|idx| idx);
                             child = self.load_node(node.child(idx));
                         }
 
                         // The child should now be not full.
                         assert!(!child.is_full());
 
-                        self.insert_nonfull(child, key, value)
+                        self.find_node_for_insert_nonfull(child, key)
                     }
                 }
             }
@@ -796,25 +827,7 @@ where
             NodeType::Leaf => {
                 match node.search(key, self.memory()) {
                     Ok(idx) => {
-                        // Case 1: The node is a leaf node and the key exists in it.
-                        // This is the simplest case. The key is removed from the leaf.
-                        let value = node.remove_entry(idx, self.memory()).1;
-                        self.length -= 1;
-
-                        if node.entries_len() == 0 {
-                            assert_eq!(
-                                node.address(), self.root_addr,
-                                "Removal can only result in an empty leaf node if that node is the root"
-                            );
-
-                            // Deallocate the empty node.
-                            self.deallocate_node(node);
-                            self.root_addr = NULL;
-                        } else {
-                            self.save_node(&mut node);
-                        }
-
-                        self.save_header();
+                        let value = self.remove_from_leaf_node(node, idx);
                         Some(value)
                     }
                     _ => None, // Key not found.
@@ -823,129 +836,8 @@ where
             NodeType::Internal => {
                 match node.search(key, self.memory()) {
                     Ok(idx) => {
-                        // Case 2: The node is an internal node and the key exists in it.
-
-                        let left_child = self.load_node(node.child(idx));
-                        if left_child.can_remove_entry_without_merging() {
-                            // Case 2.a: A key can be removed from the left child without merging.
-                            //
-                            //                       parent
-                            //                  [..., key, ...]
-                            //                       /   \
-                            //            [left child]   [...]
-                            //           /            \
-                            //        [...]         [..., key predecessor]
-                            //
-                            // In this case, we replace `key` with the key's predecessor from the
-                            // left child's subtree, then we recursively delete the key's
-                            // predecessor for the following end result:
-                            //
-                            //                       parent
-                            //            [..., key predecessor, ...]
-                            //                       /   \
-                            //            [left child]   [...]
-                            //           /            \
-                            //        [...]          [...]
-
-                            // Recursively delete the predecessor.
-                            // TODO(EXC-1034): Do this in a single pass.
-                            let predecessor = left_child.get_max(self.memory());
-                            self.remove_helper(left_child, &predecessor.0)?;
-
-                            // Replace the `key` with its predecessor.
-                            let (_, old_value) = node.swap_entry(idx, predecessor, self.memory());
-
-                            // Save the parent node.
-                            self.save_node(&mut node);
-                            return Some(old_value);
-                        }
-
-                        let right_child = self.load_node(node.child(idx + 1));
-                        if right_child.can_remove_entry_without_merging() {
-                            // Case 2.b: A key can be removed from the right child without merging.
-                            //
-                            //                       parent
-                            //                  [..., key, ...]
-                            //                       /   \
-                            //                   [...]   [right child]
-                            //                          /             \
-                            //              [key successor, ...]     [...]
-                            //
-                            // In this case, we replace `key` with the key's successor from the
-                            // right child's subtree, then we recursively delete the key's
-                            // successor for the following end result:
-                            //
-                            //                       parent
-                            //            [..., key successor, ...]
-                            //                       /   \
-                            //                  [...]   [right child]
-                            //                           /            \
-                            //                        [...]          [...]
-
-                            // Recursively delete the successor.
-                            // TODO(EXC-1034): Do this in a single pass.
-                            let successor = right_child.get_min(self.memory());
-                            self.remove_helper(right_child, &successor.0)?;
-
-                            // Replace the `key` with its successor.
-                            let (_, old_value) = node.swap_entry(idx, successor, self.memory());
-
-                            // Save the parent node.
-                            self.save_node(&mut node);
-                            return Some(old_value);
-                        }
-
-                        // Case 2.c: Both the left and right child are at their minimum sizes.
-                        //
-                        //                       parent
-                        //                  [..., key, ...]
-                        //                       /   \
-                        //            [left child]   [right child]
-                        //
-                        // In this case, we merge (left child, key, right child) into a single
-                        // node. The result will look like this:
-                        //
-                        //                       parent
-                        //                     [...  ...]
-                        //                         |
-                        //          [left child, `key`, right child] <= new child
-                        //
-                        // We then recurse on this new child to delete `key`.
-                        //
-                        // If `parent` becomes empty (which can only happen if it's the root),
-                        // then `parent` is deleted and `new_child` becomes the new root.
-                        assert!(left_child.at_minimum());
-                        assert!(right_child.at_minimum());
-
-                        // Merge the right child into the left child.
-                        let mut new_child = self.merge(
-                            right_child,
-                            left_child,
-                            node.remove_entry(idx, self.memory()),
-                        );
-
-                        // Remove the right child from the parent node.
-                        node.remove_child(idx + 1);
-
-                        if node.entries_len() == 0 {
-                            // Can only happen if this node is root.
-                            assert_eq!(node.address(), self.root_addr);
-                            assert_eq!(node.child(0), new_child.address());
-                            assert_eq!(node.children_len(), 1);
-
-                            self.root_addr = new_child.address();
-
-                            // Deallocate the root node.
-                            self.deallocate_node(node);
-                            self.save_header();
-                        } else {
-                            self.save_node(&mut node);
-                        }
-
-                        self.save_node(&mut new_child);
-
-                        // Recursively delete the key.
-                        self.remove_helper(new_child, key)
+                        let value = self.remove_from_internal_node(node, idx, key);
+                        Some(value)
                     }
                     Err(idx) => {
                         // Case 3: The node is an internal node and the key does NOT exist in it.
@@ -1150,6 +1042,170 @@ where
         }
     }
 
+    /// PRECONDITION
+    ///   - `node` is a leaf node
+    ///   - `node.can_remove_entry_without_merging()` is true
+    fn remove_from_leaf_node(&mut self, mut node: Node<K>, idx: usize) -> Vec<u8> {
+        debug_assert!(node.node_type() == NodeType::Leaf);
+        debug_assert!(node.can_remove_entry_without_merging());
+
+        // Case 1: The node is a leaf node and the key exists in it.
+        // This is the simplest case. The key is removed from the leaf.
+        let value = node.remove_entry(idx, self.memory()).1;
+        self.length -= 1;
+
+        if node.entries_len() == 0 {
+            assert_eq!(
+                node.address(),
+                self.root_addr,
+                "Removal can only result in an empty leaf node if that node is the root"
+            );
+
+            // Deallocate the empty node.
+            self.deallocate_node(node);
+            self.root_addr = NULL;
+        } else {
+            self.save_node(&mut node);
+        }
+
+        self.save_header();
+        value
+    }
+
+    /// PRECONDITION
+    ///   - `node` is an internal node
+    ///   - `node` contains `key` at index `idx`
+    ///   - `node.can_remove_entry_without_merging()` is true
+    fn remove_from_internal_node(&mut self, mut node: Node<K>, idx: usize, key: &K) -> Vec<u8> {
+        debug_assert!(node.node_type() == NodeType::Internal);
+        debug_assert!(node.search(key, self.memory()) == Ok(idx));
+        debug_assert!(node.can_remove_entry_without_merging());
+
+        // Case 2: The node is an internal node and the key exists in it.
+
+        let left_child = self.load_node(node.child(idx));
+        if left_child.can_remove_entry_without_merging() {
+            // Case 2.a: A key can be removed from the left child without merging.
+            //
+            //                       parent
+            //                  [..., key, ...]
+            //                       /   \
+            //            [left child]   [...]
+            //           /            \
+            //        [...]         [..., key predecessor]
+            //
+            // In this case, we replace `key` with the key's predecessor from the
+            // left child's subtree, then we recursively delete the key's
+            // predecessor for the following end result:
+            //
+            //                       parent
+            //            [..., key predecessor, ...]
+            //                       /   \
+            //            [left child]   [...]
+            //           /            \
+            //        [...]          [...]
+
+            // Recursively delete the predecessor.
+            // TODO(EXC-1034): Do this in a single pass.
+            let predecessor = left_child.get_max(self.memory());
+            self.remove_helper(left_child, &predecessor.0).unwrap();
+
+            // Replace the `key` with its predecessor.
+            let (_, old_value) = node.swap_entry(idx, predecessor, self.memory());
+
+            // Save the parent node.
+            self.save_node(&mut node);
+            return old_value;
+        }
+
+        let right_child = self.load_node(node.child(idx + 1));
+        if right_child.can_remove_entry_without_merging() {
+            // Case 2.b: A key can be removed from the right child without merging.
+            //
+            //                       parent
+            //                  [..., key, ...]
+            //                       /   \
+            //                   [...]   [right child]
+            //                          /             \
+            //              [key successor, ...]     [...]
+            //
+            // In this case, we replace `key` with the key's successor from the
+            // right child's subtree, then we recursively delete the key's
+            // successor for the following end result:
+            //
+            //                       parent
+            //            [..., key successor, ...]
+            //                       /   \
+            //                  [...]   [right child]
+            //                           /            \
+            //                        [...]          [...]
+
+            // Recursively delete the successor.
+            // TODO(EXC-1034): Do this in a single pass.
+            let successor = right_child.get_min(self.memory());
+            self.remove_helper(right_child, &successor.0).unwrap();
+
+            // Replace the `key` with its successor.
+            let (_, old_value) = node.swap_entry(idx, successor, self.memory());
+
+            // Save the parent node.
+            self.save_node(&mut node);
+            return old_value;
+        }
+
+        // Case 2.c: Both the left and right child are at their minimum sizes.
+        //
+        //                       parent
+        //                  [..., key, ...]
+        //                       /   \
+        //            [left child]   [right child]
+        //
+        // In this case, we merge (left child, key, right child) into a single
+        // node. The result will look like this:
+        //
+        //                       parent
+        //                     [...  ...]
+        //                         |
+        //          [left child, `key`, right child] <= new child
+        //
+        // We then recurse on this new child to delete `key`.
+        //
+        // If `parent` becomes empty (which can only happen if it's the root),
+        // then `parent` is deleted and `new_child` becomes the new root.
+        assert!(left_child.at_minimum());
+        assert!(right_child.at_minimum());
+
+        // Merge the right child into the left child.
+        let mut new_child = self.merge(
+            right_child,
+            left_child,
+            node.remove_entry(idx, self.memory()),
+        );
+
+        // Remove the right child from the parent node.
+        node.remove_child(idx + 1);
+
+        if node.entries_len() == 0 {
+            // Can only happen if this node is root.
+            assert_eq!(node.address(), self.root_addr);
+            assert_eq!(node.child(0), new_child.address());
+            assert_eq!(node.children_len(), 1);
+
+            self.root_addr = new_child.address();
+
+            // Deallocate the root node.
+            self.deallocate_node(node);
+            self.save_header();
+        } else {
+            self.save_node(&mut node);
+        }
+
+        self.save_node(&mut new_child);
+
+        // Recursively delete the key.
+        self.remove_helper(new_child, key).unwrap()
+    }
+
     /// Returns an iterator over the entries of the map, sorted by key.
     ///
     /// # Example
@@ -1272,7 +1328,7 @@ where
     /// Output:
     ///   [1, 2, 3, 4, 5, 6, 7] (stored in the `into` node)
     ///   `source` is deallocated.
-    fn merge(&mut self, source: Node<K>, mut into: Node<K>, median: Entry<K>) -> Node<K> {
+    fn merge(&mut self, source: Node<K>, mut into: Node<K>, median: node::Entry<K>) -> Node<K> {
         into.merge(source, median, &mut self.allocator);
         into
     }

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1053,10 +1053,9 @@ where
 
     /// PRECONDITION
     ///   - `node` is a leaf node
-    ///   - `node.can_remove_entry_without_merging()` is true
+    ///   - `node.entries_len() > 1` or node is the root node
     fn remove_from_leaf_node(&mut self, mut node: Node<K>, idx: usize) -> Vec<u8> {
         debug_assert!(node.node_type() == NodeType::Leaf);
-        debug_assert!(node.can_remove_entry_without_merging());
 
         // Case 1: The node is a leaf node and the key exists in it.
         // This is the simplest case. The key is removed from the leaf.
@@ -1084,11 +1083,9 @@ where
     /// PRECONDITION
     ///   - `node` is an internal node
     ///   - `node` contains `key` at index `idx`
-    ///   - `node.can_remove_entry_without_merging()` is true
     fn remove_from_internal_node(&mut self, mut node: Node<K>, idx: usize, key: &K) -> Vec<u8> {
         debug_assert!(node.node_type() == NodeType::Internal);
         debug_assert!(node.search(key, self.memory()) == Ok(idx));
-        debug_assert!(node.can_remove_entry_without_merging());
 
         // Case 2: The node is an internal node and the key exists in it.
 

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -1055,7 +1055,7 @@ where
     ///   - `node` is a leaf node
     ///   - `node.entries_len() > 1` or node is the root node
     fn remove_from_leaf_node(&mut self, mut node: Node<K>, idx: usize) -> Vec<u8> {
-        debug_assert!(node.node_type() == NodeType::Leaf);
+        debug_assert_eq!(node.node_type(), NodeType::Leaf);
 
         // Case 1: The node is a leaf node and the key exists in it.
         // This is the simplest case. The key is removed from the leaf.
@@ -1084,8 +1084,8 @@ where
     ///   - `node` is an internal node
     ///   - `node` contains `key` at index `idx`
     fn remove_from_internal_node(&mut self, mut node: Node<K>, idx: usize, key: &K) -> Vec<u8> {
-        debug_assert!(node.node_type() == NodeType::Internal);
-        debug_assert!(node.search(key, self.memory()) == Ok(idx));
+        debug_assert_eq!(node.node_type(), NodeType::Internal);
+        debug_assert_eq!(node.search(key, self.memory()), Ok(idx));
 
         // Case 2: The node is an internal node and the key exists in it.
 

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -519,11 +519,47 @@ where
         }
     }
 
-    /// Searches for the entry within the map where the key belongs.
-    /// The value returned is either a `VacantEntry` (if the key doesn't already exist), or an
-    /// `OccupiedEntry` (if the key does exist).
-    /// Once you have the entry you can `get` the value, `insert` a new value, or `remove`
-    /// the value.
+    /// Gets an [`Entry`](entry::Entry) for the given `key`, which gives efficient in-place access
+    /// to a map's entries, allowing inspection or modification without redundant key lookups. The
+    /// API mirrors [`std::collections::btree_map::Entry`] as closely as the stable-memory model
+    /// allows.
+    ///
+    /// Returns [`Entry::Occupied`](entry::Entry::Occupied) when `key` is already present, or
+    /// [`Entry::Vacant`](entry::Entry::Vacant) when it is not. Both variants expose methods to
+    /// read, overwrite, or remove the value.
+    ///
+    /// # Differences from `std::collections::BTreeMap::entry`
+    ///
+    /// The standard library's `or_insert` returns `&mut V`, giving a direct reference into the
+    /// map. Because values live in stable memory, long-lived references are not possible here.
+    /// Instead, `or_insert` (and its variants) return an [`OccupiedEntry`](entry::OccupiedEntry),
+    /// which lets you continue operating on the entry without a second key lookup.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ic_stable_structures::{BTreeMap, DefaultMemoryImpl};
+    ///
+    /// let mut map: BTreeMap<u32, u32, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    ///
+    /// // Insert a default value when the key is absent, then read it back.
+    /// let val = map.entry(1).or_insert(0).get();
+    /// assert_eq!(val, 0);
+    ///
+    /// // Increment a counter, seeding it to 1 when first seen.
+    /// for key in [1, 1, 2, 3, 1] {
+    ///     map.entry(key).and_modify(|v| *v += 1).or_insert(1);
+    /// }
+    /// assert_eq!(map.get(&1), Some(3));
+    /// assert_eq!(map.get(&2), Some(1));
+    /// assert_eq!(map.get(&3), Some(1));
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// - [`entry::Entry`] — the type returned by this method
+    /// - [`entry::OccupiedEntry`] — methods available when the key is present
+    /// - [`entry::VacantEntry`] — methods available when the key is absent
     pub fn entry(&mut self, key: K) -> entry::Entry<K, V, M> {
         // For an empty map the key is trivially absent.  Avoid calling
         // `find_node_for_insert` here because that eagerly allocates a root

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -739,12 +739,18 @@ where
             return entry::Entry::Vacant(entry::VacantEntry {
                 map: self,
                 key,
-                location: None,
+                slot: None,
             });
         }
 
-        // Load the root from memory.
-        let mut root = self.load_node(self.root_addr);
+        // Take the root from the node cache, or load it from memory. The node is handed
+        // to the returned entry, which reads and writes it without another load. It is
+        // not put back into the cache when the entry goes away: mutating an entry saves
+        // the node, and `save_node` invalidates the cache slot precisely because a
+        // just-saved node holds all of its keys and values materialized. An entry that
+        // is dropped without mutating therefore costs at most one cold cache slot,
+        // refilled by the next ordinary lookup.
+        let mut root = self.take_or_load_node(self.root_addr);
 
         // Check if the key already exists in the root.
         if let Ok(idx) = root.search(&key, self.memory()) {
@@ -752,34 +758,29 @@ where
             return entry::Entry::Occupied(entry::OccupiedEntry {
                 map: self,
                 key,
-                node: root,
-                idx,
+                slot: entry::NodeSlot::new(root, idx, 0),
             });
         }
 
         root = self.split_root_if_full(root);
 
-        let (key, node, search_result) =
-            self.find_node_for_insert(root, key, 0, |_, node, idx, key, key_exists| {
-                if key_exists {
-                    (key, node, Ok(idx))
-                } else {
-                    (key, node, Err(idx))
-                }
+        let (key, slot, key_exists) =
+            self.find_node_for_insert(root, key, 0, |_, node, idx, depth, key, key_exists| {
+                (key, entry::NodeSlot::new(node, idx, depth), key_exists)
             });
 
-        match search_result {
-            Ok(idx) => entry::Entry::Occupied(entry::OccupiedEntry {
+        if key_exists {
+            entry::Entry::Occupied(entry::OccupiedEntry {
                 map: self,
                 key,
-                node,
-                idx,
-            }),
-            Err(idx) => entry::Entry::Vacant(entry::VacantEntry {
+                slot,
+            })
+        } else {
+            entry::Entry::Vacant(entry::VacantEntry {
                 map: self,
                 key,
-                location: Some((node, idx)),
-            }),
+                slot: Some(slot),
+            })
         }
     }
 
@@ -817,11 +818,15 @@ where
     /// * `map`        — mutable access to the map (for saving nodes, updating length, etc.)
     /// * `node`       — the target node
     /// * `idx`        — the relevant slot index within `node`
+    /// * `depth`      — the depth of `node` (distance from the root)
     /// * `key`        — the key being inserted
     /// * `key_exists` — `true` if `key` is already present at `idx`; `false` if `idx` is
     ///                  the position where `key` should be inserted
     ///
     /// The callback's return value is propagated back to the caller.
+    ///
+    /// Unmodified nodes along the traversal path are returned to the node cache. The
+    /// target node is not: ownership passes to `callback`, which is responsible for it.
     ///
     /// PRECONDITION: `node` is not full.
     fn find_node_for_insert<R>(
@@ -829,7 +834,7 @@ where
         mut node: Node<K>,
         key: K,
         depth: u8,
-        callback: impl FnOnce(&mut Self, Node<K>, usize, K, bool) -> R,
+        callback: impl FnOnce(&mut Self, Node<K>, usize, u8, K, bool) -> R,
     ) -> R {
         // We're guaranteed by the caller that the provided node is not full.
         assert!(!node.is_full());
@@ -838,7 +843,7 @@ where
         match node.search(&key, self.memory()) {
             Ok(idx) => {
                 // Key found.
-                callback(self, node, idx, key, true)
+                callback(self, node, idx, depth, key, true)
             }
             Err(idx) => {
                 // The key isn't in the node. `idx` is where that key should be inserted.
@@ -846,7 +851,7 @@ where
                 match node.node_type() {
                     NodeType::Leaf => {
                         // The node is a non-full leaf.
-                        callback(self, node, idx, key, false)
+                        callback(self, node, idx, depth, key, false)
                     }
                     NodeType::Internal => {
                         // The node is an internal node.
@@ -859,7 +864,7 @@ where
                             if let Ok(idx) = child.search(&key, self.memory()) {
                                 // Key found. The parent node is unmodified — return it to cache.
                                 self.return_node(node, depth);
-                                return callback(self, child, idx, key, true);
+                                return callback(self, child, idx, child_depth, key, true);
                             }
 
                             // The child is full. Split the child.

--- a/src/btreemap.rs
+++ b/src/btreemap.rs
@@ -704,6 +704,19 @@ where
     /// Instead, `or_insert` (and its variants) return an [`OccupiedEntry`](entry::OccupiedEntry),
     /// which lets you continue operating on the entry without a second key lookup.
     ///
+    /// # This method writes to stable memory
+    ///
+    /// Unlike [`get`](Self::get) and [`contains_key`](Self::contains_key), `entry` **writes**.
+    /// So that a later insert can complete in a single pass, it splits every full node on the
+    /// path down from the root, which allocates nodes and rewrites the header — even when
+    /// `key` turns out to be present, and even if the returned entry is dropped without
+    /// inserting anything.
+    ///
+    /// The cost is bounded and self-limiting: each node splits at most once, and that split
+    /// would have happened on the next insert through the same path regardless. Repeating the
+    /// same probes allocates nothing further. Still, prefer [`get`](Self::get) or
+    /// [`contains_key`](Self::contains_key) when you only mean to read.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -729,6 +742,8 @@ where
     /// - [`entry::Entry`] — the type returned by this method
     /// - [`entry::OccupiedEntry`] — methods available when the key is present
     /// - [`entry::VacantEntry`] — methods available when the key is absent
+    #[must_use = "`entry` writes to stable memory even when its result is unused; \
+                  for a read-only lookup use `get` or `contains_key`"]
     pub fn entry(&mut self, key: K) -> entry::Entry<K, V, M> {
         // For an empty map the key is trivially absent.  Avoid calling
         // `find_node_for_insert` here because that eagerly allocates a root
@@ -747,9 +762,10 @@ where
         // to the returned entry, which reads and writes it without another load. It is
         // not put back into the cache when the entry goes away: mutating an entry saves
         // the node, and `save_node` invalidates the cache slot precisely because a
-        // just-saved node holds all of its keys and values materialized. An entry that
-        // is dropped without mutating therefore costs at most one cold cache slot,
-        // refilled by the next ordinary lookup.
+        // just-saved node holds all of its keys and values materialized. In *node cache*
+        // terms an entry dropped without mutating therefore costs at most one cold slot,
+        // refilled by the next ordinary lookup. That is not the whole cost of a dropped
+        // entry though — see the "This method writes to stable memory" section above.
         let mut root = self.take_or_load_node(self.root_addr);
 
         // Check if the key already exists in the root.
@@ -828,6 +844,11 @@ where
     /// Unmodified nodes along the traversal path are returned to the node cache. The
     /// target node is not: ownership passes to `callback`, which is responsible for it.
     ///
+    /// NOTE: this is the same descent as [`BTreeMap::insert_nonfull`], which stops at the
+    /// target node instead of inserting into it. The two were deliberately left separate:
+    /// expressing `insert` in terms of this callback form benchmarked slower. Keep the
+    /// split and descent logic in the two in sync.
+    ///
     /// PRECONDITION: `node` is not full.
     fn find_node_for_insert<R>(
         &mut self,
@@ -873,7 +894,16 @@ where
 
                             // The children have now changed. Search again for
                             // the child where we need to store the entry in.
-                            let idx = node.search(&key, self.memory()).unwrap_or_else(|idx| idx);
+                            // The median promoted by the split came out of `child`, which
+                            // was just shown not to contain `key`, so the search cannot
+                            // find it here; `Ok` would mean descending past a matching key
+                            // and inserting a duplicate.
+                            let search_result = node.search(&key, self.memory());
+                            debug_assert!(
+                                search_result.is_err(),
+                                "promoted median cannot equal the key"
+                            );
+                            let idx = search_result.unwrap_or_else(|idx| idx);
                             child = self.load_node(node.child(idx));
                         } else {
                             // Happy path: child is not full. The current node
@@ -892,6 +922,9 @@ where
     }
 
     /// Inserts an entry into a node that is *not full*.
+    ///
+    /// NOTE: shares its descent and node-splitting logic with
+    /// [`BTreeMap::find_node_for_insert`]; keep the two in sync.
     fn insert_nonfull(
         &mut self,
         mut node: Node<K>,

--- a/src/btreemap/entry.rs
+++ b/src/btreemap/entry.rs
@@ -68,9 +68,9 @@ pub struct OccupiedEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M
 }
 
 /// A value returned by [`OccupiedEntry::insert`] or [`OccupiedEntry::remove`] that has not
-/// yet been deserialised.
+/// yet been deserialized.
 ///
-/// Deserialisation is deferred so that callers who do not need the previous value pay no
+/// Deserialization is deferred so that callers who do not need the previous value pay no
 /// decode cost. Call [`into_value`](LazyValue::into_value) to obtain the concrete `T`.
 ///
 /// # Examples
@@ -82,12 +82,12 @@ pub struct OccupiedEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M
 /// map.insert(1, 10);
 ///
 /// if let Entry::Occupied(e) = map.entry(1) {
-///     // Discard the old value without deserialising it.
+///     // Discard the old value without deserializing it.
 ///     let _old: _ = e.insert(99);
 /// }
 ///
 /// if let Entry::Occupied(e) = map.entry(1) {
-///     // Deserialise only when the value is actually needed.
+///     // Deserialize only when the value is actually needed.
 ///     let old_value = e.insert(0).into_value();
 ///     assert_eq!(old_value, 99);
 /// }
@@ -312,7 +312,7 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     }
 
     /// Replaces the current value with `value` and returns the previous value as a
-    /// [`LazyValue`], which is only deserialised if you call [`LazyValue::into_value`].
+    /// [`LazyValue`], which is only deserialized if you call [`LazyValue::into_value`].
     ///
     /// # Examples
     ///
@@ -336,7 +336,7 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     }
 
     /// Removes the entry from the map and returns the stored value as a [`LazyValue`], which
-    /// is only deserialised if you call [`LazyValue::into_value`].
+    /// is only deserialized if you call [`LazyValue::into_value`].
     ///
     /// # Examples
     ///
@@ -379,7 +379,7 @@ impl<T: Storable> LazyValue<T> {
         }
     }
 
-    /// Deserialises and returns the value.
+    /// Deserializes and returns the value.
     pub fn into_value(self) -> T {
         T::from_bytes(Cow::Owned(self.bytes))
     }

--- a/src/btreemap/entry.rs
+++ b/src/btreemap/entry.rs
@@ -67,6 +67,31 @@ pub struct OccupiedEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M
     pub(crate) idx: usize,
 }
 
+/// A value returned by [`OccupiedEntry::insert`] or [`OccupiedEntry::remove`] that has not
+/// yet been deserialised.
+///
+/// Deserialisation is deferred so that callers who do not need the previous value pay no
+/// decode cost. Call [`into_value`](LazyValue::into_value) to obtain the concrete `T`.
+///
+/// # Examples
+///
+/// ```rust
+/// use ic_stable_structures::{BTreeMap, DefaultMemoryImpl, btreemap::entry::Entry};
+///
+/// let mut map: BTreeMap<u32, u32, _> = BTreeMap::new(DefaultMemoryImpl::default());
+/// map.insert(1, 10);
+///
+/// if let Entry::Occupied(e) = map.entry(1) {
+///     // Discard the old value without deserialising it.
+///     let _old: _ = e.insert(99);
+/// }
+///
+/// if let Entry::Occupied(e) = map.entry(1) {
+///     // Deserialise only when the value is actually needed.
+///     let old_value = e.insert(0).into_value();
+///     assert_eq!(old_value, 99);
+/// }
+/// ```
 pub struct LazyValue<T: Storable> {
     bytes: Vec<u8>,
     phantom_data: PhantomData<T>,
@@ -286,7 +311,8 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
         self
     }
 
-    /// Replaces the current value with `value` and returns the previous value.
+    /// Replaces the current value with `value` and returns the previous value as a
+    /// [`LazyValue`], which is only deserialised if you call [`LazyValue::into_value`].
     ///
     /// # Examples
     ///
@@ -297,7 +323,7 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     /// map.insert(1, 10);
     ///
     /// if let Entry::Occupied(e) = map.entry(1) {
-    ///     let old = e.insert(99);
+    ///     let old = e.insert(99).into_value();
     ///     assert_eq!(old, 10);
     /// }
     /// assert_eq!(map.get(&1), Some(99));
@@ -309,7 +335,8 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
         LazyValue::new(old_bytes)
     }
 
-    /// Removes the entry from the map and returns the value that was stored.
+    /// Removes the entry from the map and returns the stored value as a [`LazyValue`], which
+    /// is only deserialised if you call [`LazyValue::into_value`].
     ///
     /// # Examples
     ///
@@ -320,7 +347,7 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     /// map.insert(1, 42);
     ///
     /// if let Entry::Occupied(e) = map.entry(1) {
-    ///     assert_eq!(e.remove(), 42);
+    ///     assert_eq!(e.remove().into_value(), 42);
     /// }
     /// assert!(map.is_empty());
     /// ```
@@ -345,13 +372,14 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
 }
 
 impl<T: Storable> LazyValue<T> {
-    pub fn new(bytes: Vec<u8>) -> Self {
+    pub(crate) fn new(bytes: Vec<u8>) -> Self {
         LazyValue {
             bytes,
             phantom_data: PhantomData,
         }
     }
 
+    /// Deserialises and returns the value.
     pub fn into_value(self) -> T {
         T::from_bytes(Cow::Owned(self.bytes))
     }

--- a/src/btreemap/entry.rs
+++ b/src/btreemap/entry.rs
@@ -30,6 +30,7 @@
 use crate::btreemap::node::{Node, NodeType};
 use crate::{BTreeMap, Memory, Storable};
 use std::borrow::Cow;
+use std::marker::PhantomData;
 
 /// A view into a single entry of a [`BTreeMap`], which may either be occupied or vacant.
 ///
@@ -64,6 +65,11 @@ pub struct OccupiedEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M
     pub(crate) key: K,
     pub(crate) node: Node<K>,
     pub(crate) idx: usize,
+}
+
+pub struct LazyValue<T: Storable> {
+    bytes: Vec<u8>,
+    phantom_data: PhantomData<T>,
 }
 
 impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> Entry<'a, K, V, M> {
@@ -133,10 +139,7 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> Entry<'a, 
     /// map.entry(7).or_insert_with_key(|&k| k * 2);
     /// assert_eq!(map.get(&7), Some(14));
     /// ```
-    pub fn or_insert_with_key(
-        self,
-        default: impl FnOnce(&K) -> V,
-    ) -> OccupiedEntry<'a, K, V, M> {
+    pub fn or_insert_with_key(self, default: impl FnOnce(&K) -> V) -> OccupiedEntry<'a, K, V, M> {
         match self {
             Entry::Occupied(entry) => entry,
             Entry::Vacant(entry) => {
@@ -229,7 +232,12 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> VacantEntr
                 map.insert(key.clone(), value);
                 let (node, result) = map.find_node_for_insert(&key);
                 let idx = result.expect("key was just inserted");
-                OccupiedEntry { map, key, node, idx }
+                OccupiedEntry {
+                    map,
+                    key,
+                    node,
+                    idx,
+                }
             }
         }
     }
@@ -294,11 +302,11 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     /// }
     /// assert_eq!(map.get(&1), Some(99));
     /// ```
-    pub fn insert(mut self, value: V) -> V {
+    pub fn insert(mut self, value: V) -> LazyValue<V> {
         let old_bytes = self
             .map
             .update_value(&mut self.node, self.idx, value.into_bytes_checked());
-        V::from_bytes(Cow::Owned(old_bytes))
+        LazyValue::new(old_bytes)
     }
 
     /// Removes the entry from the map and returns the value that was stored.
@@ -316,13 +324,13 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     /// }
     /// assert!(map.is_empty());
     /// ```
-    pub fn remove(self) -> V {
+    pub fn remove(self) -> LazyValue<V> {
         let bytes = match self.node.node_type() {
             NodeType::Leaf if self.node.can_remove_entry_without_merging() => {
                 self.map.remove_from_leaf_node(self.node, self.idx)
             }
             NodeType::Leaf => {
-                // TODO: avoid this slow path by walking the tree upward from the leaf.
+                // TODO: avoid this slow path
                 let root = self.map.load_node(self.map.root_addr);
                 self.map
                     .remove_helper(root, &self.key)
@@ -332,7 +340,20 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
                 .map
                 .remove_from_internal_node(self.node, self.idx, &self.key),
         };
-        V::from_bytes(Cow::Owned(bytes))
+        LazyValue::new(bytes)
+    }
+}
+
+impl<T: Storable> LazyValue<T> {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        LazyValue {
+            bytes,
+            phantom_data: PhantomData,
+        }
+    }
+
+    pub fn into_value(self) -> T {
+        T::from_bytes(Cow::Owned(self.bytes))
     }
 }
 
@@ -362,7 +383,7 @@ mod tests {
                 panic!();
             };
             assert_eq!(i, e.get());
-            let old = e.insert(i + 1);
+            let old = e.insert(i + 1).into_value();
             assert_eq!(old, i);
         }
 
@@ -371,7 +392,7 @@ mod tests {
                 panic!();
             };
             assert_eq!(i + 1, e.get());
-            let removed = e.remove();
+            let removed = e.remove().into_value();
             assert_eq!(removed, i + 1);
         }
 
@@ -452,7 +473,7 @@ mod tests {
         let Entry::Occupied(e) = map.entry(1) else {
             panic!();
         };
-        assert_eq!(e.insert(99), 10);
+        assert_eq!(e.insert(99).into_value(), 10);
         assert_eq!(map.get(&1), Some(99));
     }
 
@@ -463,7 +484,7 @@ mod tests {
         let Entry::Occupied(e) = map.entry(1) else {
             panic!();
         };
-        assert_eq!(e.remove(), 42);
+        assert_eq!(e.remove().into_value(), 42);
         assert!(map.is_empty());
     }
 

--- a/src/btreemap/entry.rs
+++ b/src/btreemap/entry.rs
@@ -251,17 +251,17 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> VacantEntr
             }
             None => {
                 // The map was empty when `entry()` was called. Delegate to the regular
-                // insert path which handles root allocation, then find the new entry.
+                // insert path which handles root allocation, then set the node and idx of the
+                // new `OccupiedEntry` to the root node and index 0.
                 let map = self.map;
                 let key = self.key;
                 map.insert(key.clone(), value);
-                let (node, result) = map.find_node_for_insert(&key);
-                let idx = result.expect("key was just inserted");
+                let node = map.load_node(map.root_addr);
                 OccupiedEntry {
                     map,
                     key,
                     node,
-                    idx,
+                    idx: 0,
                 }
             }
         }

--- a/src/btreemap/entry.rs
+++ b/src/btreemap/entry.rs
@@ -76,18 +76,20 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     }
 
     pub fn remove(self) {
-        if self.node.can_remove_entry_without_merging() {
-            match self.node.node_type() {
-                NodeType::Leaf => self.map.remove_from_leaf_node(self.node, self.idx),
-                NodeType::Internal => self
-                    .map
-                    .remove_from_internal_node(self.node, self.idx, &self.key),
-            };
-        } else {
-            // TODO avoid using this slow path
-            let root = self.map.load_node(self.map.root_addr);
-            self.map.remove_helper(root, &self.key);
-        }
+        match self.node.node_type() {
+            NodeType::Leaf if self.node.can_remove_entry_without_merging() => {
+                self.map.remove_from_leaf_node(self.node, self.idx);
+            }
+            NodeType::Leaf => {
+                // TODO avoid using this slow path
+                let root = self.map.load_node(self.map.root_addr);
+                self.map.remove_helper(root, &self.key);
+            }
+            NodeType::Internal => {
+                self.map
+                    .remove_from_internal_node(self.node, self.idx, &self.key);
+            }
+        };
     }
 }
 

--- a/src/btreemap/entry.rs
+++ b/src/btreemap/entry.rs
@@ -1,6 +1,6 @@
 use crate::btreemap::node::{Node, NodeType};
 use crate::{BTreeMap, Memory, Storable};
-use std::borrow::Cow;
+use std::cell::Cell;
 
 pub enum Entry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> {
     Vacant(VacantEntry<'a, K, V, M>),
@@ -19,6 +19,7 @@ pub struct OccupiedEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M
     pub(crate) key: K,
     pub(crate) node: Node<K>,
     pub(crate) idx: usize,
+    pub(crate) cached_value: Cell<Option<V>>,
 }
 
 impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> Entry<'a, K, V, M> {
@@ -35,6 +36,37 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> Entry<'a, 
             Entry::Vacant(entry) => entry.into_key(),
         }
     }
+
+    pub fn and_modify(self, f: impl FnOnce(&mut V)) -> Self {
+        match self {
+            Entry::Occupied(entry) => Entry::Occupied(entry.and_modify(f)),
+            Entry::Vacant(entry) => Entry::Vacant(entry),
+        }
+    }
+
+    pub fn or_insert(self, default: V) -> OccupiedEntry<'a, K, V, M> {
+        match self {
+            Entry::Occupied(entry) => entry,
+            Entry::Vacant(entry) => entry.insert(default),
+        }
+    }
+
+    pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> OccupiedEntry<'a, K, V, M> {
+        match self {
+            Entry::Occupied(entry) => entry,
+            Entry::Vacant(entry) => entry.insert(default()),
+        }
+    }
+
+    pub fn or_default(self) -> OccupiedEntry<'a, K, V, M>
+    where
+        V: Default,
+    {
+        match self {
+            Entry::Occupied(entry) => entry,
+            Entry::Vacant(entry) => entry.insert(Default::default()),
+        }
+    }
 }
 
 impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> VacantEntry<'a, K, V, M> {
@@ -46,13 +78,23 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> VacantEntr
         self.key
     }
 
-    pub fn insert(mut self, value: V) {
-        self.node
-            .insert_entry(self.idx, (self.key, value.into_bytes_checked()));
+    pub fn insert(mut self, value: V) -> OccupiedEntry<'a, K, V, M> {
+        self.node.insert_entry(
+            self.idx,
+            (self.key.clone(), value.to_bytes_checked().into_owned()),
+        );
 
         self.map.save_node(&mut self.node);
         self.map.length += 1;
         self.map.save_header();
+
+        OccupiedEntry {
+            map: self.map,
+            key: self.key,
+            node: self.node,
+            idx: self.idx,
+            cached_value: Cell::new(Some(value)),
+        }
     }
 }
 
@@ -66,8 +108,22 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     }
 
     pub fn get(&self) -> V {
-        let value_bytes = self.node.value(self.idx, self.map.memory());
-        V::from_bytes(Cow::Borrowed(value_bytes))
+        if let Some(cached) = self.cached_value.take() {
+            cached
+        } else {
+            self.get()
+        }
+    }
+
+    pub fn and_modify(mut self, f: impl FnOnce(&mut V)) -> Self {
+        let mut value = self.get();
+        f(&mut value);
+        self.map.update_value(
+            &mut self.node,
+            self.idx,
+            value.to_bytes_checked().into_owned(),
+        );
+        self
     }
 
     pub fn insert(mut self, value: V) {

--- a/src/btreemap/entry.rs
+++ b/src/btreemap/entry.rs
@@ -1,28 +1,73 @@
+//! Entry API for [`BTreeMap`].
+//!
+//! This module provides the [`Entry`] type, which gives efficient in-place access to a map's
+//! entries, allowing inspection or modification without redundant key lookups. The API mirrors
+//! [`std::collections::btree_map::Entry`] as closely as the stable-memory model allows.
+//!
+//! # Note on `or_insert` return type
+//!
+//! The standard library's `or_insert` returns `&mut V`, giving a direct reference into the
+//! map. Because values in this [`BTreeMap`] live in stable memory, long-lived references are
+//! not possible. Instead, `or_insert` (and its variants) return an [`OccupiedEntry`], which
+//! lets you continue reading or modifying the entry without a second key lookup.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use ic_stable_structures::{BTreeMap, DefaultMemoryImpl};
+//!
+//! let mut map: BTreeMap<u32, u32, _> = BTreeMap::new(DefaultMemoryImpl::default());
+//!
+//! // Insert a value only when the key is absent.
+//! map.entry(1).or_insert(42);
+//! assert_eq!(map.get(&1), Some(42));
+//!
+//! // Increment a counter, seeding it to 1 if absent.
+//! map.entry(1).and_modify(|v| *v += 1).or_insert(1);
+//! assert_eq!(map.get(&1), Some(43));
+//! ```
+
 use crate::btreemap::node::{Node, NodeType};
 use crate::{BTreeMap, Memory, Storable};
-use std::cell::Cell;
+use std::borrow::Cow;
 
+/// A view into a single entry of a [`BTreeMap`], which may either be occupied or vacant.
+///
+/// This type is returned by [`BTreeMap::entry`].
 pub enum Entry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> {
+    /// A vacant entry: the key is not present in the map.
     Vacant(VacantEntry<'a, K, V, M>),
+    /// An occupied entry: the key is already present in the map.
     Occupied(OccupiedEntry<'a, K, V, M>),
 }
 
+/// A view into a vacant entry in a [`BTreeMap`].
+///
+/// Obtained from [`Entry::Vacant`].
 pub struct VacantEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> {
     pub(crate) map: &'a mut BTreeMap<K, V, M>,
     pub(crate) key: K,
-    pub(crate) node: Node<K>,
-    pub(crate) idx: usize,
+    /// Pre-computed insertion point from [`BTreeMap::entry`].
+    ///
+    /// `None` when the map was empty at the time `entry` was called — the root
+    /// node had not yet been allocated, so we defer the full insert to
+    /// [`VacantEntry::insert`] to avoid corrupting the map if this entry is
+    /// dropped without inserting.
+    pub(crate) location: Option<(Node<K>, usize)>,
 }
 
+/// A view into an occupied entry in a [`BTreeMap`].
+///
+/// Obtained from [`Entry::Occupied`] or as the result of [`VacantEntry::insert`].
 pub struct OccupiedEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> {
     pub(crate) map: &'a mut BTreeMap<K, V, M>,
     pub(crate) key: K,
     pub(crate) node: Node<K>,
     pub(crate) idx: usize,
-    pub(crate) cached_value: Cell<Option<V>>,
 }
 
 impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> Entry<'a, K, V, M> {
+    /// Returns a reference to this entry's key.
     pub fn key(&self) -> &K {
         match self {
             Entry::Occupied(entry) => entry.key(),
@@ -30,6 +75,7 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> Entry<'a, 
         }
     }
 
+    /// Consumes the entry and returns its key.
     pub fn into_key(self) -> K {
         match self {
             Entry::Occupied(entry) => entry.into_key(),
@@ -37,13 +83,18 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> Entry<'a, 
         }
     }
 
-    pub fn and_modify(self, f: impl FnOnce(&mut V)) -> Self {
-        match self {
-            Entry::Occupied(entry) => Entry::Occupied(entry.and_modify(f)),
-            Entry::Vacant(entry) => Entry::Vacant(entry),
-        }
-    }
-
+    /// Ensures a value is present by inserting `default` if the entry is vacant, then returns
+    /// an [`OccupiedEntry`] for further operations.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ic_stable_structures::{BTreeMap, DefaultMemoryImpl};
+    ///
+    /// let mut map: BTreeMap<u32, u32, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    /// assert_eq!(map.entry(1).or_insert(10).get(), 10);
+    /// assert_eq!(map.entry(1).or_insert(99).get(), 10); // already present
+    /// ```
     pub fn or_insert(self, default: V) -> OccupiedEntry<'a, K, V, M> {
         match self {
             Entry::Occupied(entry) => entry,
@@ -51,101 +102,237 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> Entry<'a, 
         }
     }
 
-    pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> OccupiedEntry<'a, K, V, M> {
+    /// Ensures a value is present by inserting the result of `default` if the entry is vacant,
+    /// then returns an [`OccupiedEntry`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ic_stable_structures::{BTreeMap, DefaultMemoryImpl};
+    ///
+    /// let mut map: BTreeMap<u32, u32, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    /// map.entry(1).or_insert_with(|| 42u32);
+    /// assert_eq!(map.get(&1), Some(42));
+    /// ```
+    pub fn or_insert_with(self, default: impl FnOnce() -> V) -> OccupiedEntry<'a, K, V, M> {
         match self {
             Entry::Occupied(entry) => entry,
             Entry::Vacant(entry) => entry.insert(default()),
         }
     }
 
+    /// Ensures a value is present by inserting the result of `default`, called with the
+    /// entry's key, if the entry is vacant. Returns an [`OccupiedEntry`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ic_stable_structures::{BTreeMap, DefaultMemoryImpl};
+    ///
+    /// let mut map: BTreeMap<u32, u32, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    /// map.entry(7).or_insert_with_key(|&k| k * 2);
+    /// assert_eq!(map.get(&7), Some(14));
+    /// ```
+    pub fn or_insert_with_key(
+        self,
+        default: impl FnOnce(&K) -> V,
+    ) -> OccupiedEntry<'a, K, V, M> {
+        match self {
+            Entry::Occupied(entry) => entry,
+            Entry::Vacant(entry) => {
+                let val = default(&entry.key);
+                entry.insert(val)
+            }
+        }
+    }
+
+    /// Ensures a value is present by inserting `V::default()` if the entry is vacant, then
+    /// returns an [`OccupiedEntry`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ic_stable_structures::{BTreeMap, DefaultMemoryImpl};
+    ///
+    /// let mut map: BTreeMap<u32, u32, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    /// map.entry(1).or_default();
+    /// assert_eq!(map.get(&1), Some(0u32));
+    /// ```
     pub fn or_default(self) -> OccupiedEntry<'a, K, V, M>
     where
         V: Default,
     {
+        self.or_insert_with(V::default)
+    }
+
+    /// Provides in-place mutable access to an occupied entry before any potential inserts
+    /// via `or_insert` and friends.
+    ///
+    /// If the entry is vacant the closure is not called and the entry is returned unchanged,
+    /// making it possible to chain with `or_insert` and friends.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ic_stable_structures::{BTreeMap, DefaultMemoryImpl};
+    ///
+    /// let mut map: BTreeMap<u32, u32, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    /// map.insert(1, 10);
+    ///
+    /// // Increment existing value, or seed with 1 for a new key.
+    /// map.entry(1).and_modify(|v| *v += 1).or_insert(1);
+    /// assert_eq!(map.get(&1), Some(11));
+    ///
+    /// map.entry(2).and_modify(|v| *v += 1).or_insert(1);
+    /// assert_eq!(map.get(&2), Some(1));
+    /// ```
+    pub fn and_modify(self, f: impl FnOnce(&mut V)) -> Self {
         match self {
-            Entry::Occupied(entry) => entry,
-            Entry::Vacant(entry) => entry.insert(Default::default()),
+            Entry::Occupied(entry) => Entry::Occupied(entry.and_modify(f)),
+            Entry::Vacant(entry) => Entry::Vacant(entry),
         }
     }
 }
 
 impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> VacantEntry<'a, K, V, M> {
+    /// Returns a reference to the entry's key.
     pub fn key(&self) -> &K {
         &self.key
     }
 
+    /// Consumes the entry and returns its key.
     pub fn into_key(self) -> K {
         self.key
     }
 
-    pub fn insert(mut self, value: V) -> OccupiedEntry<'a, K, V, M> {
-        self.node.insert_entry(
-            self.idx,
-            (self.key.clone(), value.to_bytes_checked().into_owned()),
-        );
-
-        self.map.save_node(&mut self.node);
-        self.map.length += 1;
-        self.map.save_header();
-
-        OccupiedEntry {
-            map: self.map,
-            key: self.key,
-            node: self.node,
-            idx: self.idx,
-            cached_value: Cell::new(Some(value)),
+    /// Inserts `value` into the map at this entry's key and returns an [`OccupiedEntry`]
+    /// pointing at the newly inserted value.
+    pub fn insert(self, value: V) -> OccupiedEntry<'a, K, V, M> {
+        match self.location {
+            Some((mut node, idx)) => {
+                node.insert_entry(idx, (self.key.clone(), value.into_bytes_checked()));
+                self.map.save_node(&mut node);
+                self.map.length += 1;
+                self.map.save_header();
+                OccupiedEntry {
+                    map: self.map,
+                    key: self.key,
+                    node,
+                    idx,
+                }
+            }
+            None => {
+                // The map was empty when `entry()` was called. Delegate to the regular
+                // insert path which handles root allocation, then find the new entry.
+                let map = self.map;
+                let key = self.key;
+                map.insert(key.clone(), value);
+                let (node, result) = map.find_node_for_insert(&key);
+                let idx = result.expect("key was just inserted");
+                OccupiedEntry { map, key, node, idx }
+            }
         }
     }
 }
 
 impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEntry<'a, K, V, M> {
+    /// Returns a reference to the entry's key.
     pub fn key(&self) -> &K {
         &self.key
     }
 
+    /// Consumes the entry and returns its key.
     pub fn into_key(self) -> K {
         self.key
     }
 
+    /// Returns the current value associated with this entry.
     pub fn get(&self) -> V {
-        if let Some(cached) = self.cached_value.take() {
-            cached
-        } else {
-            self.get()
-        }
+        let value_bytes = self.node.value(self.idx, self.map.memory());
+        V::from_bytes(Cow::Borrowed(value_bytes))
     }
 
+    /// Provides in-place mutable access to the value in this occupied entry.
+    ///
+    /// Reads the current value, calls `f` with a mutable reference to it, then writes the
+    /// modified value back. Returns `self` so the call can be chained.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ic_stable_structures::{BTreeMap, DefaultMemoryImpl, btreemap::entry::Entry};
+    ///
+    /// let mut map: BTreeMap<u32, u32, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    /// map.insert(1, 10);
+    ///
+    /// if let Entry::Occupied(e) = map.entry(1) {
+    ///     e.and_modify(|v| *v *= 2);
+    /// }
+    /// assert_eq!(map.get(&1), Some(20));
+    /// ```
     pub fn and_modify(mut self, f: impl FnOnce(&mut V)) -> Self {
         let mut value = self.get();
         f(&mut value);
-        self.map.update_value(
-            &mut self.node,
-            self.idx,
-            value.to_bytes_checked().into_owned(),
-        );
+        self.map
+            .update_value(&mut self.node, self.idx, value.into_bytes_checked());
         self
     }
 
-    pub fn insert(mut self, value: V) {
-        self.map
+    /// Replaces the current value with `value` and returns the previous value.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ic_stable_structures::{BTreeMap, DefaultMemoryImpl, btreemap::entry::Entry};
+    ///
+    /// let mut map: BTreeMap<u32, u32, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    /// map.insert(1, 10);
+    ///
+    /// if let Entry::Occupied(e) = map.entry(1) {
+    ///     let old = e.insert(99);
+    ///     assert_eq!(old, 10);
+    /// }
+    /// assert_eq!(map.get(&1), Some(99));
+    /// ```
+    pub fn insert(mut self, value: V) -> V {
+        let old_bytes = self
+            .map
             .update_value(&mut self.node, self.idx, value.into_bytes_checked());
+        V::from_bytes(Cow::Owned(old_bytes))
     }
 
-    pub fn remove(self) {
-        match self.node.node_type() {
+    /// Removes the entry from the map and returns the value that was stored.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ic_stable_structures::{BTreeMap, DefaultMemoryImpl, btreemap::entry::Entry};
+    ///
+    /// let mut map: BTreeMap<u32, u32, _> = BTreeMap::new(DefaultMemoryImpl::default());
+    /// map.insert(1, 42);
+    ///
+    /// if let Entry::Occupied(e) = map.entry(1) {
+    ///     assert_eq!(e.remove(), 42);
+    /// }
+    /// assert!(map.is_empty());
+    /// ```
+    pub fn remove(self) -> V {
+        let bytes = match self.node.node_type() {
             NodeType::Leaf if self.node.can_remove_entry_without_merging() => {
-                self.map.remove_from_leaf_node(self.node, self.idx);
+                self.map.remove_from_leaf_node(self.node, self.idx)
             }
             NodeType::Leaf => {
-                // TODO avoid using this slow path
+                // TODO: avoid this slow path by walking the tree upward from the leaf.
                 let root = self.map.load_node(self.map.root_addr);
-                self.map.remove_helper(root, &self.key);
-            }
-            NodeType::Internal => {
                 self.map
-                    .remove_from_internal_node(self.node, self.idx, &self.key);
+                    .remove_helper(root, &self.key)
+                    .expect("key must exist")
             }
+            NodeType::Internal => self
+                .map
+                .remove_from_internal_node(self.node, self.idx, &self.key),
         };
+        V::from_bytes(Cow::Owned(bytes))
     }
 }
 
@@ -155,9 +342,13 @@ mod tests {
     use std::cell::RefCell;
     use std::rc::Rc;
 
+    fn new_map() -> BTreeMap<u32, u32, Rc<RefCell<Vec<u8>>>> {
+        BTreeMap::new(Rc::new(RefCell::new(Vec::new())))
+    }
+
     #[test]
     fn entry_end_to_end() {
-        let mut map = BTreeMap::new(Rc::new(RefCell::new(Vec::new())));
+        let mut map = new_map();
 
         for i in 0u32..100 {
             let Entry::Vacant(e) = map.entry(i) else {
@@ -171,7 +362,8 @@ mod tests {
                 panic!();
             };
             assert_eq!(i, e.get());
-            e.insert(i + 1);
+            let old = e.insert(i + 1);
+            assert_eq!(old, i);
         }
 
         for i in 0u32..100 {
@@ -179,9 +371,110 @@ mod tests {
                 panic!();
             };
             assert_eq!(i + 1, e.get());
-            e.remove();
+            let removed = e.remove();
+            assert_eq!(removed, i + 1);
         }
 
         assert!(map.is_empty());
+    }
+
+    #[test]
+    fn or_insert_vacant() {
+        let mut map = new_map();
+        assert_eq!(map.entry(1).or_insert(42).get(), 42);
+        assert_eq!(map.get(&1), Some(42));
+    }
+
+    #[test]
+    fn or_insert_occupied() {
+        let mut map = new_map();
+        map.insert(1, 10);
+        assert_eq!(map.entry(1).or_insert(99).get(), 10); // default ignored
+    }
+
+    #[test]
+    fn or_insert_with() {
+        let mut map = new_map();
+        map.entry(1).or_insert_with(|| 7u32);
+        assert_eq!(map.get(&1), Some(7));
+        // closure is not called when key is present
+        map.entry(1)
+            .or_insert_with(|| panic!("should not be called"));
+        assert_eq!(map.get(&1), Some(7));
+    }
+
+    #[test]
+    fn or_insert_with_key() {
+        let mut map = new_map();
+        map.entry(6).or_insert_with_key(|&k| k * 3);
+        assert_eq!(map.get(&6), Some(18));
+    }
+
+    #[test]
+    fn or_default() {
+        let mut map = new_map();
+        map.entry(1).or_default();
+        assert_eq!(map.get(&1), Some(0u32));
+    }
+
+    #[test]
+    fn and_modify_occupied() {
+        let mut map = new_map();
+        map.insert(1, 10);
+        map.entry(1).and_modify(|v| *v += 5);
+        assert_eq!(map.get(&1), Some(15));
+    }
+
+    #[test]
+    fn and_modify_vacant() {
+        let mut map = new_map();
+        // closure must not be called; map must stay empty
+        map.entry(1).and_modify(|_| panic!("should not be called"));
+        assert_eq!(map.get(&1), None);
+    }
+
+    #[test]
+    fn and_modify_then_or_insert() {
+        let mut map = new_map();
+        map.insert(1, 10u32);
+
+        map.entry(1).and_modify(|v| *v += 1).or_insert(1);
+        assert_eq!(map.get(&1), Some(11));
+
+        map.entry(2).and_modify(|v| *v += 1).or_insert(1);
+        assert_eq!(map.get(&2), Some(1));
+    }
+
+    #[test]
+    fn occupied_insert_returns_old_value() {
+        let mut map = new_map();
+        map.insert(1, 10);
+        let Entry::Occupied(e) = map.entry(1) else {
+            panic!();
+        };
+        assert_eq!(e.insert(99), 10);
+        assert_eq!(map.get(&1), Some(99));
+    }
+
+    #[test]
+    fn occupied_remove_returns_value() {
+        let mut map = new_map();
+        map.insert(1, 42);
+        let Entry::Occupied(e) = map.entry(1) else {
+            panic!();
+        };
+        assert_eq!(e.remove(), 42);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn or_insert_on_empty_map_then_drop() {
+        // Dropping a VacantEntry on an empty map without inserting must not corrupt the map.
+        let mut map = new_map();
+        map.entry(1).and_modify(|_| panic!("should not be called"));
+        assert_eq!(map.get(&1), None);
+        // The map must still be usable after the drop.
+        map.insert(1, 99);
+        assert_eq!(map.get(&1), Some(99));
     }
 }

--- a/src/btreemap/entry.rs
+++ b/src/btreemap/entry.rs
@@ -1,0 +1,129 @@
+use crate::btreemap::node::{Node, NodeType};
+use crate::{BTreeMap, Memory, Storable};
+use std::borrow::Cow;
+
+pub enum Entry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> {
+    Vacant(VacantEntry<'a, K, V, M>),
+    Occupied(OccupiedEntry<'a, K, V, M>),
+}
+
+pub struct VacantEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> {
+    pub(crate) map: &'a mut BTreeMap<K, V, M>,
+    pub(crate) key: K,
+    pub(crate) node: Node<K>,
+    pub(crate) idx: usize,
+}
+
+pub struct OccupiedEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> {
+    pub(crate) map: &'a mut BTreeMap<K, V, M>,
+    pub(crate) key: K,
+    pub(crate) node: Node<K>,
+    pub(crate) idx: usize,
+}
+
+impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> Entry<'a, K, V, M> {
+    pub fn key(&self) -> &K {
+        match self {
+            Entry::Occupied(entry) => entry.key(),
+            Entry::Vacant(entry) => entry.key(),
+        }
+    }
+
+    pub fn into_key(self) -> K {
+        match self {
+            Entry::Occupied(entry) => entry.into_key(),
+            Entry::Vacant(entry) => entry.into_key(),
+        }
+    }
+}
+
+impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> VacantEntry<'a, K, V, M> {
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+
+    pub fn into_key(self) -> K {
+        self.key
+    }
+
+    pub fn insert(mut self, value: V) {
+        self.node
+            .insert_entry(self.idx, (self.key, value.into_bytes_checked()));
+
+        self.map.save_node(&mut self.node);
+        self.map.length += 1;
+        self.map.save_header();
+    }
+}
+
+impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEntry<'a, K, V, M> {
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+
+    pub fn into_key(self) -> K {
+        self.key
+    }
+
+    pub fn get(&self) -> V {
+        let value_bytes = self.node.value(self.idx, self.map.memory());
+        V::from_bytes(Cow::Borrowed(value_bytes))
+    }
+
+    pub fn insert(mut self, value: V) {
+        self.map
+            .update_value(&mut self.node, self.idx, value.into_bytes_checked());
+    }
+
+    pub fn remove(self) {
+        if self.node.can_remove_entry_without_merging() {
+            match self.node.node_type() {
+                NodeType::Leaf => self.map.remove_from_leaf_node(self.node, self.idx),
+                NodeType::Internal => self
+                    .map
+                    .remove_from_internal_node(self.node, self.idx, &self.key),
+            };
+        } else {
+            // TODO avoid using this slow path
+            let root = self.map.load_node(self.map.root_addr);
+            self.map.remove_helper(root, &self.key);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[test]
+    fn entry_end_to_end() {
+        let mut map = BTreeMap::new(Rc::new(RefCell::new(Vec::new())));
+
+        for i in 0u32..100 {
+            let Entry::Vacant(e) = map.entry(i) else {
+                panic!();
+            };
+            e.insert(i);
+        }
+
+        for i in 0u32..100 {
+            let Entry::Occupied(e) = map.entry(i) else {
+                panic!();
+            };
+            assert_eq!(i, e.get());
+            e.insert(i + 1);
+        }
+
+        for i in 0u32..100 {
+            let Entry::Occupied(e) = map.entry(i) else {
+                panic!();
+            };
+            assert_eq!(i + 1, e.get());
+            e.remove();
+        }
+
+        assert!(map.is_empty());
+    }
+}

--- a/src/btreemap/entry.rs
+++ b/src/btreemap/entry.rs
@@ -282,14 +282,21 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> VacantEntr
 }
 
 impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEntry<'a, K, V, M> {
-    /// Returns a reference to the entry's key.
+    /// Returns a reference to the key stored in the map.
+    ///
+    /// As in the standard library, this is the key already held by the map, not the one
+    /// passed to [`BTreeMap::entry`]. The two compare equal, but they can differ in ways
+    /// `Ord` does not see — for example a `K` whose ordering ignores some of its fields.
     pub fn key(&self) -> &K {
-        &self.key
+        self.slot.node.key(self.slot.idx, self.map.memory())
     }
 
-    /// Consumes the entry and returns its key.
+    /// Consumes the entry and returns the key stored in the map.
+    ///
+    /// Like [`key`](Self::key), this is the map's own key rather than the one passed to
+    /// [`BTreeMap::entry`].
     pub fn into_key(self) -> K {
-        self.key
+        self.key().clone()
     }
 
     /// Returns the current value associated with this entry.
@@ -443,6 +450,77 @@ mod tests {
 
     fn new_map() -> BTreeMap<u32, u32, Rc<RefCell<Vec<u8>>>> {
         BTreeMap::new(Rc::new(RefCell::new(Vec::new())))
+    }
+
+    /// A key whose ordering ignores `tag`, so two keys can be `Ord`-equal while holding
+    /// different bytes. Used to tell the stored key apart from the one passed to `entry`.
+    #[derive(Clone, Debug)]
+    struct TaggedKey {
+        id: u32,
+        tag: u8,
+    }
+
+    impl PartialEq for TaggedKey {
+        fn eq(&self, other: &Self) -> bool {
+            self.id == other.id
+        }
+    }
+    impl Eq for TaggedKey {}
+    impl PartialOrd for TaggedKey {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+    impl Ord for TaggedKey {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            self.id.cmp(&other.id)
+        }
+    }
+    impl Storable for TaggedKey {
+        fn to_bytes(&self) -> Cow<'_, [u8]> {
+            let mut bytes = self.id.to_be_bytes().to_vec();
+            bytes.push(self.tag);
+            Cow::Owned(bytes)
+        }
+        fn into_bytes(self) -> Vec<u8> {
+            self.to_bytes().into_owned()
+        }
+        fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+            Self {
+                id: u32::from_be_bytes(bytes[0..4].try_into().unwrap()),
+                tag: bytes[4],
+            }
+        }
+        const BOUND: crate::storable::Bound = crate::storable::Bound::Bounded {
+            max_size: 5,
+            is_fixed_size: true,
+        };
+    }
+
+    /// `OccupiedEntry::key` must report the key held by the map, like the std lib does,
+    /// not the `Ord`-equal one that was passed to `entry`.
+    #[test]
+    fn occupied_entry_reports_the_stored_key() {
+        let mut map: BTreeMap<TaggedKey, u32, _> = BTreeMap::new(Rc::new(RefCell::new(Vec::new())));
+        map.insert(TaggedKey { id: 1, tag: 7 }, 100);
+
+        let Entry::Occupied(e) = map.entry(TaggedKey { id: 1, tag: 99 }) else {
+            panic!("key 1 is present");
+        };
+        assert_eq!(e.key().tag, 7, "`key` must return the stored key");
+        assert_eq!(e.into_key().tag, 7, "`into_key` must return the stored key");
+
+        // Overwriting the value must leave the stored key alone, also matching the std lib.
+        if let Entry::Occupied(e) = map.entry(TaggedKey { id: 1, tag: 42 }) {
+            e.insert(101);
+        }
+        assert_eq!(map.iter().next().unwrap().key().tag, 7);
+
+        // A vacant entry has no stored key, so it reports the one it was given.
+        let Entry::Vacant(e) = map.entry(TaggedKey { id: 2, tag: 55 }) else {
+            panic!("key 2 is absent");
+        };
+        assert_eq!(e.key().tag, 55);
     }
 
     #[test]

--- a/src/btreemap/entry.rs
+++ b/src/btreemap/entry.rs
@@ -11,6 +11,19 @@
 //! not possible. Instead, `or_insert` (and its variants) return an [`OccupiedEntry`], which
 //! lets you continue reading or modifying the entry without a second key lookup.
 //!
+//! For the same reason there is no equivalent of the standard library's `get_mut` or
+//! `into_mut`. Use [`OccupiedEntry::and_modify`], which reads the value, hands it to your
+//! closure, and writes it back.
+//!
+//! # `entry` writes to stable memory
+//!
+//! [`BTreeMap::entry`] splits full nodes on the way down so that a later insert can finish
+//! in one pass. It therefore writes — allocating nodes and rewriting the header — even for
+//! a key that turns out to be present, and even if the entry is dropped unused. The cost is
+//! bounded (each node splits at most once, and that split was coming on the next insert
+//! anyway), but prefer [`BTreeMap::get`] when you only mean to read. See
+//! [`BTreeMap::entry`] for details.
+//!
 //! # Examples
 //!
 //! ```rust
@@ -257,6 +270,13 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> VacantEntr
 
     /// Inserts `value` into the map at this entry's key and returns an [`OccupiedEntry`]
     /// pointing at the newly inserted value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the serialized key or value exceeds the maximum size of its type, exactly
+    /// as [`BTreeMap::insert`] does. Note that [`BTreeMap::entry`] may already have split
+    /// nodes by this point; the map is left valid and consistent, but not necessarily in
+    /// the shape it had before `entry` was called.
     pub fn insert(self, value: V) -> OccupiedEntry<'a, K, V, M> {
         let Self { map, key, slot } = self;
         let slot = match slot {
@@ -300,6 +320,9 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     }
 
     /// Returns the current value associated with this entry.
+    ///
+    /// Every call re-reads the value from stable memory and deserializes it; the result is
+    /// not memoized. Bind it to a local if you need it more than once.
     pub fn get(&self) -> V {
         // Read straight out of the node the entry already holds — no load required.
         // The read is uncached so that repeated reads don't inflate the node with a
@@ -315,6 +338,9 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     ///
     /// Reads the current value, calls `f` with a mutable reference to it, then writes the
     /// modified value back. Returns `self` so the call can be chained.
+    ///
+    /// The write is unconditional: the value is re-serialized and the node saved even if
+    /// `f` left it untouched.
     ///
     /// # Examples
     ///
@@ -351,6 +377,11 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
 
     /// Replaces the current value with `value` and returns the previous value as a
     /// [`LazyValue`], which is only deserialized if you call [`LazyValue::into_value`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the serialized `value` exceeds the maximum size of `V`, exactly as
+    /// [`BTreeMap::insert`] does. The map is left unmodified in that case.
     ///
     /// # Examples
     ///
@@ -430,6 +461,41 @@ impl<T: Storable> LazyValue<T> {
     /// Deserializes and returns the value.
     pub fn into_value(self) -> T {
         T::from_bytes(Cow::Owned(self.bytes))
+    }
+}
+
+// The `Debug` impls below print keys only. Values are deliberately left out: reading one
+// means a stable-memory read and a deserialization, which is not what anyone expects a
+// `Debug` impl to do.
+
+impl<K: Storable + Ord + Clone + std::fmt::Debug, V: Storable, M: Memory> std::fmt::Debug
+    for Entry<'_, K, V, M>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Entry::Vacant(entry) => f.debug_tuple("Entry::Vacant").field(entry).finish(),
+            Entry::Occupied(entry) => f.debug_tuple("Entry::Occupied").field(entry).finish(),
+        }
+    }
+}
+
+impl<K: Storable + Ord + Clone + std::fmt::Debug, V: Storable, M: Memory> std::fmt::Debug
+    for VacantEntry<'_, K, V, M>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VacantEntry")
+            .field("key", self.key())
+            .finish()
+    }
+}
+
+impl<K: Storable + Ord + Clone + std::fmt::Debug, V: Storable, M: Memory> std::fmt::Debug
+    for OccupiedEntry<'_, K, V, M>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OccupiedEntry")
+            .field("key", self.key())
+            .finish()
     }
 }
 

--- a/src/btreemap/entry.rs
+++ b/src/btreemap/entry.rs
@@ -32,6 +32,29 @@ use crate::{BTreeMap, Memory, Storable};
 use std::borrow::Cow;
 use std::marker::PhantomData;
 
+/// A loaded node together with the index of one slot inside it: for an
+/// [`OccupiedEntry`] the slot holding the entry, for a [`VacantEntry`] the slot the key
+/// would occupy. `depth` is the node's distance from the root, which the node cache's
+/// eviction policy needs.
+///
+/// The node itself is kept, rather than just its address, so that reading and writing
+/// through an entry needs no further node loads. [`BTreeMap::entry`] takes the node out
+/// of the map's node cache; it is put back only where that is both useful and cheap (see
+/// [`OccupiedEntry::remove`]). Mutating an entry saves the node, which invalidates its
+/// cache slot — a just-saved node holds every one of its keys and values materialized,
+/// so returning it to the cache in that state would waste heap.
+pub(crate) struct NodeSlot<K: Storable + Ord + Clone> {
+    pub(crate) node: Node<K>,
+    pub(crate) idx: usize,
+    pub(crate) depth: u8,
+}
+
+impl<K: Storable + Ord + Clone> NodeSlot<K> {
+    pub(crate) fn new(node: Node<K>, idx: usize, depth: u8) -> Self {
+        Self { node, idx, depth }
+    }
+}
+
 /// A view into a single entry of a [`BTreeMap`], which may either be occupied or vacant.
 ///
 /// This type is returned by [`BTreeMap::entry`].
@@ -54,7 +77,7 @@ pub struct VacantEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: 
     /// node had not yet been allocated, so we defer the full insert to
     /// [`VacantEntry::insert`] to avoid corrupting the map if this entry is
     /// dropped without inserting.
-    pub(crate) location: Option<(Node<K>, usize)>,
+    pub(crate) slot: Option<NodeSlot<K>>,
 }
 
 /// A view into an occupied entry in a [`BTreeMap`].
@@ -63,8 +86,7 @@ pub struct VacantEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: 
 pub struct OccupiedEntry<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> {
     pub(crate) map: &'a mut BTreeMap<K, V, M>,
     pub(crate) key: K,
-    pub(crate) node: Node<K>,
-    pub(crate) idx: usize,
+    pub(crate) slot: NodeSlot<K>,
 }
 
 /// A value returned by [`OccupiedEntry::insert`] or [`OccupiedEntry::remove`] that has not
@@ -168,7 +190,7 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> Entry<'a, 
         match self {
             Entry::Occupied(entry) => entry,
             Entry::Vacant(entry) => {
-                let val = default(&entry.key);
+                let val = default(entry.key());
                 entry.insert(val)
             }
         }
@@ -236,35 +258,26 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> VacantEntr
     /// Inserts `value` into the map at this entry's key and returns an [`OccupiedEntry`]
     /// pointing at the newly inserted value.
     pub fn insert(self, value: V) -> OccupiedEntry<'a, K, V, M> {
-        match self.location {
-            Some((mut node, idx)) => {
-                node.insert_entry(idx, (self.key.clone(), value.into_bytes_checked()));
-                self.map.save_node(&mut node);
-                self.map.length += 1;
-                self.map.save_header();
-                OccupiedEntry {
-                    map: self.map,
-                    key: self.key,
-                    node,
-                    idx,
-                }
+        let Self { map, key, slot } = self;
+        let slot = match slot {
+            Some(mut slot) => {
+                slot.node
+                    .insert_entry(slot.idx, (key.clone(), value.into_bytes_checked()));
+                map.save_node(&mut slot.node);
+                map.length += 1;
+                map.save_header();
+                slot
             }
             None => {
                 // The map was empty when `entry()` was called. Delegate to the regular
-                // insert path which handles root allocation, then set the node and idx of the
-                // new `OccupiedEntry` to the root node and index 0.
-                let map = self.map;
-                let key = self.key;
+                // insert path, which handles allocating the root, then point the new
+                // `OccupiedEntry` at the root node's first slot.
                 map.insert(key.clone(), value);
-                let node = map.load_node(map.root_addr);
-                OccupiedEntry {
-                    map,
-                    key,
-                    node,
-                    idx: 0,
-                }
+                let node = map.take_or_load_node(map.root_addr);
+                NodeSlot::new(node, 0, 0)
             }
-        }
+        };
+        OccupiedEntry { map, key, slot }
     }
 }
 
@@ -281,8 +294,14 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
 
     /// Returns the current value associated with this entry.
     pub fn get(&self) -> V {
-        let value_bytes = self.node.value(self.idx, self.map.memory());
-        V::from_bytes(Cow::Borrowed(value_bytes))
+        // Read straight out of the node the entry already holds — no load required.
+        // The read is uncached so that repeated reads don't inflate the node with a
+        // materialized value buffer.
+        let value_bytes = self
+            .slot
+            .node
+            .read_value_uncached(self.slot.idx, self.map.memory());
+        V::from_bytes(Cow::Owned(value_bytes))
     }
 
     /// Provides in-place mutable access to the value in this occupied entry.
@@ -306,9 +325,21 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     pub fn and_modify(mut self, f: impl FnOnce(&mut V)) -> Self {
         let mut value = self.get();
         f(&mut value);
-        self.map
-            .update_value(&mut self.node, self.idx, value.into_bytes_checked());
+        self.write_value(value);
         self
+    }
+
+    /// Overwrites the value in this entry's slot, returning the old bytes.
+    ///
+    /// `update_value` saves the node, which invalidates its cache slot. The node is
+    /// deliberately not put back into the cache: a just-saved node holds every one of
+    /// its keys and values materialized, so caching it in that state would waste heap.
+    fn write_value(&mut self, value: V) -> Vec<u8> {
+        self.map.update_value(
+            &mut self.slot.node,
+            self.slot.idx,
+            value.into_bytes_checked(),
+        )
     }
 
     /// Replaces the current value with `value` and returns the previous value as a
@@ -329,10 +360,7 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     /// assert_eq!(map.get(&1), Some(99));
     /// ```
     pub fn insert(mut self, value: V) -> LazyValue<V> {
-        let old_bytes = self
-            .map
-            .update_value(&mut self.node, self.idx, value.into_bytes_checked());
-        LazyValue::new(old_bytes)
+        LazyValue::new(self.write_value(value))
     }
 
     /// Removes the entry from the map and returns the stored value as a [`LazyValue`], which
@@ -352,29 +380,32 @@ impl<'a, K: 'a + Storable + Ord + Clone, V: 'a + Storable, M: Memory> OccupiedEn
     /// assert!(map.is_empty());
     /// ```
     pub fn remove(self) -> LazyValue<V> {
-        let bytes = match self.node.node_type() {
-            NodeType::Leaf if self.node.can_remove_entry_without_merging() => {
+        let Self { map, key, slot } = self;
+        let NodeSlot {
+            mut node,
+            idx,
+            depth,
+        } = slot;
+        let bytes = match node.node_type() {
+            NodeType::Leaf if node.can_remove_entry_without_merging() => {
                 // Fast path: the leaf has enough entries to remove without merging.
-                let mut node = self.node;
-                let value = node.remove_entry(self.idx, self.map.memory()).1;
-                self.map.length -= 1;
-                if node.entries_len() == 0 {
-                    // The leaf was the only node (the root). Deallocate it.
-                    self.map.deallocate_node(node);
-                    self.map.root_addr = crate::types::NULL;
-                } else {
-                    self.map.save_node(&mut node);
-                }
-                self.map.save_header();
+                let value = node.remove_entry(idx, map.memory()).1;
+                // `can_remove_entry_without_merging` guarantees the leaf held more than
+                // the minimum number of entries, so it cannot be empty after removal.
+                debug_assert!(node.entries_len() > 0);
+                map.save_node(&mut node);
+                map.length -= 1;
+                map.save_header();
                 value
             }
             _ => {
-                // Slow path: the node may need rebalancing/merging.
-                // Drop the already-loaded node and do a fresh traversal from the root.
-                let root = self.map.take_or_load_node(self.map.root_addr);
-                self.map
-                    .remove_helper(root, &self.key, 0)
-                    .expect("key must exist")
+                // Slow path: the removal may require rebalancing/merging, so do a fresh
+                // traversal from the root. The node is unmodified, so return it to the
+                // cache first — the traversal can then take it from there rather than
+                // re-reading it from memory.
+                map.return_node(node, depth);
+                let root = map.take_or_load_node(map.root_addr);
+                map.remove_helper(root, &key, 0).expect("key must exist")
             }
         };
         LazyValue::new(bytes)
@@ -392,6 +423,15 @@ impl<T: Storable> LazyValue<T> {
     /// Deserializes and returns the value.
     pub fn into_value(self) -> T {
         T::from_bytes(Cow::Owned(self.bytes))
+    }
+}
+
+impl<T: Storable> std::fmt::Debug for LazyValue<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The value is intentionally not deserialized here.
+        f.debug_struct("LazyValue")
+            .field("num_bytes", &self.bytes.len())
+            .finish()
     }
 }
 
@@ -524,6 +564,66 @@ mod tests {
         };
         assert_eq!(e.remove().into_value(), 42);
         assert!(map.is_empty());
+    }
+
+    #[test]
+    fn entry_uses_the_node_cache_along_the_path() {
+        let mut map = new_map().with_node_cache(32);
+        for i in 0u32..1000 {
+            map.insert(i, i);
+        }
+
+        // Warm the cache along the path, then probe the same key again: the nodes on
+        // the way down are taken from the cache and put back by the traversal, so the
+        // second probe hits rather than re-reading them from memory.
+        let _ = map.entry(500);
+        map.node_cache_reset_metrics();
+        let _ = map.entry(500);
+        assert!(map.node_cache_metrics().hits() > 0);
+
+        // The same holds for a vacant entry dropped without inserting, and the map is
+        // unchanged by the probe.
+        let _ = map.entry(5000);
+        map.node_cache_reset_metrics();
+        let _ = map.entry(5000);
+        assert!(map.node_cache_metrics().hits() > 0);
+        assert_eq!(map.get(&5000), None);
+    }
+
+    #[test]
+    fn reading_and_writing_through_an_entry_needs_no_further_loads() {
+        let mut map = new_map().with_node_cache(32);
+        for i in 0u32..1000 {
+            map.insert(i, i);
+        }
+
+        let Entry::Occupied(e) = map.entry(500) else {
+            panic!();
+        };
+        // The entry holds its node, so reading and writing through it touch the cache
+        // not at all — no lookups, hence no loads from memory.
+        e.map.node_cache_reset_metrics();
+        assert_eq!(e.get(), 500);
+        let e = e.and_modify(|v| *v += 1);
+        assert_eq!(e.get(), 501);
+        assert_eq!(e.map.node_cache_metrics().total(), 0);
+
+        assert_eq!(map.get(&500), Some(501));
+    }
+
+    #[test]
+    fn entry_mutations_do_not_leave_stale_nodes_in_cache() {
+        let mut map = new_map().with_node_cache(32);
+        for i in 0u32..1000 {
+            map.insert(i, i);
+        }
+        for i in 0u32..1000 {
+            // Warm the cache along the key's path, mutate through the entry API,
+            // then read back through the cached path.
+            assert_eq!(map.get(&i), Some(i));
+            map.entry(i).and_modify(|v| *v += 1);
+            assert_eq!(map.get(&i), Some(i + 1));
+        }
     }
 
     #[test]

--- a/src/btreemap/proptests.rs
+++ b/src/btreemap/proptests.rs
@@ -215,29 +215,38 @@ fn entry(
         for (key, operation) in keys.iter().copied().zip(operations.iter().copied()) {
             let entry = btree.entry(key);
             let std_entry = std_map.entry(key);
-            match (entry, std_entry) {
-                (Entry::Occupied(e), btree_map::Entry::Occupied(mut std_e)) => match operation {
-                    0 => {
-                        e.insert(key);
-                        std_e.insert(key);
-                    }
-                    1 => {
-                        let existing = e.get();
-                        let std_existing = *std_e.get();
-                        e.insert(existing.overflowing_add(1).0);
-                        std_e.insert(std_existing.overflowing_add(1).0);
-                    }
-                    2 => {
-                        e.remove();
-                        std_e.remove();
-                    }
-                    _ => unreachable!(),
-                },
-                (Entry::Vacant(e), btree_map::Entry::Vacant(std_e)) => {
-                    e.insert(key);
-                    std_e.insert(key);
+            let occupied = matches!(entry, Entry::Occupied(_));
+            let std_occupied = matches!(std_entry, btree_map::Entry::Occupied(_));
+            assert_eq!(occupied, std_occupied);
+
+            match operation {
+                0 => {
+                    entry.and_modify(|v| *v = key).or_insert(key);
+                    std_entry.and_modify(|v| *v = key).or_insert(key);
                 }
-                _ => prop_assert!(false, "Map out of sync with std lib BTreeMap"),
+                1 => {
+                    entry.and_modify(|v| *v += 1).or_insert(key);
+                    std_entry.and_modify(|v| *v += 1).or_insert(key);
+                }
+                2 => {
+                    match entry {
+                        Entry::Occupied(e) => {
+                            e.remove();
+                        }
+                        Entry::Vacant(e) => {
+                            e.insert(key);
+                        }
+                    }
+                    match std_entry {
+                        btree_map::Entry::Occupied(e) => {
+                            e.remove();
+                        }
+                        btree_map::Entry::Vacant(e) => {
+                            e.insert(key);
+                        }
+                    }
+                }
+                _ => unreachable!(),
             }
         }
 
@@ -378,35 +387,27 @@ fn execute_operation<M: Memory>(
             }
         }
         Operation::EntryInsertOrXor { key, value } => {
-            match std_btree.entry(key.clone()) {
-                btree_map::Entry::Occupied(mut entry) => {
-                    let existing = entry.get().clone();
-                    let xor = existing
+            std_btree
+                .entry(key.clone())
+                .and_modify(|existing| {
+                    *existing = existing
                         .into_iter()
                         .zip(value.clone())
                         .map(|(l, r)| l.bitxor(r))
                         .collect::<Vec<_>>();
-                    entry.insert(xor);
-                }
-                btree_map::Entry::Vacant(entry) => {
-                    entry.insert(value.clone());
-                }
-            };
+                })
+                .or_insert(value.clone());
 
-            match btree.entry(key.clone()) {
-                Entry::Occupied(entry) => {
-                    let existing = entry.get();
-                    let xor = existing
+            btree
+                .entry(key.clone())
+                .and_modify(|existing| {
+                    *existing = existing
                         .into_iter()
                         .zip(value.clone())
                         .map(|(l, r)| l.bitxor(r))
                         .collect::<Vec<_>>();
-                    entry.insert(xor);
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(value.clone());
-                }
-            }
+                })
+                .or_insert(value);
 
             assert_eq!(btree.get(&key).as_ref(), std_btree.get(&key));
         }

--- a/src/btreemap/proptests.rs
+++ b/src/btreemap/proptests.rs
@@ -1,3 +1,4 @@
+use crate::btreemap::entry::Entry;
 use crate::{
     btreemap::{
         test::{b, make_memory, run_btree_test},
@@ -9,7 +10,8 @@ use crate::{
 use proptest::collection::btree_set as pset;
 use proptest::collection::vec as pvec;
 use proptest::prelude::*;
-use std::collections::{BTreeMap as StdBTreeMap, BTreeSet};
+use std::collections::{btree_map, BTreeMap as StdBTreeMap, BTreeSet};
+use std::ops::BitXor;
 use test_strategy::proptest;
 
 #[derive(Debug, Clone)]
@@ -21,6 +23,7 @@ enum Operation {
     Values { from: usize, len: usize },
     Get(usize),
     Remove(usize),
+    EntryInsertOrXor { key: Vec<u8>, value: Vec<u8> },
     Range { from: usize, len: usize },
     PopLast,
     PopFirst,
@@ -43,6 +46,8 @@ fn operation_strategy() -> impl Strategy<Value = Operation> {
             .prop_map(|(from, len)| Operation::Values { from, len }),
         50 => (any::<usize>()).prop_map(Operation::Get),
         15 => (any::<usize>()).prop_map(Operation::Remove),
+        10 => (any::<Vec<u8>>(), any::<Vec<u8>>())
+            .prop_map(|(key, value)| Operation::EntryInsertOrXor { key, value }),
         5 => (any::<usize>(), any::<usize>())
             .prop_map(|(from, len)| Operation::Range { from, len }),
         2 =>  Just(Operation::PopFirst),
@@ -320,6 +325,40 @@ fn execute_operation<M: Memory>(
                 assert_eq!(btree.remove(&k), Some(v));
             }
         }
+        Operation::EntryInsertOrXor { key, value } => {
+            match std_btree.entry(key.clone()) {
+                btree_map::Entry::Occupied(mut entry) => {
+                    let existing = entry.get().clone();
+                    let xor = existing
+                        .into_iter()
+                        .zip(value.clone())
+                        .map(|(l, r)| l.bitxor(r))
+                        .collect::<Vec<_>>();
+                    entry.insert(xor);
+                }
+                btree_map::Entry::Vacant(entry) => {
+                    entry.insert(value.clone());
+                }
+            };
+
+            match btree.entry(key.clone()) {
+                Entry::Occupied(entry) => {
+                    let existing = entry.get();
+                    let xor = existing
+                        .into_iter()
+                        .zip(value.clone())
+                        .map(|(l, r)| l.bitxor(r))
+                        .collect::<Vec<_>>();
+                    entry.insert(xor);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(value.clone());
+                }
+            }
+
+            assert_eq!(btree.get(&key).as_ref(), std_btree.get(&key));
+        }
+
         Operation::Range { from, len } => {
             assert_eq!(std_btree.len(), btree.len() as usize);
             if std_btree.is_empty() {

--- a/src/btreemap/proptests.rs
+++ b/src/btreemap/proptests.rs
@@ -197,6 +197,58 @@ fn no_memory_leaks(#[strategy(pvec(pvec(0..u8::MAX, 100..10_000), 100))] keys: V
     assert_eq!(btree.allocator.num_allocated_chunks(), 0);
 }
 
+#[proptest]
+fn entry(
+    #[strategy(pvec(0..255u8, 10))] keys: Vec<u8>,
+    #[strategy(pvec(0..3u8, 10))] operations: Vec<u8>,
+) {
+    run_btree_test(|mut btree| {
+        let mut std_map = StdBTreeMap::new();
+
+        // Operations (if Occupied):
+        // 0 - insert
+        // 1 - increment
+        // 2 - remove
+        //
+        // Operations (if Vacant):
+        //   - always insert
+        for (key, operation) in keys.iter().copied().zip(operations.iter().copied()) {
+            let entry = btree.entry(key);
+            let std_entry = std_map.entry(key);
+            match (entry, std_entry) {
+                (Entry::Occupied(e), btree_map::Entry::Occupied(mut std_e)) => match operation {
+                    0 => {
+                        e.insert(key);
+                        std_e.insert(key);
+                    }
+                    1 => {
+                        let existing = e.get();
+                        let std_existing = *std_e.get();
+                        e.insert(existing.overflowing_add(1).0);
+                        std_e.insert(std_existing.overflowing_add(1).0);
+                    }
+                    2 => {
+                        e.remove();
+                        std_e.remove();
+                    }
+                    _ => unreachable!(),
+                },
+                (Entry::Vacant(e), btree_map::Entry::Vacant(std_e)) => {
+                    e.insert(key);
+                    std_e.insert(key);
+                }
+                _ => prop_assert!(false, "Map out of sync with std lib BTreeMap"),
+            }
+        }
+
+        let entries: Vec<_> = btree.iter().map(|e| (*e.key(), e.value())).collect();
+        let std_entries: Vec<_> = std_map.into_iter().collect();
+
+        prop_assert_eq!(entries, std_entries);
+        Ok(())
+    });
+}
+
 // Given an operation, executes it on the given stable btreemap and standard btreemap, verifying
 // that the result of the operation is equal in both btrees.
 fn execute_operation<M: Memory>(

--- a/src/btreemap/proptests.rs
+++ b/src/btreemap/proptests.rs
@@ -391,7 +391,7 @@ fn execute_operation<M: Memory>(
                 .entry(key.clone())
                 .and_modify(|existing| {
                     *existing = existing
-                        .into_iter()
+                        .iter()
                         .zip(value.clone())
                         .map(|(l, r)| l.bitxor(r))
                         .collect::<Vec<_>>();
@@ -402,7 +402,7 @@ fn execute_operation<M: Memory>(
                 .entry(key.clone())
                 .and_modify(|existing| {
                     *existing = existing
-                        .into_iter()
+                        .iter()
                         .zip(value.clone())
                         .map(|(l, r)| l.bitxor(r))
                         .collect::<Vec<_>>();

--- a/src/btreemap/proptests.rs
+++ b/src/btreemap/proptests.rs
@@ -24,6 +24,7 @@ enum Operation {
     Get(usize),
     Remove(usize),
     EntryInsertOrXor { key: Vec<u8>, value: Vec<u8> },
+    EntryRemove(usize),
     Range { from: usize, len: usize },
     PopLast,
     PopFirst,
@@ -48,6 +49,7 @@ fn operation_strategy() -> impl Strategy<Value = Operation> {
         15 => (any::<usize>()).prop_map(Operation::Remove),
         10 => (any::<Vec<u8>>(), any::<Vec<u8>>())
             .prop_map(|(key, value)| Operation::EntryInsertOrXor { key, value }),
+        10 => (any::<usize>()).prop_map(Operation::EntryRemove),
         5 => (any::<usize>(), any::<usize>())
             .prop_map(|(from, len)| Operation::Range { from, len }),
         2 =>  Just(Operation::PopFirst),
@@ -289,8 +291,10 @@ fn entry(
                     std_entry.and_modify(|v| *v = key).or_insert(key);
                 }
                 1 => {
-                    entry.and_modify(|v| *v += 1).or_insert(key);
-                    std_entry.and_modify(|v| *v += 1).or_insert(key);
+                    entry.and_modify(|v| *v = v.wrapping_add(1)).or_insert(key);
+                    std_entry
+                        .and_modify(|v| *v = v.wrapping_add(1))
+                        .or_insert(key);
                 }
                 2 => {
                     match entry {
@@ -474,6 +478,31 @@ fn execute_operation<M: Memory>(
                 .or_insert(value);
 
             assert_eq!(btree.get(&key).as_ref(), std_btree.get(&key));
+        }
+        Operation::EntryRemove(idx) => {
+            assert_eq!(std_btree.len(), btree.len() as usize);
+            if std_btree.is_empty() {
+                return;
+            }
+
+            let idx = idx % std_btree.len();
+
+            if let Some(k) = btree
+                .iter()
+                .skip(idx)
+                .take(1)
+                .next()
+                .map(|entry| entry.key().clone())
+            {
+                eprintln!("EntryRemove({})", hex::encode(&k));
+                let expected = std_btree.remove(&k).expect("key must exist in std map");
+                match btree.entry(k) {
+                    Entry::Occupied(e) => {
+                        assert_eq!(e.remove().into_value(), expected);
+                    }
+                    Entry::Vacant(_) => panic!("entry must be occupied"),
+                }
+            }
         }
 
         Operation::Range { from, len } => {

--- a/src/btreemap/proptests.rs
+++ b/src/btreemap/proptests.rs
@@ -263,10 +263,13 @@ fn no_memory_leaks(#[strategy(pvec(pvec(0..u8::MAX, 100..10_000), 100))] keys: V
     assert_eq!(btree.allocator.num_allocated_chunks(), 0);
 }
 
+// A node holds up to `CAPACITY` (11) entries, so the operation count has to comfortably
+// exceed that for the tree to actually split and merge. This is also the only entry-API
+// coverage of the V1 and V1-migrated-to-V2 layouts, via `run_btree_test`.
 #[proptest]
 fn entry(
-    #[strategy(pvec(0..255u8, 10))] keys: Vec<u8>,
-    #[strategy(pvec(0..3u8, 10))] operations: Vec<u8>,
+    #[strategy(pvec(0..255u8, 200))] keys: Vec<u8>,
+    #[strategy(pvec(0..3u8, 200))] operations: Vec<u8>,
 ) {
     run_btree_test(|mut btree| {
         let mut std_map = StdBTreeMap::new();


### PR DESCRIPTION
This allows you to lookup an entry by searching the map, then modify the value and insert it back into the map without having to search again.

The API is similar to `entry` on the std lib `BTreeMap`, but is not able to return mutable references, so you need to either use `and_modify` or get the owned value, update it, then insert it back in the entry.

For example in the std lib you would write this
```
match map.entry(1) {
    Occupied(mut e) => {
        let value = e.get_mut();
        *value += 1;
    }
    Vacant(e) => {
        e.insert(1);
    }
}
```
Or using the shorthand syntax
```
map.entry(1).and_modify(|v| *v += 1).or_insert(1)
```
 
Whereas using this new API for `StableBTreeMap` you would write it as this
```
match map.entry(1) {
    Occupied(e) => {
        let value = e.get();
        e.insert(value + 1);
    }
    Vacant(e) => {
        e.insert(1);
    }
}
```
Or using the shorthand syntax
```
map.entry(1).and_modify(|v| *v += 1).or_insert(1)
```

I've added some benchmarks which compare using `get` then `insert` vs using `entry` for 10k u32 values, from the results you can see that in this scenario using `entry` is roughly 37% faster
```
| status | name                            | calls |     ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
|--------|---------------------------------|-------|---------|---------|----|--------|-----|---------|
|  new   | btreemap_get_and_incr           |       | 597.30M |         |  0 |        |   0 |         |
|  new   | btreemap_get_and_incr_via_entry |       | 374.19M |         |  0 |        |   0 |         |
```